### PR TITLE
Fix extrusion bracket direction to point outward from face

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -343,8 +343,11 @@ export class AppController {
       const currentFaceCorners = FACES[this._dragFaceIdx].corners.map(ci => this._corners[ci])
       this._meshView.setExtrusionDisplay(this._savedFaceCorners, currentFaceCorners)
       // Label sits at the midpoint of the span segment (same ARM_LEN=0.5 as MeshView)
+      const faceCentroid = new THREE.Vector3()
+      this._savedFaceCorners.forEach(v => faceCentroid.add(v))
+      faceCentroid.divideScalar(this._savedFaceCorners.length)
       const armDir = new THREE.Vector3()
-        .subVectors(this._savedFaceCorners[1], this._savedFaceCorners[0]).normalize()
+        .subVectors(this._savedFaceCorners[0], faceCentroid).normalize()
       const ARM_LEN = 0.5
       const tipS = this._savedFaceCorners[0].clone().addScaledVector(armDir, ARM_LEN)
       const tipC = currentFaceCorners[0].clone().addScaledVector(armDir, ARM_LEN)

--- a/src/view/MeshView.js
+++ b/src/view/MeshView.js
@@ -73,14 +73,17 @@ export class MeshView {
    * @param {THREE.Vector3[]} currentFaceCorners - 4 face vertices at current position
    */
   setExtrusionDisplay(savedFaceCorners, currentFaceCorners) {
-    // Bracket shape: extend from corners[0] in the corners[1] direction by a fixed length,
+    // Bracket shape: extend from corners[0] outward (away from face centroid) by a fixed length,
     // then connect the two tips with a span segment.
     //   savedFaceCorners[0]   ──────── tipS
     //                                  |  ← span
     //   currentFaceCorners[0] ──────── tipC
     const ARM_LEN = 0.5
+    const faceCentroid = new THREE.Vector3()
+    savedFaceCorners.forEach(v => faceCentroid.add(v))
+    faceCentroid.divideScalar(savedFaceCorners.length)
     const armDir = new THREE.Vector3()
-      .subVectors(savedFaceCorners[1], savedFaceCorners[0]).normalize()
+      .subVectors(savedFaceCorners[0], faceCentroid).normalize()
     const tipS = savedFaceCorners[0].clone().addScaledVector(armDir,  ARM_LEN)
     const tipC = currentFaceCorners[0].clone().addScaledVector(armDir, ARM_LEN)
 


### PR DESCRIPTION
## Summary
Fixed the extrusion bracket visualization to extend outward from the face centroid rather than along an arbitrary edge direction. This ensures the bracket arms point away from the face in a consistent manner.

## Key Changes
- **MeshView.js**: Updated `setExtrusionDisplay()` to calculate the face centroid and use it as the reference point for determining the bracket arm direction, instead of using the vector between two adjacent corners
- **AppController.js**: Updated the corresponding label positioning logic in the drag handler to use the same face centroid-based calculation for consistency

## Implementation Details
- The face centroid is calculated by averaging all corner vertices of the face
- The arm direction is now computed as the vector from corner[0] pointing away from the centroid, normalized to unit length
- This change is applied in both the visualization (MeshView) and the label positioning (AppController) to keep them synchronized
- The ARM_LEN constant (0.5) remains unchanged

https://claude.ai/code/session_01PgC3xor5jM2rwD9eGPd38X