### PR TITLE
mobile: Nodesボタン非表示、ステータスをキャンバスオーバーレイに移動、フェイスエクストルードツールバー簡略化

### DIFF
--- a/.claude/MENTAL_MODEL.md
+++ b/.claude/MENTAL_MODEL.md
@@ -212,7 +212,25 @@ the entire centered toolbar shifts left/right, making tapping unreliable.
 | Edit 2D      | ← Object · Extrude                                  |
 | Edit 3D      | ← Object · Vertex · Edge · Face · Extrude           |
 | Grab active  | ✓ Confirm · ✕ Cancel                               |
-| Face extrude | ✓ Confirm · ✕ Cancel                               |
+| Face extrude | (same as Edit 3D — no separate state)               |
+
+Face extrude on mobile is a gesture-only operation (tap → drag → release = confirm). No
+Confirm/Cancel toolbar state is shown because the user's finger is occupied with the drag.
+Extrude button stays in the toolbar but is `disabled` while `_faceExtrude.active` to
+prevent re-triggering.
+
+## Mobile status is shown as a canvas overlay pill, not in the header
+
+On desktop the status text lives in `_headerStatusEl` (centered in the header bar).
+On mobile the header is too narrow (hamburger + mode button + N-panel toggle already
+fill it), so `_headerStatusEl` is hidden and `_canvasStatusEl` (a semi-transparent pill
+floating at `top: 48px`, below the header) is shown instead.
+
+`setStatus()` and `setStatusRich()` always update both elements; CSS visibility controlled
+by `_applyMobileLayout()` determines which one is visible.
+
+The Nodes button (`_nodeEditorBtn`) is desktop-only and is hidden on mobile because
+NodeEditorView is not optimised for small screens and requires a BFF connection.
 
 ## Toast must be positioned above the mobile toolbar
 

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -459,16 +459,6 @@ export class AppController {
       return
     }
 
-    if (this._faceExtrude.active) {
-      // On mobile, lifting the finger auto-confirms (pointerup wasDragging guard).
-      // Confirm button is therefore redundant. Show an indicator + Cancel only.
-      this._uiView.setMobileToolbar([
-        { icon: ICONS.extrude, label: 'Extrude', indicator: true },
-        { icon: ICONS.cancel,  label: 'Cancel',  onClick: () => this._cancelFaceExtrude(), danger: true },
-      ])
-      return
-    }
-
     if (mode === 'object') {
       // Always show the same 4 buttons; Edit/Move/Delete are disabled when no
       // object is selected. Fixed count prevents layout shifts on selection.
@@ -525,7 +515,8 @@ export class AppController {
             const sel = [...this._scene.editSelection].filter(x => x instanceof Face)
             if (sel.length > 0) this._startFaceExtrude(sel[0])
           },
-          disabled: !hasFaceSel,
+          // Also disabled while an extrude is already in progress (mid-drag)
+          disabled: !hasFaceSel || this._faceExtrude.active,
         },
       ])
     }

--- a/src/view/UIView.js
+++ b/src/view/UIView.js
@@ -194,6 +194,34 @@ export class UIView {
       if (this._nodeEditorToggle) this._nodeEditorToggle()
     })
 
