### PR TITLE
feat: convert sidebars to mobile drawers

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -179,6 +179,32 @@ export class AppController {
       if (obj) obj.description = desc
     })
 
+    // ── Mobile drawer coordination ─────────────────────────────────────────
+    uiView.onOutlinerToggle(() => {
+      if (!outlinerView) return
+      if (outlinerView.isDrawerOpen) {
+        outlinerView.closeDrawer()
+        uiView.hideBackdrop()
+      } else {
+        if (uiView.nPanelVisible) this._toggleNPanel()
+        outlinerView.openDrawer()
+        uiView.showBackdrop(() => outlinerView.closeDrawer())
+      }
+    })
+
+    uiView.onNPanelToggle(() => {
+      if (outlinerView?.isDrawerOpen) {
+        outlinerView.closeDrawer()
+        uiView.hideBackdrop()
+      }
+      this._toggleNPanel()
+      if (uiView.nPanelVisible) {
+        uiView.showBackdrop(() => this._toggleNPanel())
+      } else {
+        uiView.hideBackdrop()
+      }
+    })
+
     this._bindEvents()
 
     // Create the initial object
@@ -306,6 +332,16 @@ export class AppController {
   _renameObject(id, name) {
     this._service.renameObject(id, name)
     if (id === this._scene.activeId) this._updateNPanel()
+  }
+
+  /** Toggles N panel visibility and updates gizmo offset (desktop only) */
+  _toggleNPanel() {
+    this._uiView.toggleNPanel()
+    this._updateNPanel()
+    if (this._gizmoView) {
+      const mobile = window.innerWidth < 768
+      this._gizmoView.setRightOffset(!mobile && this._uiView.nPanelVisible ? 216 : 16)
+    }
   }
 
   /** Called when user clicks a row in the outliner */
@@ -1837,11 +1873,7 @@ export class AppController {
       return
     }
     if (e.key === 'n' || e.key === 'N') {
-      this._uiView.toggleNPanel()
-      this._updateNPanel()
-      if (this._gizmoView) {
-        this._gizmoView.setRightOffset(this._uiView.nPanelVisible ? 216 : 16)
-      }
+      this._toggleNPanel()
       return
     }
 

--- a/src/view/OutlinerView.js
+++ b/src/view/OutlinerView.js
@@ -89,9 +89,42 @@ export class OutlinerView {
     this._addBtn.addEventListener('click', () => {
       if (this._onAddCb) this._onAddCb()
     })
+
+    // ── Mobile drawer ──────────────────────────────────────────────────────
+    this._drawerOpen = false
+    this._applyLayout()
+    window.addEventListener('resize', () => this._applyLayout())
   }
 
   get width() { return 180 }
+
+  // ─── Mobile drawer ─────────────────────────────────────────────────────────
+
+  _isMobile() { return window.innerWidth < 768 }
+
+  _applyLayout() {
+    if (this._isMobile()) {
+      Object.assign(this._el.style, {
+        transition: 'transform 0.25s ease',
+        transform: this._drawerOpen ? 'translateX(0)' : 'translateX(-100%)',
+      })
+    } else {
+      Object.assign(this._el.style, {
+        transition: '',
+        transform: 'translateX(0)',
+      })
+      this._drawerOpen = false
+    }
+  }
+
+  openDrawer()  { this._drawerOpen = true;  this._el.style.transform = 'translateX(0)' }
+  closeDrawer() { this._drawerOpen = false; this._el.style.transform = 'translateX(-100%)' }
+  toggleDrawer() {
+    if (this._drawerOpen) this.closeDrawer(); else this.openDrawer()
+    return this._drawerOpen
+  }
+
+  get isDrawerOpen() { return this._drawerOpen }
 
   // ─── Callbacks ────────────────────────────────────────────────────────────
   onSelect(cb)  { this._onSelectCb  = cb }

--- a/src/view/UIView.js
+++ b/src/view/UIView.js
@@ -93,6 +93,23 @@ export class UIView {
 
     this._modeSelectorEl.appendChild(this._modeBtnEl)
     this._modeSelectorEl.appendChild(this._modeDropdownEl)
+
+    // ── Hamburger button (mobile only — opens Outliner drawer) ────────────
+    this._hamburgerBtn = document.createElement('button')
+    Object.assign(this._hamburgerBtn.style, {
+      padding: '4px 10px',
+      background: 'transparent',
+      border: 'none',
+      color: '#e8e8e8',
+      cursor: 'pointer',
+      fontSize: '18px',
+      lineHeight: '1',
+      display: 'none',
+      marginRight: '4px',
+    })
+    this._hamburgerBtn.textContent = '☰'
+    this._headerEl.appendChild(this._hamburgerBtn)
+
     this._headerEl.appendChild(this._modeSelectorEl)
 
     // ── Header status (centered within header bar) ────────────────────────
@@ -110,6 +127,22 @@ export class UIView {
       whiteSpace: 'nowrap',
     })
     this._headerEl.appendChild(this._headerStatusEl)
+
+    // ── N-panel toggle button (mobile only — opens N panel drawer) ────────
+    this._nToggleBtn = document.createElement('button')
+    Object.assign(this._nToggleBtn.style, {
+      padding: '4px 10px',
+      background: 'transparent',
+      border: 'none',
+      color: '#e8e8e8',
+      cursor: 'pointer',
+      fontSize: '16px',
+      lineHeight: '1',
+      marginLeft: 'auto',
+      display: 'none',
+    })
+    this._nToggleBtn.textContent = '⊞'
+    this._headerEl.appendChild(this._nToggleBtn)
 
     // Close dropdown on outside click
     document.addEventListener('click', (e) => {
@@ -168,6 +201,18 @@ export class UIView {
 
     document.body.appendChild(this._nPanelEl)
 
+    // ── Backdrop (mobile drawers) ─────────────────────────────────────────
+    this._backdrop   = document.createElement('div')
+    this._backdropCb = null
+    Object.assign(this._backdrop.style, {
+      position: 'fixed',
+      top: '36px', bottom: '26px', left: '0', right: '0',
+      background: 'rgba(0,0,0,0.5)',
+      zIndex: '80',
+      display: 'none',
+    })
+    document.body.appendChild(this._backdrop)
+
     // ── Extrusion label (floating) ────────────────────────────────────────
     this._extrusionLabelEl = document.createElement('div')
     Object.assign(this._extrusionLabelEl.style, {
@@ -190,6 +235,10 @@ export class UIView {
     this._modeChangeCallback = null
     this._onNameChangeCb = null
     this._onDescriptionChangeCb = null
+
+    // Apply initial mobile layout and listen for resize
+    this._applyMobileLayout()
+    window.addEventListener('resize', () => this._applyMobileLayout())
   }
 
   /** Registers callback for name changes from the N panel */
@@ -435,8 +484,57 @@ export class UIView {
   /** Toggles N panel visibility */
   toggleNPanel() {
     this._nPanelVisible = !this._nPanelVisible
-    this._nPanelEl.style.display = this._nPanelVisible ? 'block' : 'none'
+    if (this._isMobile()) {
+      this._nPanelEl.style.transform = this._nPanelVisible ? 'translateX(0)' : 'translateX(100%)'
+    } else {
+      this._nPanelEl.style.display = this._nPanelVisible ? 'block' : 'none'
+    }
   }
+
+  // ─── Mobile layout ─────────────────────────────────────────────────────────
+
+  _isMobile() { return window.innerWidth < 768 }
+
+  _applyMobileLayout() {
+    const mobile = this._isMobile()
+    this._hamburgerBtn.style.display = mobile ? 'block' : 'none'
+    this._nToggleBtn.style.display   = mobile ? 'block' : 'none'
+    if (mobile) {
+      Object.assign(this._nPanelEl.style, {
+        display:    'block',
+        transition: 'transform 0.25s ease',
+        transform:  this._nPanelVisible ? 'translateX(0)' : 'translateX(100%)',
+      })
+    } else {
+      Object.assign(this._nPanelEl.style, {
+        display:    this._nPanelVisible ? 'block' : 'none',
+        transition: '',
+        transform:  'none',
+      })
+    }
+  }
+
+  /** Shows the backdrop; calls onClose when user taps it */
+  showBackdrop(onClose) {
+    this._backdrop.style.display = 'block'
+    this._backdropCb = () => { this.hideBackdrop(); onClose?.() }
+    this._backdrop.addEventListener('click', this._backdropCb, { once: true })
+  }
+
+  /** Hides the backdrop */
+  hideBackdrop() {
+    this._backdrop.style.display = 'none'
+    if (this._backdropCb) {
+      this._backdrop.removeEventListener('click', this._backdropCb)
+      this._backdropCb = null
+    }
+  }
+
+  /** Registers callback for Outliner hamburger button tap (mobile) */
+  onOutlinerToggle(cb) { this._hamburgerBtn.addEventListener('click', cb) }
+
+  /** Registers callback for N-panel toggle button tap (mobile) */
+  onNPanelToggle(cb) { this._nToggleBtn.addEventListener('click', cb) }
 
   /**
    * Updates N panel content.


### PR DESCRIPTION
On viewports < 768px, left (Outliner) and right (N panel) sidebars
become drawers that slide in from the edges, keeping the canvas fully
visible by default.

- OutlinerView: _applyLayout() switches between always-visible (desktop)
  and transform-based drawer (mobile); openDrawer/closeDrawer/toggleDrawer
  public API
- UIView: add hamburger (☰) and properties (⊞) buttons to header,
  visible only on mobile; backdrop overlay (z-index 80) closes the active
  drawer on tap; N panel uses transform transition on mobile instead of
  display toggle; _applyMobileLayout() syncs state on resize
- AppController: _toggleNPanel() helper consolidates N-panel toggle +
  updateNPanel + gizmo offset (gizmo offset skipped on mobile since
  panel overlays rather than pushes canvas); onOutlinerToggle /
  onNPanelToggle wiring ensures only one drawer is open at a time and
  backdrop is shown/hidden consistently

https://claude.ai/code/session_012R5DsfLUEGj1RcSEwudNLW