### PR TITLE
feat: 直方体の面押し出し操作を実装

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,174 +1,277 @@
 import * as THREE from 'three'
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
 
-// Scene
-const scene = new THREE.Scene()
-scene.background = new THREE.Color(0x1a1a2e)
-scene.fog = new THREE.FogExp2(0x1a1a2e, 0.02)
-
-// Camera
-const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000)
-camera.position.set(5, 5, 10)
-
-// Renderer
+// ─── Renderer / Camera / Scene ───────────────────────────────────────────────
 const renderer = new THREE.WebGLRenderer({ antialias: true })
-renderer.setSize(window.innerWidth, window.innerHeight)
-renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
-renderer.shadowMap.enabled = true
-renderer.shadowMap.type = THREE.PCFSoftShadowMap
+renderer.setSize(innerWidth, innerHeight)
+renderer.setPixelRatio(Math.min(devicePixelRatio, 2))
 document.body.appendChild(renderer.domElement)
 
-// Controls
+const scene = new THREE.Scene()
+scene.background = new THREE.Color(0x1a1a2e)
+
+const camera = new THREE.PerspectiveCamera(60, innerWidth / innerHeight, 0.1, 100)
+camera.position.set(4, 3, 6)
+
 const controls = new OrbitControls(camera, renderer.domElement)
 controls.enableDamping = true
-controls.dampingFactor = 0.05
 
-// Lights
-const ambientLight = new THREE.AmbientLight(0xffffff, 0.3)
-scene.add(ambientLight)
+// ─── Lighting ────────────────────────────────────────────────────────────────
+scene.add(new THREE.AmbientLight(0xffffff, 0.5))
+const dirLight = new THREE.DirectionalLight(0xffffff, 1.5)
+dirLight.position.set(5, 10, 5)
+scene.add(dirLight)
 
-const directionalLight = new THREE.DirectionalLight(0xffffff, 1.5)
-directionalLight.position.set(5, 10, 5)
-directionalLight.castShadow = true
-directionalLight.shadow.mapSize.width = 2048
-directionalLight.shadow.mapSize.height = 2048
-scene.add(directionalLight)
-
-const pointLight1 = new THREE.PointLight(0x4fc3f7, 2, 20)
-pointLight1.position.set(-5, 3, -5)
-scene.add(pointLight1)
-
-const pointLight2 = new THREE.PointLight(0xf48fb1, 2, 20)
-pointLight2.position.set(5, 3, -5)
-scene.add(pointLight2)
-
-// Floor
-const floorGeometry = new THREE.PlaneGeometry(30, 30)
-const floorMaterial = new THREE.MeshStandardMaterial({
-  color: 0x16213e,
-  roughness: 0.8,
-  metalness: 0.2,
-})
-const floor = new THREE.Mesh(floorGeometry, floorMaterial)
-floor.rotation.x = -Math.PI / 2
-floor.receiveShadow = true
-scene.add(floor)
-
-// Grid helper
-const grid = new THREE.GridHelper(30, 30, 0x4fc3f7, 0x0d3b66)
-grid.material.opacity = 0.3
+// ─── Grid ────────────────────────────────────────────────────────────────────
+const grid = new THREE.GridHelper(20, 20, 0x444466, 0x222244)
 grid.material.transparent = true
+grid.material.opacity = 0.4
 scene.add(grid)
 
-// --- Extrude sample shapes ---
-const extrudeSettings = { depth: 1, bevelEnabled: true, bevelThickness: 0.1, bevelSize: 0.1, bevelSegments: 4 }
+// ─── Cuboid data model ────────────────────────────────────────────────────────
+//
+//      3─────2
+//     /|    /|    +Y up
+//    7─────6 |    +Z front
+//    | 0───|─1    +X right
+//    |/    |/
+//    4─────5
+//
+// 8 corner positions (mutable logical vertices)
+let corners = [
+  new THREE.Vector3(-1, -1, -1), // 0 back-bottom-left
+  new THREE.Vector3( 1, -1, -1), // 1 back-bottom-right
+  new THREE.Vector3( 1,  1, -1), // 2 back-top-right
+  new THREE.Vector3(-1,  1, -1), // 3 back-top-left
+  new THREE.Vector3(-1, -1,  1), // 4 front-bottom-left
+  new THREE.Vector3( 1, -1,  1), // 5 front-bottom-right
+  new THREE.Vector3( 1,  1,  1), // 6 front-top-right
+  new THREE.Vector3(-1,  1,  1), // 7 front-top-left
+]
 
