### PR TITLE
feat: modernize snap point visuals

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -129,6 +129,8 @@ export class AppController {
       snappedTarget:   null,
       /** Snap target filter: 'all'|'vertex'|'edge'|'face' */
       snapMode:        'all',
+      /** All snap candidates from last _trySnapToGeometry call (for display) */
+      snapTargets:     [],
     }
 
     this._ctrlHeld  = false
@@ -697,6 +699,7 @@ export class AppController {
     this._grab.pivotSelectMode = false
     this._grab.hoveredPivotIdx = -1
     this._grab.snapMode        = 'all'
+    this._grab.snapTargets     = []
     this._grab.startMouse.copy(this._mouse)
     this._grab.startCorners = this._corners.map(c => c.clone())
     this._grab.centroid.copy(getCentroid(this._corners))
@@ -729,6 +732,7 @@ export class AppController {
     this._grab.autoSnap      = false
     this._grab.snappedTarget = null
     this._meshView.clearPivotDisplay()
+    this._meshView.clearSnapDisplay()
     this._controls.enabled = true
     this._uiView.setCursor('default')
     this._refreshObjectModeStatus()
@@ -742,6 +746,7 @@ export class AppController {
     this._meshView.updateGeometry(this._corners)
     this._meshView.updateBoxHelper()
     this._meshView.clearPivotDisplay()
+    this._meshView.clearSnapDisplay()
     this._grab.active        = false
     this._grab.axis          = null
     this._grab.autoSnap      = false
@@ -884,6 +889,7 @@ export class AppController {
     const pScreen    = this._projectToScreen(pivotAfter)
 
     const targets  = collectSnapTargets(this._scene.objects, this._grab.snapMode)
+    this._grab.snapTargets = targets  // cache for candidate display
     let bestDist   = SNAP_PX
     let bestTarget = null
 
@@ -977,7 +983,7 @@ export class AppController {
     this._grab.snapMode      = mode
     this._grab.snapping      = false
     this._grab.snappedTarget = null
-    this._meshView.clearPivotDisplay()
+    this._meshView.clearSnapLocked()
     this._updateGrabStatus()
   }
 
@@ -1025,10 +1031,19 @@ export class AppController {
         return
       }
       this._applyGrab()
-      if ((this._ctrlHeld || this._grab.autoSnap) && this._grab.snapping && this._grab.snappedTarget) {
-        this._meshView.showSnapTarget(this._grab.snappedTarget.position, true)
+      if (this._ctrlHeld || this._grab.autoSnap) {
+        this._meshView.showSnapCandidates(this._grab.snapTargets)
+        if (this._grab.snapping && this._grab.snappedTarget) {
+          this._meshView.showSnapLocked(
+            this._grab.snappedTarget.position,
+            this._grab.snappedTarget.type,
+            this._grab.pivot,
+          )
+        } else {
+          this._meshView.clearSnapLocked()
+        }
       } else {
-        this._meshView.clearPivotDisplay()
+        this._meshView.clearSnapDisplay()
       }
       this._updateGrabStatus()
       this._updateNPanel()

--- a/src/model/CuboidModel.js
+++ b/src/model/CuboidModel.js
@@ -165,7 +165,7 @@ export function collectSnapTargets(objects, mode = 'all') {
   const targets = []
 
   if (doFace) {
-    targets.push({ label: 'World Origin', position: new THREE.Vector3(0, 0, 0) })
+    targets.push({ label: 'World Origin', position: new THREE.Vector3(0, 0, 0), type: 'origin' })
   }
 
   for (const obj of objects.values()) {
@@ -173,14 +173,14 @@ export function collectSnapTargets(objects, mode = 'all') {
 
     if (doVert) {
       for (const v of obj.vertices) {
-        targets.push({ label: `${obj.name} Vertex`, position: v.position })
+        targets.push({ label: `${obj.name} Vertex`, position: v.position, type: 'vertex' })
       }
     }
 
     if (doEdge && obj.edges) {
       for (const e of obj.edges) {
         const mid = e.v0.position.clone().add(e.v1.position).multiplyScalar(0.5)
-        targets.push({ label: `${obj.name} Edge`, position: mid })
+        targets.push({ label: `${obj.name} Edge`, position: mid, type: 'edge' })
       }
     }
 
@@ -189,7 +189,7 @@ export function collectSnapTargets(objects, mode = 'all') {
         const center = f.vertices
           .reduce((acc, v) => acc.add(v.position), new THREE.Vector3())
           .divideScalar(f.vertices.length)
-        targets.push({ label: `${obj.name} ${f.name}`, position: center })
+        targets.push({ label: `${obj.name} ${f.name}`, position: center, type: 'face' })
       }
     }
   }

--- a/src/view/MeshView.js
+++ b/src/view/MeshView.js
@@ -62,6 +62,35 @@ export class MeshView {
     this._hoveredPivotPoints.visible = false
     scene.add(this._hoveredPivotPoints)
 
+    // ── Modern snap indicators ─────────────────────────────────────────────
+
+    // All snap candidates — small type-colored dots (vertexColors)
+    this._snapCandidatesGeo = new THREE.BufferGeometry()
+    this._snapCandidates = new THREE.Points(
+      this._snapCandidatesGeo,
+      new THREE.PointsMaterial({ size: 6, sizeAttenuation: false, depthTest: false, vertexColors: true, transparent: true, opacity: 0.55 }),
+    )
+    this._snapCandidates.visible = false
+    scene.add(this._snapCandidates)
+
+    // Locked snap target — large bright type-colored dot
+    this._snapLockedGeo = new THREE.BufferGeometry()
+    this._snapLocked = new THREE.Points(
+      this._snapLockedGeo,
+      new THREE.PointsMaterial({ size: 16, sizeAttenuation: false, depthTest: false, vertexColors: true }),
+    )
+    this._snapLocked.visible = false
+    scene.add(this._snapLocked)
+
+    // Snap guide line — pivot → locked target
+    this._snapLineGeo = new THREE.BufferGeometry()
+    this._snapLine = new THREE.Line(
+      this._snapLineGeo,
+      new THREE.LineBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.35, depthTest: false }),
+    )
+    this._snapLine.visible = false
+    scene.add(this._snapLine)
+
     // Sketch rect preview (ground-plane rectangle outline + fill)
     this._sketchRectGeo = new THREE.BufferGeometry()
     this._sketchRectLines = new THREE.LineLoop(
@@ -245,6 +274,76 @@ export class MeshView {
   clearPivotDisplay() {
     this._pivotPoints.visible = false
     this._hoveredPivotPoints.visible = false
+  }
+
+  // ── Modern snap display ──────────────────────────────────────────────────
+
+  /** Color per snap target type */
+  static _SNAP_COLOR = {
+    vertex: new THREE.Color(0x69f0ae),
+    edge:   new THREE.Color(0xffd740),
+    face:   new THREE.Color(0x4fc3f7),
+    origin: new THREE.Color(0xe040fb),
+  }
+
+  /**
+   * Shows all snap candidates as small type-colored dots.
+   * @param {{ position: THREE.Vector3, type: string }[]} targets
+   */
+  showSnapCandidates(targets) {
+    if (!targets.length) { this._snapCandidates.visible = false; return }
+    const positions = new Float32Array(targets.length * 3)
+    const colors    = new Float32Array(targets.length * 3)
+    targets.forEach((t, i) => {
+      positions[i * 3]     = t.position.x
+      positions[i * 3 + 1] = t.position.y
+      positions[i * 3 + 2] = t.position.z
+      const c = MeshView._SNAP_COLOR[t.type] ?? MeshView._SNAP_COLOR.vertex
+      colors[i * 3]     = c.r
+      colors[i * 3 + 1] = c.g
+      colors[i * 3 + 2] = c.b
+    })
+    this._snapCandidatesGeo.setAttribute('position', new THREE.BufferAttribute(positions, 3))
+    this._snapCandidatesGeo.setAttribute('color',    new THREE.BufferAttribute(colors,    3))
+    this._snapCandidatesGeo.attributes.position.needsUpdate = true
+    this._snapCandidates.visible = true
+  }
+
+  /**
+   * Shows the locked snap indicator (large dot + guide line from pivot).
+   * @param {THREE.Vector3} position - snap target position
+   * @param {string}        type     - 'vertex'|'edge'|'face'|'origin'
+   * @param {THREE.Vector3} pivot    - grab pivot (guide line start)
+   */
+  showSnapLocked(position, type, pivot) {
+    const c = MeshView._SNAP_COLOR[type] ?? MeshView._SNAP_COLOR.vertex
+    const posArr = new Float32Array([position.x, position.y, position.z])
+    const colArr = new Float32Array([c.r, c.g, c.b])
+    this._snapLockedGeo.setAttribute('position', new THREE.BufferAttribute(posArr, 3))
+    this._snapLockedGeo.setAttribute('color',    new THREE.BufferAttribute(colArr, 3))
+    this._snapLockedGeo.attributes.position.needsUpdate = true
+    this._snapLocked.visible = true
+
+    const linePos = new Float32Array([
+      pivot.x,    pivot.y,    pivot.z,
+      position.x, position.y, position.z,
+    ])
+    this._snapLineGeo.setAttribute('position', new THREE.BufferAttribute(linePos, 3))
+    this._snapLineGeo.attributes.position.needsUpdate = true
+    this._snapLine.visible = true
+  }
+
+  /** Hides the locked snap dot and guide line only. */
+  clearSnapLocked() {
+    this._snapLocked.visible = false
+    this._snapLine.visible   = false
+  }
+
+  /** Hides all snap candidate and locked-target visuals. */
+  clearSnapDisplay() {
+    this._snapCandidates.visible = false
+    this._snapLocked.visible     = false
+    this._snapLine.visible       = false
   }
 
   /**


### PR DESCRIPTION
- Show all snap candidates as small type-colored dots when Ctrl/autoSnap active
- Color-code by type: vertex=green, edge=amber, face=sky-blue, origin=purple
- Locked snap target gets a large bright dot (16px, same type color)
- Guide line drawn from grab pivot to locked snap target for directional clarity
- Add `type` field to collectSnapTargets() results
- Dedicated snap geometry objects (separate from pivot candidate reuse)
- New MeshView API: showSnapCandidates / showSnapLocked / clearSnapLocked / clearSnapDisplay

https://claude.ai/code/session_01DSVgV1vZ1N771Q8zF42912