### PR TITLE
fix: 面が対面を超えた際の押し出し法線方向を補正

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -5,7 +5,7 @@
  * 副作用: イベントリスナー登録・requestAnimationFrame・Model 状態の更新を行う。
  */
 import * as THREE from 'three'
-import { FACES, computeFaceNormal, getCentroid, toNDC } from '../model/CuboidModel.js'
+import { FACES, computeOutwardFaceNormal, getCentroid, toNDC } from '../model/CuboidModel.js'
 
 export class AppController {
   /**
@@ -202,7 +202,7 @@ export class AppController {
     this._faceDragging        = true
     this._dragFaceIdx         = hit.faceIdx
     this._controls.enabled    = false
-    this._dragNormal.copy(computeFaceNormal(this._corners, this._dragFaceIdx))
+    this._dragNormal.copy(computeOutwardFaceNormal(this._corners, this._dragFaceIdx))
     const camDir = new THREE.Vector3()
     this._camera.getWorldDirection(camDir)
     this._dragPlane.setFromNormalAndCoplanarPoint(camDir, hit.point)

--- a/src/model/CuboidModel.js
+++ b/src/model/CuboidModel.js
@@ -45,6 +45,21 @@ export function computeFaceNormal(corners, fi) {
   return new THREE.Vector3().crossVectors(ab, ad).normalize()
 }
 
+/**
+ * 面 fi の外向き法線ベクトルを計算する純粋関数
+ * 面が対面を超えて押し出された場合でも、重心から外向きになるよう符号を補正する
+ */
+export function computeOutwardFaceNormal(corners, fi) {
+  const n = computeFaceNormal(corners, fi)
+  const faceCorners = FACES[fi].corners
+  const faceCenter = faceCorners
+    .reduce((acc, ci) => acc.add(corners[ci]), new THREE.Vector3())
+    .divideScalar(faceCorners.length)
+  const objCentroid = getCentroid(corners)
+  if (faceCenter.sub(objCentroid).dot(n) < 0) n.negate()
+  return n
+}
+
 /** コーナー配列から BufferGeometry を構築する純粋関数 */
 export function buildGeometry(corners) {
   const pos  = new Float32Array(72) // 6 faces × 4 verts × 3


### PR DESCRIPTION
computeOutwardFaceNormal を追加し、面が対面を超えて押し出された後に
再ドラッグを開始した際も _dragNormal が常に重心から外向きになるよう補正する。
ワインディング順から求めた法線が内向きになる場合に negate() で符号を反転させる。

https://claude.ai/code/session_014NczDaLdpRQ4nvg52irPXY