### PR TITLE
feat(mobile): remove Move button from Object mode toolbar

### DIFF
--- a/.claude/MENTAL_MODEL.md
+++ b/.claude/MENTAL_MODEL.md
@@ -172,7 +172,7 @@ the entire centered toolbar shifts left/right, making tapping unreliable.
 
 | Mode         | Buttons (always shown)                              |
 |--------------|-----------------------------------------------------|
-| Object       | Add · Edit · Move · Delete                          |
+| Object       | Add · Edit · Delete                                 |
 | Edit 2D      | ← Object · Extrude                                  |
 | Edit 3D      | ← Object · Vertex · Edge · Face · Extrude           |
 | Grab active  | ✓ Confirm · ✕ Cancel                               |

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -476,7 +476,6 @@ export class AppController {
           ),
         },
         { icon: '⊞', label: 'Edit',   onClick: () => this.setMode('edit'),                                     disabled: !hasObj },
-        { icon: '↔', label: 'Move',   onClick: () => this._startGrab(),                                        disabled: !hasObj },
         { icon: '🗑', label: 'Delete', onClick: () => this._deleteObject(this._scene.activeId), danger: hasObj, disabled: !hasObj },
       ])
       return


### PR DESCRIPTION
The Move button called _startGrab(), but on mobile it was non-functional:
after tapping the button, the next touch on the canvas starts _objDragging
(direct drag), so Grab mode never got a chance to operate. Meanwhile,
direct object drag already lets users move objects without the button.
On desktop, G key remains available for Blender-style Grab.

Reduces Object mode toolbar from 4 to 3 buttons: Add · Edit · Delete.
Updated MENTAL_MODEL.md table accordingly.

https://claude.ai/code/session_019ZWxRrG1ykRobsSZ2u8PGG