-// Star shape
-function createStarShape(outerR, innerR, points) {
-  const shape = new THREE.Shape()
-  for (let i = 0; i < points * 2; i++) {
-    const angle = (i / (points * 2)) * Math.PI * 2 - Math.PI / 2
-    const r = i % 2 === 0 ? outerR : innerR
-    const x = Math.cos(angle) * r
-    const y = Math.sin(angle) * r
-    i === 0 ? shape.moveTo(x, y) : shape.lineTo(x, y)
+// Face definitions: 4 corner indices in CCW order when viewed from outside.
+// Outward normal = cross(corners[b] - corners[a], corners[d] - corners[a])
+// Faces are ordered so geometry vertex fi*4..fi*4+3 corresponds to FACES[fi].
+const FACES = [
+  { name: '前面 (+Z)', corners: [4, 5, 6, 7] }, // fi=0
+  { name: '背面 (-Z)', corners: [1, 0, 3, 2] }, // fi=1
+  { name: '上面 (+Y)', corners: [3, 7, 6, 2] }, // fi=2
+  { name: '下面 (-Y)', corners: [0, 1, 5, 4] }, // fi=3
+  { name: '右面 (+X)', corners: [5, 1, 2, 6] }, // fi=4
+  { name: '左面 (-X)', corners: [0, 4, 7, 3] }, // fi=5
+]
+
+// Compute outward face normal from current corner positions
+function computeFaceNormal(fi) {
+  const [a, b, , d] = FACES[fi].corners
+  const ab = new THREE.Vector3().subVectors(corners[b], corners[a])
+  const ad = new THREE.Vector3().subVectors(corners[d], corners[a])
+  return new THREE.Vector3().crossVectors(ab, ad).normalize()
+}
+
+// Build BufferGeometry from current corner positions.
+// Layout: face fi → geometry vertices [fi*4 .. fi*4+3]
+// This lets us recover face index from hit.face.a via Math.floor(hit.face.a / 4).
+function buildGeometry() {
+  const pos  = new Float32Array(72) // 6 faces × 4 verts × 3
+  const norm = new Float32Array(72)
+  const idx  = []
+
+  FACES.forEach((face, fi) => {
+    const n = computeFaceNormal(fi)
+    face.corners.forEach((ci, vi) => {
+      const i = (fi * 4 + vi) * 3
+      const v = corners[ci]
+      pos[i]  = v.x; pos[i+1]  = v.y; pos[i+2]  = v.z
+      norm[i] = n.x; norm[i+1] = n.y; norm[i+2] = n.z
+    })
+    const b = fi * 4
+    idx.push(b, b+1, b+2,  b, b+2, b+3)
+  })
+
+  const geo = new THREE.BufferGeometry()
+  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3))
+  geo.setAttribute('normal',   new THREE.BufferAttribute(norm, 3))
+  geo.setIndex(idx)
+  return geo
+}
+
+// ─── Meshes ───────────────────────────────────────────────────────────────────
+let cuboidGeo = buildGeometry()
+
+const cuboid = new THREE.Mesh(
+  cuboidGeo,
+  new THREE.MeshStandardMaterial({ color: 0x4fc3f7, roughness: 0.3, metalness: 0.3 })
+)
+scene.add(cuboid)
+
+// Edge wireframe
+let edgesGeo = new THREE.EdgesGeometry(cuboidGeo, 1)
+const wireframe = new THREE.LineSegments(
+  edgesGeo,
+  new THREE.LineBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.4 })
+)
+scene.add(wireframe)
+
+// Face highlight (semi-transparent yellow quad over hovered / dragged face)
+const hlGeo = new THREE.BufferGeometry()
+const hlMesh = new THREE.Mesh(hlGeo, new THREE.MeshBasicMaterial({
+  color: 0xffeb3b,
+  transparent: true,
+  opacity: 0.35,
+  depthTest: false,
+  side: THREE.DoubleSide,
+  polygonOffset: true,
+  polygonOffsetFactor: -1,
+}))
+scene.add(hlMesh)
+
+function setHighlight(fi) {
+  if (fi === null) {
+    hlGeo.setIndex([])
+    hlGeo.setAttribute('position', new THREE.BufferAttribute(new Float32Array(0), 3))
+    return
   }
-  shape.closePath()
-  return shape
+  const pos = new Float32Array(12)
+  FACES[fi].corners.forEach((ci, vi) => {
+    const v = corners[ci]; const i = vi * 3
+    pos[i] = v.x; pos[i+1] = v.y; pos[i+2] = v.z
+  })
+  hlGeo.setAttribute('position', new THREE.BufferAttribute(pos, 3))
+  hlGeo.setIndex([0, 1, 2,  0, 2, 3])
+  hlGeo.attributes.position.needsUpdate = true
+  hlGeo.computeBoundingSphere()
 }
 
