### PR TITLE
docs: README と CLAUDE.md を現在の MVC 実装に合わせて更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,10 +44,10 @@ easy-extrude/
 
 | レイヤー | ファイル | 責務 |
 |---|---|---|
-| **Model** | `model/CuboidModel.js` | データ定義 (`FACES`, `createInitialCorners`) と純粋関数 (`buildGeometry`, `computeFaceNormal`, `getCentroid`, `buildFaceHighlightPositions`, `toNDC`) |
+| **Model** | `model/CuboidModel.js` | データ定義 (`FACES`, `createInitialCorners`) と純粋関数 (`buildGeometry`, `computeFaceNormal`, `computeOutwardFaceNormal`, `getCentroid`, `buildFaceHighlightPositions`, `toNDC`) |
 | **View** | `view/SceneView.js` | Three.js シーン・WebGL レンダラー・OrbitControls の初期化と `render()` |
-| **View** | `view/MeshView.js` | 直方体メッシュ・ワイヤーフレーム・BoxHelper・面ハイライトの更新 |
-| **View** | `view/UIView.js` | DOM 要素の生成・モードボタン・ステータス表示・カーソル変更 |
+| **View** | `view/MeshView.js` | 直方体メッシュ・ワイヤーフレーム・BoxHelper・面ハイライト・押し出し表示ラインの更新 |
+| **View** | `view/UIView.js` | DOM 要素の生成・モードボタン・ステータス表示・押し出し量ラベル・カーソル変更 |
 | **Controller** | `controller/AppController.js` | マウス/キーボードイベント・レイキャスト・モード切替・アニメーションループ |
 
 ### 純粋関数と副作用の分離
@@ -83,3 +83,4 @@ easy-extrude/
 ## セッション履歴
 
 - **2026-03-17**: `src/main.js` を MVC パターンにリファクタリング。純粋関数と副作用を分離し、`model/` / `view/` / `controller/` に分割。セッション完了。
+- **2026-03-18**: ドキュメント更新。README.md を実装済み MVC 構成に合わせて全面改訂。CLAUDE.md の Model 純粋関数リストに `computeOutwardFaceNormal` を追記、MeshView・UIView の責務説明を実態に合わせて更新。

--- a/README.md
+++ b/README.md
@@ -13,29 +13,21 @@ An interactive web app that lets anyone experience 3D "extrude" operations intui
 "Face Extrude" is the operation of selecting a face on a 3D model and pushing it outward to create new geometry. It's a fundamental technique in tools like Blender and Maya — and we're bringing it to the **browser, the easy way**.
 
 ```
-Click to select a face → Drag to extrude → Your 3D shape is ready!
+Switch to Face mode → Hover to highlight a face → Drag to extrude → Your 3D shape is ready!
 ```
 
 ---
 
-## Current State
+## Features
 
-A prototype interactive 3D scene built with Three.js + Vite.
+An interactive 3D scene built with Three.js + Vite (MVC architecture).
 
-- 3D shapes (star, heart, arrow) using ExtrudeGeometry
-- Mouse controls via OrbitControls (rotate, zoom, pan)
-- Animated PointLight orbiting the scene
-- Floating particle effects
-- Fog and grid helpers
-
----
-
-## Roadmap
-
-- [ ] Draw any 2D shape and extrude it
-- [ ] Face selection → Face Extrude interaction
-- [ ] Export (OBJ / GLTF)
-- [ ] Mobile support
+- Custom **BufferGeometry** cuboid with 8 corners and 6 independently addressable faces
+- **Object mode** (`O` key): click to select, left-drag to move, Ctrl+drag to rotate around Y-axis
+- **Face mode** (`F` key): hover to highlight a face, left-drag to extrude along face normal
+- Extrusion dimension line with live `Δ` label while dragging
+- **OrbitControls**: right-drag to orbit camera, scroll to zoom
+- Grid helper and directional lighting
 
 ---
 
@@ -50,6 +42,32 @@ pnpm dev
 
 Dev server runs at http://localhost:5173
 
+### Build & Preview
+
+```bash
+pnpm build    # Production build → dist/
+pnpm preview  # Preview the build locally
+```
+
+---
+
+## Project Structure (MVC)
+
+```
+src/
+├── main.js                    # Entry point: wires MVC components and calls start()
+├── model/
+│   └── CuboidModel.js         # Pure functions only (no side effects)
+├── view/
+│   ├── SceneView.js           # Renderer, camera, OrbitControls, lighting, grid
+│   ├── MeshView.js            # Cuboid mesh, wireframe, face highlight, extrusion display
+│   └── UIView.js              # DOM UI: mode buttons, status bar, info bar, extrusion label
+└── controller/
+    └── AppController.js       # Input handling, animation loop, MV coordination
+```
+
+---
+
 ## Tech Stack
 
 | Tool | Role |
@@ -58,6 +76,16 @@ Dev server runs at http://localhost:5173
 | [Vite](https://vitejs.dev/) | Bundler & dev server |
 | [pnpm](https://pnpm.io/) | Package manager |
 | GitHub Actions | CI/CD → auto deploy to GitHub Pages |
+
+---
+
+## Roadmap
+
+- [x] Face selection → Face Extrude interaction
+- [ ] Multi-face extrude
+- [ ] Export (OBJ / GLTF)
+- [ ] Mobile support
+- [ ] Draw any 2D shape and extrude it
 
 ---
 


### PR DESCRIPTION
- README.md: 旧 prototype 記述 (ExtrudeGeometry / 星・ハート形状 / パーティクル) を削除し、
  実装済みの BufferGeometry 直方体・オブジェクトモード・面押し出し機能・MVC 構成を反映
- CLAUDE.md: Model の純粋関数リストに computeOutwardFaceNormal を追記、
  MeshView の責務に押し出し表示ライン、UIView に押し出し量ラベルを追加

https://claude.ai/code/session_01Gtj1UNpp1aE44o7ZFGhw7j