### PR TITLE
docs: add mobile state transitions and refresh outdated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 > **Face Extrude made simple, right in your browser.**
 
-An interactive web app that lets anyone experience 3D "extrude" operations intuitively — no complex software required. Just open and create.
+An interactive web app for 3D modeling — sketch shapes, extrude them, and sculpt faces.
+Works on desktop and mobile. No installation required.
 
 **Live Demo:** https://yuubae215.github.io/easy-extrude/
 
@@ -13,22 +14,25 @@ An interactive web app that lets anyone experience 3D "extrude" operations intui
 "Face Extrude" is the operation of selecting a face on a 3D model and pushing it outward to create new geometry. It's a fundamental technique in tools like Blender and Maya — and we're bringing it to the **browser, the easy way**.
 
 ```
-Switch to Face mode → Hover to highlight a face → Drag to extrude → Your 3D shape is ready!
+Shift+A → Add Sketch → Draw rectangle → Enter → Drag height → Enter → Edit faces → Extrude
 ```
 
 ---
 
 ## Features
 
-An interactive 3D scene built with Three.js + Vite (MVC architecture).
-
-- Custom **BufferGeometry** cuboid with 8 corners and 6 independently addressable faces
-- **Object mode** (`O` key): click to select, left-drag to move, Ctrl+drag to rotate around Z-axis (world up)
-- **Face mode** (`F` key): hover to highlight a face, left-drag to extrude along face normal
-- Extrusion dimension line with live `Δ` label while dragging
-- **OrbitControls**: right-drag to orbit camera, scroll to zoom
-- Grid helper and directional lighting
-- **ROS world frame**: +X forward, +Y left, +Z up (right-handed, same as ROS convention)
+- **Sketch → Extrude** workflow: draw a 2D rectangle on the ground plane, extrude it into a 3D cuboid
+- **Add Box**: instantly place a default cuboid
+- **Object Mode**: click to select, left-drag to move, Ctrl+drag to rotate around Z-axis
+- **Edit Mode (3D)**: switch sub-element selection between Vertex / Edge / Face (keys `1` / `2` / `3`)
+  - Hover to highlight a face, click to select, `E` key (or mobile button) to extrude along normal
+  - Live extrusion distance label while dragging
+- **Grab** (`G` key): move objects with optional axis lock (X/Y/Z), numeric input, and origin snap (Ctrl)
+- **Outliner**: scene hierarchy sidebar — rename objects, toggle visibility, delete
+- **Rectangle selection**: drag on empty space to select multiple objects (enclosed or touch)
+- **OrbitControls**: right-drag / two-finger to orbit, scroll / pinch to zoom
+- **Mobile toolbar**: fixed floating buttons adapt to current mode; all gestures use Pointer Events
+- **ROS world frame**: +X forward, +Y left, +Z up (right-handed, matches ROS REP-103)
 
 ---
 
@@ -52,20 +56,49 @@ pnpm preview  # Preview the build locally
 
 ---
 
-## Project Structure (MVC)
+## Project Structure (MVC + DDD)
 
 ```
 src/
-├── main.js                    # Entry point: wires MVC components and calls start()
+├── main.js                    # Entry point: assembles layers and calls start()
+├── domain/
+│   ├── Cuboid.js              # Domain entity: 3D cuboid (vertices, faces, edges, behaviour)
+│   └── Sketch.js              # Domain entity: 2D sketch (draw → extrude)
+├── graph/
+│   ├── Vertex.js              # { id, position: Vector3 }
+│   ├── Edge.js                # { id, v0: Vertex, v1: Vertex }
+│   └── Face.js                # { id, vertices: Vertex[4], name, index }
 ├── model/
-│   └── CuboidModel.js         # Pure functions only (no side effects)
+│   ├── CuboidModel.js         # Pure functions: geometry computation (stateless)
+│   └── SceneModel.js          # Aggregate root: objects + mode state + editSelection
+├── service/
+│   └── SceneService.js        # ApplicationService: entity creation, CRUD, observable events
 ├── view/
 │   ├── SceneView.js           # Renderer, camera, OrbitControls, lighting, grid
-│   ├── MeshView.js            # Cuboid mesh, wireframe, face highlight, extrusion display
-│   └── UIView.js              # DOM UI: mode buttons, status bar, info bar, extrusion label
+│   ├── MeshView.js            # Per-object mesh, wireframe, face highlight, sketch rect
+│   ├── UIView.js              # DOM UI: header, N panel, status bar, mobile toolbar
+│   ├── GizmoView.js           # World-axis gizmo (top-right corner)
+│   └── OutlinerView.js        # Scene hierarchy sidebar (left panel)
 └── controller/
-    └── AppController.js       # Input handling, animation loop, MV coordination
+    └── AppController.js       # Input handling (Pointer Events), animation loop, MV coordination
 ```