-const starShape = createStarShape(1.2, 0.5, 5)
-const starGeometry = new THREE.ExtrudeGeometry(starShape, extrudeSettings)
-const starMaterial = new THREE.MeshStandardMaterial({ color: 0xffd54f, roughness: 0.3, metalness: 0.6 })
-const star = new THREE.Mesh(starGeometry, starMaterial)
-star.position.set(-4, 1, 0)
-star.castShadow = true
-scene.add(star)
-
-// Heart shape
-function createHeartShape() {
-  const shape = new THREE.Shape()
-  shape.moveTo(0, 0.5)
-  shape.bezierCurveTo(0, 1, 1, 1.5, 1, 0.5)
-  shape.bezierCurveTo(1, -0.3, 0, -0.8, 0, -1.2)
-  shape.bezierCurveTo(0, -0.8, -1, -0.3, -1, 0.5)
-  shape.bezierCurveTo(-1, 1.5, 0, 1, 0, 0.5)
-  return shape
+function rebuildMeshes() {
+  const newGeo = buildGeometry()
+  cuboid.geometry.dispose()
+  cuboid.geometry = newGeo
+  wireframe.geometry.dispose()
+  wireframe.geometry = new THREE.EdgesGeometry(newGeo, 1)
 }
 
-const heartShape = createHeartShape()
-const heartGeometry = new THREE.ExtrudeGeometry(heartShape, extrudeSettings)
-const heartMaterial = new THREE.MeshStandardMaterial({ color: 0xef5350, roughness: 0.3, metalness: 0.4 })
-const heart = new THREE.Mesh(heartGeometry, heartMaterial)
-heart.position.set(0, 1.2, 0)
-heart.castShadow = true
-scene.add(heart)
+// ─── UI overlay ───────────────────────────────────────────────────────────────
+const infoEl = document.createElement('div')
+Object.assign(infoEl.style, {
+  position: 'fixed', bottom: '20px', left: '50%', transform: 'translateX(-50%)',
+  color: '#ccc', fontSize: '13px', fontFamily: 'sans-serif',
+  background: 'rgba(0,0,0,0.55)', padding: '8px 18px', borderRadius: '8px',
+  pointerEvents: 'none', textAlign: 'center', lineHeight: '1.6',
+})
+infoEl.innerHTML = '面にホバー → 選択 &nbsp;|&nbsp; 左ドラッグ → 面を押し出し &nbsp;|&nbsp; 右ドラッグ / Alt+ドラッグ → 視点回転'
+document.body.appendChild(infoEl)
 
-// Arrow shape
-function createArrowShape() {
-  const shape = new THREE.Shape()
-  shape.moveTo(0, 1.5)
-  shape.lineTo(1.2, 0)
-  shape.lineTo(0.4, 0)
-  shape.lineTo(0.4, -1.5)
-  shape.lineTo(-0.4, -1.5)
-  shape.lineTo(-0.4, 0)
-  shape.lineTo(-1.2, 0)
-  shape.closePath()
-  return shape
+const faceEl = document.createElement('div')
+Object.assign(faceEl.style, {
+  position: 'fixed', top: '20px', left: '50%', transform: 'translateX(-50%)',
+  color: '#ffeb3b', fontSize: '15px', fontFamily: 'sans-serif',
+  background: 'rgba(0,0,0,0.55)', padding: '6px 16px', borderRadius: '6px',
+  pointerEvents: 'none', minWidth: '120px', textAlign: 'center',
+})
+document.body.appendChild(faceEl)
+
+// ─── Interaction ──────────────────────────────────────────────────────────────
+const raycaster = new THREE.Raycaster()
+const mouse = new THREE.Vector2()
+
+let hoveredFace  = null
+let isDragging   = false
+let dragFaceIdx  = null
+let dragNormal   = new THREE.Vector3()
+let dragPlane    = new THREE.Plane()
+let dragStart    = new THREE.Vector3()
+let savedCorners = []
+
+function toNDC(e) {
+  mouse.set(
+    (e.clientX / innerWidth)  *  2 - 1,
+    (e.clientY / innerHeight) * -2 + 1
+  )
 }
 
-const arrowShape = createArrowShape()
-const arrowGeometry = new THREE.ExtrudeGeometry(arrowShape, extrudeSettings)
-const arrowMaterial = new THREE.MeshStandardMaterial({ color: 0x66bb6a, roughness: 0.3, metalness: 0.5 })
-const arrow = new THREE.Mesh(arrowGeometry, arrowMaterial)
-arrow.position.set(4, 1.5, 0)
-arrow.castShadow = true
-scene.add(arrow)
-
-// Floating particles
-const particleCount = 200
-const particleGeometry = new THREE.BufferGeometry()
-const positions = new Float32Array(particleCount * 3)
-for (let i = 0; i < particleCount; i++) {
-  positions[i * 3] = (Math.random() - 0.5) * 20
-  positions[i * 3 + 1] = Math.random() * 8
-  positions[i * 3 + 2] = (Math.random() - 0.5) * 20
+function pickFace() {
+  raycaster.setFromCamera(mouse, camera)
+  const hits = raycaster.intersectObject(cuboid)
+  if (!hits.length) return null
+  // Geometry vertex index → face index: face fi occupies verts [fi*4 .. fi*4+3]
+  return { faceIdx: Math.floor(hits[0].face.a / 4), point: hits[0].point }
 }
-particleGeometry.setAttribute('position', new THREE.BufferAttribute(positions, 3))
-const particleMaterial = new THREE.PointsMaterial({ color: 0x4fc3f7, size: 0.05, transparent: true, opacity: 0.6 })
-const particles = new THREE.Points(particleGeometry, particleMaterial)
-scene.add(particles)
 
-// Resize handler
-window.addEventListener('resize', () => {
-  camera.aspect = window.innerWidth / window.innerHeight
-  camera.updateProjectionMatrix()
-  renderer.setSize(window.innerWidth, window.innerHeight)
+window.addEventListener('mousemove', (e) => {
+  toNDC(e)
+
+  if (isDragging) {
+    raycaster.setFromCamera(mouse, camera)
+    const pt = new THREE.Vector3()
+    if (!raycaster.ray.intersectPlane(dragPlane, pt)) return
+
+    // Project displacement onto face normal → pure extrusion
+    const dist = pt.clone().sub(dragStart).dot(dragNormal)
+    const offset = dragNormal.clone().multiplyScalar(dist)
+
+    FACES[dragFaceIdx].corners.forEach((ci, i) => {
+      corners[ci].copy(savedCorners[i]).add(offset)
+    })
+
+    rebuildMeshes()
+    setHighlight(dragFaceIdx)
+    faceEl.textContent = `${FACES[dragFaceIdx].name}  Δ ${dist.toFixed(3)}`
+    return
+  }
+
+  // Hover detection
+  const hit = pickFace()
+  const fi = hit ? hit.faceIdx : null
+  if (fi !== hoveredFace) {
+    hoveredFace = fi
+    setHighlight(hoveredFace)
+    faceEl.textContent = fi !== null ? FACES[fi].name : ''
+    renderer.domElement.style.cursor = fi !== null ? 'pointer' : 'default'
+  }
 })
 
-// Animation loop
-const clock = new THREE.Clock()
+window.addEventListener('mousedown', (e) => {
+  if (e.button !== 0) return
+  toNDC(e)
+  const hit = pickFace()
+  if (!hit) return
+
+  isDragging   = true
+  dragFaceIdx  = hit.faceIdx
+  controls.enabled = false
+
+  // Save face normal at drag start (stays constant during extrusion)
+  dragNormal.copy(computeFaceNormal(dragFaceIdx))
+
+  // Drag plane: camera-facing plane through hit point
+  // (avoids singularity when face is nearly edge-on to camera)
+  const camDir = new THREE.Vector3()
+  camera.getWorldDirection(camDir)
+  dragPlane.setFromNormalAndCoplanarPoint(camDir, hit.point)
+  dragStart.copy(hit.point)
+
+  // Snapshot corner positions before drag
+  savedCorners = FACES[dragFaceIdx].corners.map(ci => corners[ci].clone())
+})
+
+window.addEventListener('mouseup', () => {
+  if (!isDragging) return
+  isDragging = false
+  controls.enabled = true
+  dragFaceIdx = null
+})
+
+// ─── Resize ───────────────────────────────────────────────────────────────────
+window.addEventListener('resize', () => {
+  camera.aspect = innerWidth / innerHeight
+  camera.updateProjectionMatrix()
+  renderer.setSize(innerWidth, innerHeight)
+})
+
+// ─── Animate ─────────────────────────────────────────────────────────────────
 function animate() {
   requestAnimationFrame(animate)
-  const elapsed = clock.getElapsedTime()
-
-  star.rotation.y = elapsed * 0.8
-  star.position.y = 1 + Math.sin(elapsed * 1.2) * 0.3
-
-  heart.rotation.y = elapsed * 0.6
-  heart.position.y = 1.2 + Math.sin(elapsed * 1.0 + 1) * 0.3
-
-  arrow.rotation.y = elapsed * 1.0
-  arrow.position.y = 1.5 + Math.sin(elapsed * 0.8 + 2) * 0.3
-
-  particles.rotation.y = elapsed * 0.05
-
-  pointLight1.position.x = Math.sin(elapsed * 0.5) * 6
-  pointLight1.position.z = Math.cos(elapsed * 0.5) * 6
-  pointLight2.position.x = Math.sin(elapsed * 0.5 + Math.PI) * 6
-  pointLight2.position.z = Math.cos(elapsed * 0.5 + Math.PI) * 6
-
   controls.update()
   renderer.render(scene, camera)
 }


### PR DESCRIPTION
- 8コーナー頂点のロジカルモデルで直方体を管理
- 6面を4頂点のCCW順で定義、法線はcross積で計算
- Raycasting でホバー面を特定（face.a / 4 で面インデックス復元）
- ドラッグ開始時にカメラ正面ドラッグ平面を設定
- マウス移動量を面法線方向に投影して純粋な押し出しを実現
- ドラッグ中にBfferGeometryを再構築、エッジワイヤーフレームも更新
- ホバー面をハイライト表示・面名とΔ値をUIに表示

https://claude.ai/code/session_01WHUGjwGB75YC84QE4hG2jc