### PR TITLE
fix: restore _objSelected when returning to Object mode via mobile toolbar

### DIFF
--- a/.claude/MENTAL_MODEL.md
+++ b/.claude/MENTAL_MODEL.md
@@ -55,6 +55,23 @@ Applies to: any function that adds objects, deletes the active object, or switch
 3. Reset controller state (`_hoveredFace`, `_faceDragging`, `_dragFace`, `_cleanupEditSubstate()`)
 4. Dispatch to new mode — `instanceof Sketch` → Edit 2D, otherwise → Edit 3D
 
+## _objSelected must be restored when returning to Object mode
+
+`_setObjectSelected(false)` is called on every Edit Mode entry. When `setMode('object')`
+is called to return from Edit Mode, `_objSelected` stays `false` unless explicitly restored.
+
+**Rule**: in the `mode === 'object'` branch of `setMode()`, if `_activeObj` exists and
+`_objSelected` is `false`, restore it to `true` and call `meshView.setObjectSelected(true)`.
+Without this, the mobile toolbar's Edit and Delete buttons stay disabled even though the
+object is still active.
+
+```js
+if (this._activeObj && !this._objSelected) {
+  this._objSelected = true
+  this._activeObj.meshView.setObjectSelected(true)
+}
+```
+
 ## Entity type contract (ADR-012, Phase 5-3)
 
 **Rule**: entity *type* (not a `dimension` field) determines which operations are available.

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -695,6 +695,12 @@ export class AppController {
     this._controls.enabled = true
 
     if (mode === 'object') {
+      // Restore selection state when returning from Edit Mode — the active
+      // object is still valid but _objSelected was cleared on Edit entry.
+      if (this._activeObj && !this._objSelected) {
+        this._objSelected = true
+        this._activeObj.meshView.setObjectSelected(true)
+      }
       this._refreshObjectModeStatus()
       this._uiView.updateMode('object')
       this._updateMobileToolbar()


### PR DESCRIPTION
When entering Edit Mode, _setObjectSelected(false) clears _objSelected.
On return to Object mode (e.g. via the floating "← Object" button),
_objSelected was never restored, so Edit and Delete buttons remained
disabled even though an active object existed.

Fix: in the mode === 'object' branch of setMode(), restore _objSelected
and the box-helper highlight if _activeObj is present.

Also document the invariant in MENTAL_MODEL.md.

https://claude.ai/code/session_01DeJVtZSZnU67HxoDSaJ7fF