### PR TITLE
fix: remove redundant pnpm version from workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
package.json already specifies pnpm@10.6.5 via packageManager field.
Specifying version in the action config caused a conflict error.

https://claude.ai/code/session_01VhP4H2ESqQiZ1f21AeqGcx