### PR TITLE
fix: lift toast above mobile toolbar on small screens

### DIFF
--- a/.claude/MENTAL_MODEL.md
+++ b/.claude/MENTAL_MODEL.md
@@ -178,6 +178,24 @@ the entire centered toolbar shifts left/right, making tapping unreliable.
 | Grab active  | ✓ Confirm · ✕ Cancel                               |
 | Face extrude | ✓ Confirm · ✕ Cancel                               |
 
+## Toast must be positioned above the mobile toolbar
+
+The mobile floating toolbar occupies `bottom: 26px` with `height: 60px`, so its top edge is
+at **86px** from the bottom of the viewport. The info bar occupies `bottom: 0, height: 26px`.
+
+`showToast()` uses a **fixed** `bottom` value. If that value is ≤ 86px the toast appears
+underneath (or partially inside) the mobile toolbar, making it invisible to the user even
+though it has `zIndex: 9999`.
+
+**Rule**: `showToast` must call `_isMobile()` and use a larger `bottom` on mobile:
+
+```js
+const bottomPx = this._isMobile() ? '96px' : '64px'
+```
+
+If the mobile toolbar height or position ever changes, update both the toolbar CSS and
+this constant together.
+
 ## MeshView.dispose() must mirror the constructor exactly
 
 Every `scene.add(object)` call in the `MeshView` constructor MUST have a matching

--- a/src/view/UIView.js
+++ b/src/view/UIView.js
@@ -523,9 +523,11 @@ export class UIView {
     const colors = { info: '#4a90d9', warn: '#d9a84a', error: '#d94a4a' }
     const el = document.createElement('div')
     el.textContent = message
+    // On mobile the floating toolbar occupies bottom 26–86px, so lift the toast above it.
+    const bottomPx = this._isMobile() ? '96px' : '64px'
     Object.assign(el.style, {
       position: 'fixed',
-      bottom: '64px',
+      bottom: bottomPx,
       left: '50%',
       transform: 'translateX(-50%)',
       background: '#2a2a2a',


### PR DESCRIPTION
bottom: '64px' placed the toast inside the mobile toolbar area (26–86px),
making it invisible. Now uses 96px on mobile and 64px on desktop.

Added rule to MENTAL_MODEL.md.

https://claude.ai/code/session_011vWR2psegAVzzUqwWpor3o