### PR TITLE
fix(mobile): stable toolbar layout, Face Extrude button, Move label

### DIFF
--- a/.claude/MENTAL_MODEL.md
+++ b/.claude/MENTAL_MODEL.md
@@ -126,3 +126,54 @@ Only `_objDragging` and `_sketch.drawing` legitimately need `_controls.enabled =
 
 When a second touch arrives while rect selection is active, cancel the rect selection and
 clear `_activeDragPointerId` so OrbitControls can take over the two-finger gesture.
+
+## Canvas target guard in _onPointerDown
+
+`_onPointerDown` is registered on `window` to support drag-outside-canvas. This means it
+also fires for taps on toolbar buttons, overlay menus, and other UI elements.
+
+Without a canvas guard, tapping a toolbar button fires `_handleEditClick` (which clears
+face/vertex/edge selection) **before** the button's `click` handler fires — because
+`pointerdown` precedes `click`. The classic failure: tapping the mobile Extrude button
+clears the face selection, so the `click` handler finds nothing to extrude.
+
+**Rule**: add a canvas target check immediately after the secondary-touch guard:
+
+```js
+if (e.target !== this._sceneView.renderer.domElement) return
+```
+
+This guard goes **before** the grab/faceExtrude active checks so that toolbar buttons
+always fall through to their own `click` listeners instead.
+
+## Face extrude confirm requires a canvas drag (wasDragging)
+
+`_onPointerUp` on `window` fires for toolbar button taps too. Without a guard,
+tapping the mobile Confirm button produces both a `pointerup` (which calls
+`_confirmFaceExtrude` via `_onPointerUp`) **and** a `click` (which calls it again via
+`onClick`), causing a double-confirm.
+
+**Rule**: only confirm face extrude in `_onPointerUp` when `_activeDragPointerId` was
+set for that pointer (i.e. a canvas drag was started in `_onPointerDown`):
+
+```js
+const wasDragging = this._activeDragPointerId === e.pointerId
+if (wasDragging) this._activeDragPointerId = null
+if (this._faceExtrude.active && wasDragging) { this._confirmFaceExtrude(); return }
+```
+
+## Mobile toolbar must have a fixed button count per mode
+
+If buttons appear or disappear based on sub-state (e.g. Extrude only when face selected),
+the entire centered toolbar shifts left/right, making tapping unreliable.
+
+**Rule**: every mode shows a **fixed set** of buttons. Unavailable actions use
+`disabled: true` (grayed out, no click handler) instead of being hidden.
+
+| Mode         | Buttons (always shown)                              |
+|--------------|-----------------------------------------------------|
+| Object       | Add · Edit · Move · Delete                          |
+| Edit 2D      | ← Object · Extrude                                  |
+| Edit 3D      | ← Object · Vertex · Edge · Face · Extrude           |
+| Grab active  | ✓ Confirm · ✕ Cancel                               |
+| Face extrude | ✓ Confirm · ✕ Cancel                               |

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -463,7 +463,10 @@ export class AppController {
     }
 
     if (mode === 'object') {
-      const buttons = [
+      // Always show the same 4 buttons; Edit/Move/Delete are disabled when no
+      // object is selected. Fixed count prevents layout shifts on selection.
+      const hasObj = this._objSelected
+      this._uiView.setMobileToolbar([
         {
           icon: '＋', label: 'Add',
           onClick: () => this._uiView.showAddMenu(
@@ -472,27 +475,23 @@ export class AppController {
             () => this._addObject('sketch'),
           ),
         },
-        { icon: '⊞', label: 'Edit', onClick: () => this.setMode('edit') },
-      ]
-      if (this._objSelected) {
-        buttons.push({ icon: 'G',  label: 'Grab',   onClick: () => this._startGrab() })
-        buttons.push({ icon: '🗑', label: 'Delete', onClick: () => this._deleteObject(this._scene.activeId), danger: true })
-      }
-      this._uiView.setMobileToolbar(buttons)
+        { icon: '⊞', label: 'Edit',   onClick: () => this.setMode('edit'),                                     disabled: !hasObj },
+        { icon: '↔', label: 'Move',   onClick: () => this._startGrab(),                                        disabled: !hasObj },
+        { icon: '🗑', label: 'Delete', onClick: () => this._deleteObject(this._scene.activeId), danger: hasObj, disabled: !hasObj },
+      ])
       return
     }
 
     if (substate === '2d-sketch') {
+      // Always show ← first so its position never shifts. Extrude is disabled
+      // until a rectangle has been drawn.
       const hasRect = this._sketch.p1 && this._sketch.p2 &&
         (Math.abs(this._sketch.p2.x - this._sketch.p1.x) > 0.01 ||
          Math.abs(this._sketch.p2.y - this._sketch.p1.y) > 0.01)
-      const buttons = [
-        { icon: '←', label: 'Object', onClick: () => this.setMode('object') },
-      ]
-      if (hasRect) {
-        buttons.unshift({ icon: '✓', label: 'Extrude', onClick: () => this._enterExtrudePhase() })
-      }
-      this._uiView.setMobileToolbar(buttons)
+      this._uiView.setMobileToolbar([
+        { icon: '←', label: 'Object',  onClick: () => this.setMode('object') },
+        { icon: '✓', label: 'Extrude', onClick: () => this._enterExtrudePhase(), disabled: !hasRect },
+      ])
       return
     }
 
@@ -505,24 +504,24 @@ export class AppController {
     }
 
     if (substate === '3d') {
-      const em          = this._editSelectMode
-      const hasFaceSel  = em === 'face' && [...this._scene.editSelection].some(x => x instanceof Face)
-      const buttons = [
+      // Always show all 5 buttons; Extrude is disabled until a face is selected.
+      // Fixed count prevents layout shifts when a face is selected.
+      const em         = this._editSelectMode
+      const hasFaceSel = em === 'face' && [...this._scene.editSelection].some(x => x instanceof Face)
+      this._uiView.setMobileToolbar([
         { icon: '←', label: 'Object', onClick: () => this.setMode('object') },
         { icon: '·', label: 'Vertex', onClick: () => this._setEditSelectMode('vertex'), active: em === 'vertex' },
         { icon: '─', label: 'Edge',   onClick: () => this._setEditSelectMode('edge'),   active: em === 'edge' },
         { icon: '▢', label: 'Face',   onClick: () => this._setEditSelectMode('face'),   active: em === 'face' },
-      ]
-      if (hasFaceSel) {
-        buttons.push({
-          icon: 'E', label: 'Extrude',
+        {
+          icon: '↑', label: 'Extrude',
           onClick: () => {
             const sel = [...this._scene.editSelection].filter(x => x instanceof Face)
             if (sel.length > 0) this._startFaceExtrude(sel[0])
           },
-        })
-      }
-      this._uiView.setMobileToolbar(buttons)
+          disabled: !hasFaceSel,
+        },
+      ])
     }
   }
 
@@ -1719,6 +1718,12 @@ export class AppController {
       return
     }
 
+    // Only process events that target the canvas. Toolbar button taps are
+    // handled by the buttons' own click listeners, not via pointer events.
+    // Without this guard, button taps trigger _handleEditClick which clears
+    // face selection before the button's click handler fires (e.g. Extrude).
+    if (e.target !== this._sceneView.renderer.domElement) return
+
     if (this._grab.active) {
       if (this._grab.pivotSelectMode) {
         if (e.button === 0) { this._confirmPivotSelect(); return }
@@ -1839,9 +1844,13 @@ export class AppController {
 
   _onPointerUp(e) {
     if (e.button !== 0) return
-    if (this._activeDragPointerId === e.pointerId) this._activeDragPointerId = null
+    // wasDragging: a canvas drag started for this pointer (via _onPointerDown)
+    const wasDragging = this._activeDragPointerId === e.pointerId
+    if (wasDragging) this._activeDragPointerId = null
     if (this._faceExtrude.active) {
-      this._confirmFaceExtrude()
+      // Only confirm when a canvas drag was started; prevents double-confirm
+      // when the mobile Confirm toolbar button fires both pointerup and click.
+      if (wasDragging) this._confirmFaceExtrude()
       return
     }
     if (this._sketch.drawing) {

--- a/src/view/UIView.js
+++ b/src/view/UIView.js
@@ -731,11 +731,11 @@ export class UIView {
    * Renders the mobile floating toolbar with the given buttons.
    * Only visible on mobile (<768px). Ignored on desktop.
    *
-   * @param {Array<{icon: string, label: string, onClick: () => void, active?: boolean, danger?: boolean}>} buttons
+   * @param {Array<{icon: string, label: string, onClick: () => void, active?: boolean, danger?: boolean, disabled?: boolean}>} buttons
    */
   setMobileToolbar(buttons) {
     this._mobileToolbarEl.innerHTML = ''
-    buttons.forEach(({ icon, label, onClick, active = false, danger = false }) => {
+    buttons.forEach(({ icon, label, onClick, active = false, danger = false, disabled = false }) => {
       const btn = document.createElement('button')
       Object.assign(btn.style, {
         display:        'flex',
@@ -746,11 +746,11 @@ export class UIView {
         padding:        '4px 10px',
         minWidth:       '44px',
         minHeight:      '44px',
-        background:     active  ? '#3a6a9a' : danger ? '#6a2a2a' : '#333',
-        border:         `1px solid ${active ? '#4a9eed' : danger ? '#c0392b' : '#555'}`,
+        background:     disabled ? '#2a2a2a' : active ? '#3a6a9a' : danger ? '#6a2a2a' : '#333',
+        border:         `1px solid ${disabled ? '#3a3a3a' : active ? '#4a9eed' : danger ? '#c0392b' : '#555'}`,
         borderRadius:   '6px',
-        color:          active  ? '#4fc3f7' : danger ? '#e74c3c' : '#e8e8e8',
-        cursor:         'pointer',
+        color:          disabled ? '#555'    : active ? '#4fc3f7' : danger ? '#e74c3c' : '#e8e8e8',
+        cursor:         disabled ? 'default' : 'pointer',
         fontSize:       '18px',
         lineHeight:     '1',
         fontFamily:     'sans-serif',
@@ -769,7 +769,7 @@ export class UIView {
 
       btn.appendChild(iconEl)
       btn.appendChild(labelEl)
-      btn.addEventListener('click', onClick)
+      if (!disabled) btn.addEventListener('click', onClick)
       this._mobileToolbarEl.appendChild(btn)
     })
   }


### PR DESCRIPTION
- Fix Face Extrude button clearing selection before click fires:
  _onPointerDown is on window, so tapping the Extrude toolbar button
  triggered _handleEditClick (clearing face selection) before the
  button's click handler ran. Added a canvas target guard:
    if (e.target !== canvas) return
  (placed after the secondary-touch guard)

- Fix double-confirm when tapping mobile Confirm button for face extrude:
  _onPointerUp called _confirmFaceExtrude for any pointerup while
  faceExtrude.active, including toolbar button taps. Now only confirms
  when a canvas drag was started (wasDragging check).

- Stable toolbar button count per mode:
  Buttons no longer appear/disappear based on sub-state, preventing
  the entire centered toolbar from shifting. Instead, unavailable
  actions show as disabled (grayed out). Fixed counts:
    Object mode:  Add / Edit / Move / Delete  (4 buttons)
    Edit 2D:      ← Object / Extrude          (2 buttons)
    Edit 3D:      ← Object / Vertex / Edge / Face / Extrude  (5 buttons)

- Rename "Grab" → "Move" (icon G→↔) in Object mode toolbar to avoid
  confusion with the Edit mode button.

- Update MENTAL_MODEL with canvas guard, wasDragging, and fixed-count
  toolbar rules.

https://claude.ai/code/session_018j2fT1iBqZzGRRovhXhFmw