+    // ── Canvas status overlay (mobile only — floats below header on canvas) ─
+    this._canvasStatusEl = document.createElement('div')
+    Object.assign(this._canvasStatusEl.style, {
+      position: 'fixed',
+      top: '48px',
+      left: '0', right: '0',
+      display: 'none',
+      justifyContent: 'center',
+      pointerEvents: 'none',
+      zIndex: '90',
+    })
+    this._canvasStatusPillEl = document.createElement('div')
+    Object.assign(this._canvasStatusPillEl.style, {
+      background: 'rgba(20,20,20,0.75)',
+      borderRadius: '14px',
+      padding: '4px 14px',
+      display: 'flex',
+      alignItems: 'center',
+      gap: '2px',
+      fontSize: '12px',
+      fontFamily: 'system-ui, -apple-system, sans-serif',
+      overflow: 'hidden',
+      maxWidth: '90vw',
+      whiteSpace: 'nowrap',
+    })
+    this._canvasStatusEl.appendChild(this._canvasStatusPillEl)
+    document.body.appendChild(this._canvasStatusEl)
+
     // Close dropdown on outside click
     document.addEventListener('click', (e) => {
       if (!this._modeSelectorEl.contains(e.target)) {
@@ -513,11 +541,16 @@ export class UIView {
    */
   setStatus(text) {
     this._headerStatusEl.innerHTML = ''
+    this._canvasStatusPillEl.innerHTML = ''
     if (!text) return
-    const span = document.createElement('span')
-    span.textContent = text
-    Object.assign(span.style, { color: '#c8c8c8' })
-    this._headerStatusEl.appendChild(span)
+    const mkSpan = (parent) => {
+      const span = document.createElement('span')
+      span.textContent = text
+      Object.assign(span.style, { color: '#c8c8c8' })
+      parent.appendChild(span)
+    }
+    mkSpan(this._headerStatusEl)
+    mkSpan(this._canvasStatusPillEl)
   }
 
   /**
@@ -527,23 +560,27 @@ export class UIView {
    * @param {{ text: string, color?: string, bold?: boolean }[]} parts
    */
   setStatusRich(parts) {
-    this._headerStatusEl.innerHTML = ''
-    parts.forEach((part, i) => {
-      if (i > 0) {
-        const sep = document.createElement('span')
-        sep.textContent = '·'
-        Object.assign(sep.style, { color: '#4a4a4a', margin: '0 4px' })
-        this._headerStatusEl.appendChild(sep)
-      }
-      const span = document.createElement('span')
-      span.textContent = part.text
-      Object.assign(span.style, {
-        color: part.color ?? '#c8c8c8',
-        fontWeight: part.bold ? 'bold' : 'normal',
-        letterSpacing: part.bold ? '0.02em' : 'normal',
+    const fill = (parent) => {
+      parent.innerHTML = ''
+      parts.forEach((part, i) => {
+        if (i > 0) {
+          const sep = document.createElement('span')
+          sep.textContent = '·'
+          Object.assign(sep.style, { color: '#4a4a4a', margin: '0 4px' })
+          parent.appendChild(sep)
+        }
+        const span = document.createElement('span')
+        span.textContent = part.text
+        Object.assign(span.style, {
+          color: part.color ?? '#c8c8c8',
+          fontWeight: part.bold ? 'bold' : 'normal',
+          letterSpacing: part.bold ? '0.02em' : 'normal',
+        })
+        parent.appendChild(span)
       })
-      this._headerStatusEl.appendChild(span)
-    })
+    }
+    fill(this._headerStatusEl)
+    fill(this._canvasStatusPillEl)
   }
 
   /**
@@ -635,6 +672,11 @@ export class UIView {
     this._hamburgerBtn.style.display = mobile ? 'block' : 'none'
     this._nToggleBtn.style.display   = mobile ? 'block' : 'none'
     this._mobileToolbarEl.style.display = mobile ? 'flex' : 'none'
+    // Nodes button is desktop-only (NodeEditorView is not mobile-optimised)
+    this._nodeEditorBtn.style.display = mobile ? 'none' : 'flex'
+    // On mobile, status moves to the canvas overlay pill; hide it from header
+    this._headerStatusEl.style.display = mobile ? 'none' : 'flex'
+    this._canvasStatusEl.style.display = mobile ? 'flex' : 'none'
     if (mobile) {
       Object.assign(this._nPanelEl.style, {
         display:    'block',


### PR DESCRIPTION
- Hide Nodes button on mobile (NodeEditorView is desktop-only, BFF-dependent)
- Add canvas overlay status pill (top: 48px, semi-transparent) for mobile;
  header status hidden on mobile since hamburger+mode+N-toggle already fill the bar
- Remove face-extrude special toolbar state; gesture (tap→drag→release) is the
  complete operation so Confirm/Cancel buttons were unreachable and misleading.
  Edit 3D toolbar stays visible with Extrude disabled while _faceExtrude.active.
- Update MENTAL_MODEL with new rules for canvas overlay status and face extrude toolbar

https://claude.ai/code/session_019FjipYzsSFEDKmamGDvoF3