+
+See `docs/ARCHITECTURE.md` for layer responsibilities and DDD migration status.
+
+---
+
+## Key Bindings
+
+| Key | Action |
+|-----|--------|
+| `Tab` | Toggle Object ↔ Edit Mode |
+| `Shift+A` | Add menu (Box / Sketch) |
+| `G` | Grab (move) selected object |
+| `X` / `Delete` | Delete selected object |
+| `E` | Extrude selected face (Edit Mode · 3D) |
+| `1` / `2` / `3` | Vertex / Edge / Face sub-element mode |
+| `Enter` | Confirm operation |
+| `Escape` | Cancel operation |
 
 ---
 
@@ -80,15 +113,15 @@ src/
 
 ---
 
-## Roadmap
+## Documentation
 
-- [x] Face selection → Face Extrude interaction
-- [ ] Multi-face extrude
-- [ ] Export (OBJ / GLTF)
-- [ ] Mobile support
-- [ ] Draw any 2D shape and extrude it
-
-See [docs/ROADMAP.md](docs/ROADMAP.md) for detailed implementation plans.
+| Document | Contents |
+|----------|----------|
+| `docs/ARCHITECTURE.md` | Layer responsibilities, DDD migration status, coordinate system |
+| `docs/STATE_TRANSITIONS.md` | Mode state machine, mobile input flow, toolbar states |
+| `docs/ROADMAP.md` | Feature backlog and completed items |
+| `docs/adr/` | Architecture Decision Records (ADR-001 … ADR-016) |
+| `.claude/MENTAL_MODEL.md` | Coding policies learned from real bugs |
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -16,44 +16,7 @@ This project is a **cuboid-based modeling application**. Each shape is a deforma
 | 🟡 Medium | Right-click context menu (currently: cancel only) | Low | ADR-006 |
 | 🟡 Medium | Multi-face extrude (Shift+click) | Medium | — |
 | 🟡 Medium | Export (OBJ / GLTF) | Low | — |
-| 🟢 Low | Mobile / touch support | Medium | See below |
 | 🟢 Low | 1D objects: MeasureLine, reference line | Medium | ADR-005 |
-
----
-
-## Mobile Support (Backlog · Low Priority)
-
-**Goal:** Allow cuboid editing and scene navigation on smartphones and tablets.
-
-### Challenge: no middle mouse button on touch
-
-The desktop scheme uses right-drag for orbit. Touch devices have no right button.
-
-### Proposed touch mapping
-
-| Gesture | Action |
-|---------|--------|
-| 1-finger drag | Edit action (extrude face / sketch rect) |
-| 2-finger drag | Orbit camera |
-| Pinch | Zoom |
-| Long-press | Context menu (replaces right-click) |
-| Tap | Select / confirm |
-
-OrbitControls already handles 2-finger orbit and pinch-to-zoom natively. The main work is routing single-finger drag to edit actions while letting 2-finger gestures pass through to OrbitControls.
-
-### Implementation notes
-
-- Replace `mousedown/mousemove/mouseup` with **Pointer Events API** (`pointerdown`, `pointermove`, `pointerup`) — unifies mouse, touch, stylus
-- Track `_activeDragPointerId`; ignore secondary pointers during an edit drag
-- Suppress browser context menu on long-press: `contextmenu` → `e.preventDefault()`
-- Add `touch-action: none` CSS on canvas
-- Ensure all UI tap targets >= 44x44 px
-- Verify `renderer.setPixelRatio(window.devicePixelRatio)` for HiDPI screens
-
-### Key risks
-
-- Long-press context menu conflicts with hold-to-drag on some Android browsers
-- Alt+left-drag (orbit fallback for trackpad users) may be worth adding simultaneously
 
 ---
 
@@ -61,6 +24,7 @@ OrbitControls already handles 2-finger orbit and pinch-to-zoom natively. The mai
 
 | Item | Date |
 |------|------|
+| Mobile touch support — Pointer Events API, `_activeDragPointerId`, mobile toolbar, canvas target guard, touch hover sync, face-extrude confirm on `pointerup` | 2026-03-21 |
 | DDD Phase 6 — Sub-element selection (1/2/3 keys); Grab snap expanded to all geometry (ADR-014) | 2026-03-20 |
 | DDD Phase 5-3 — Edge/Face graph objects; unified selection model; dimension field removed (ADR-012) | 2026-03-20 |
 | DDD Phase 5-2 — Event-driven status bar; _refreshObjectModeStatus() | 2026-03-20 |

--- a/docs/STATE_TRANSITIONS.md
+++ b/docs/STATE_TRANSITIONS.md
@@ -184,6 +184,151 @@ FACE EXTRUDE ACTIVE (faceExtrude.active = true)
 
 ---
 
+## Mobile Input State Machine
+
+Touch and mouse input are unified via the **Pointer Events API** (`pointerdown` / `pointermove` / `pointerup`).
+`_activeDragPointerId` tracks which pointer owns the current edit drag.
+
+### Primary pointer (first finger / mouse)
+
+```
+IDLE (_activeDragPointerId = null)
+    |
+    pointerdown (canvas target) ─────────────────────────────────────────────┐
+    |                                                                         |
+    ├─ grab.active ──────────────────────────────────────────────────────────>│
+    │   button=0 → _confirmGrab()           (IDLE)                           |
+    │   button=2 → _cancelGrab()            (IDLE)                           |
+    │                                                                         |
+    ├─ faceExtrude.active ───────────────────────────────────────────────────>│
+    │   button=0 → set _activeDragPointerId ← do NOT confirm yet             |
+    │              (wait for pointermove to set distance, confirm on up)      |
+    │   button=2 → _cancelFaceExtrude()     (IDLE)                           |
+    │                                                                         |
+    ├─ editSubstate === '2d-sketch' ─────────────────────────────────────────>│
+    │   ray hits ground plane → _sketch.drawing=true                          |
+    │   _controls.enabled = false   ← orbit must not interfere with draw      |
+    │   set _activeDragPointerId                                               |
+    │                                                                         |
+    ├─ selectionMode === 'object' ───────────────────────────────────────────>│
+    │   hit object → _objDragging=true                                        |
+    │                _controls.enabled = false                                |
+    │                set _activeDragPointerId                                  |
+    │   no hit     → _rectSel.active=true                                    |
+    │                set _activeDragPointerId                                  |
+    │                (_controls stays ENABLED — orbit must remain usable)     |
+    │                                                                         |
+    └─ editSubstate === '3d' ────────────────────────────────────────────────>│
+        re-run hit test (touch has no prior pointermove)                      |
+        → _hoveredFace / _hoveredVertex / _hoveredEdge refreshed              |
+        → _handleEditClick()                                                  |
+                                                                              ▼
+                                              DRAG (_activeDragPointerId set)
+                                                  |
+                                                  | pointermove (same pointerId)
+                                                  |── rectSel: update overlay rect
+                                                  |── objDragging: move object(s)
+                                                  |── sketch.drawing: update rect p2
+                                                  |── faceExtrude: update distance
+                                                  |── grab: apply grab
+                                                  |
+                                                  | pointerup (same pointerId)
+                                                  │   wasDragging = true
+                                                  │   _activeDragPointerId = null
+                                                  │──  faceExtrude → _confirmFaceExtrude()
+                                                  │──  sketch.drawing → _confirmSketchRect()
+                                                  │──  rectSel → _finalizeRectSel()
+                                                  │──  objDragging → reset flags
+                                                  v
+                                              IDLE
+```
+
+### Secondary touch (second finger)
+
+```
+DRAG (_activeDragPointerId set) + second touch arrives
+    |
+    pointerdown (e.pointerType === 'touch', different pointerId)
+    |
+    ├─ _rectSel.active
+    │   → cancel rect selection
+    │   → _activeDragPointerId = null   ← release ownership
+    │   → return                        ← OrbitControls takes two-finger gesture
+    │
+    └─ any other drag state
+        → return (secondary touch ignored; primary drag continues)
+```
+
+### Canvas target guard
+
+`pointerdown` is registered on `window` (to support drag-outside-canvas).
+This means it fires for toolbar button taps, overlay menus, etc.
+
+```
+pointerdown fired
+    |
+    if e.target !== canvas → return immediately
+    (toolbar click listeners handle these via the 'click' event instead)
+```
+
+Without this guard, a toolbar tap fires `_handleEditClick` (clears face/vertex/edge
+selection) **before** the button's own `click` handler fires — because `pointerdown`
+precedes `click`. The classic failure: tapping "Extrude" clears the face selection.
+
+### Face extrude confirm flow (touch vs. desktop)
+
+```
+Desktop:
+  left-click (pointerdown+pointerup without move) → confirm immediately on pointerup
+
+Touch:
+  tap "Extrude" button → _startFaceExtrude()
+      |
+      Touch canvas to start drag → _activeDragPointerId set (pointerdown)
+      |
+      Drag finger → pointermove updates distance
+      |
+      Lift finger → pointerup: wasDragging=true → _confirmFaceExtrude()
+
+  tap "Confirm" toolbar button → fires both pointerup AND click
+      pointerup: wasDragging=false (no canvas drag started) → skip confirm
+      click:     → _confirmFaceExtrude()   ← only this path fires
+```
+
+The `wasDragging` guard prevents double-confirm when the toolbar button is tapped.
+
+---
+
+## Mobile Toolbar State Machine
+
+On narrow screens (`window.innerWidth < 768`), a floating toolbar replaces keyboard shortcuts.
+The toolbar shows a **fixed set of buttons per state** — buttons are disabled (not hidden)
+to prevent layout shifts.
+
+```
+App state                   Toolbar buttons (→ always the same count)
+──────────────────────────────────────────────────────────────────────────
+grab.active                 [✓ Confirm]  [✕ Cancel]
+faceExtrude.active          [✓ Confirm]  [✕ Cancel]
+──────────────────────────────────────────────────────────────────────────
+Object Mode                 [+ Add]  [Edit*]  [Delete*]
+  * disabled if no selection
+──────────────────────────────────────────────────────────────────────────
+Edit · 2D-Sketch            [← Object]  [Extrude*]
+  * disabled until rect area > 0.01
+──────────────────────────────────────────────────────────────────────────
+Edit · 2D-Extrude           [✓ Confirm]  [✕ Cancel]
+──────────────────────────────────────────────────────────────────────────
+Edit · 3D                   [← Object]  [Vertex]  [Edge]  [Face]  [Extrude*]
+  * disabled until a Face is in editSelection; active sub-mode highlighted
+──────────────────────────────────────────────────────────────────────────
+```
+
+Toolbar button taps use `click` events, not pointer events, so they are
+unaffected by the canvas target guard above.
+
+---
+
 ## Related ADRs
 
 - **ADR-002**: Two-step Sketch → Extrude workflow


### PR DESCRIPTION
- STATE_TRANSITIONS.md: add Mobile Input State Machine section covering
  Pointer Events flow, _activeDragPointerId lifecycle, secondary-touch
  handling, canvas target guard, face-extrude confirm (wasDragging), and
  Mobile Toolbar state table per app state
- README.md: rewrite project structure (domain/graph/service layers added),
  features (Sketch→Extrude, Grab, Outliner, mobile, sub-element selection),
  key bindings table, and documentation index; remove stale MVC-only layout
- ROADMAP.md: move mobile support from backlog to Completed (implemented
  2026-03-21); remove now-obsolete "Proposed touch mapping" planning section

https://claude.ai/code/session_01LejdbuiGnF4erxkWTuxaDi