### PR TITLE
improve mobile UI: footer status, remove Edit 3D Extrude button, right-align N-panel icon

### DIFF
--- a/.claude/MENTAL_MODEL.md
+++ b/.claude/MENTAL_MODEL.md
@@ -109,7 +109,7 @@ this._handleEditClick(e.shiftKey)
 ### Gesture-Based Interaction Priority (Mobile)
 
 - **Principle**: Mobile interactions should prioritize combined gesture flows (tap + drag) over multi-step button clicks for primary spatial actions.
-- **Concrete Rule**: On mobile (`innerWidth < 768`), tapping a face in Edit 3D auto-starts extrude. In `_onPointerDown`, after `_handleEditClick`, call `_startFaceExtrude(face)` and set `_activeDragPointerId`. The auto-start fires only when: `editSubstate === '3d'`, `_editSelectMode === 'face'`, `!e.shiftKey`, and at least one Face is in `editSelection` after the click. The Extrude toolbar button is kept (`disabled: true` during the drag) to maintain fixed button count.
+- **Concrete Rule**: On mobile (`innerWidth < 768`), tapping a face in Edit 3D auto-starts extrude. In `_onPointerDown`, after `_handleEditClick`, call `_startFaceExtrude(face)` and set `_activeDragPointerId`. The auto-start fires only when: `editSubstate === '3d'`, `_editSelectMode === 'face'`, `!e.shiftKey`, and at least one Face is in `editSelection` after the click. Face extrude is a gesture-only operation — there is no Extrude toolbar button in Edit 3D.
 
 ### Interaction Confirmation Lifecycle
 
@@ -149,11 +149,10 @@ if (e.target !== this._sceneView.renderer.domElement) return
 |------|------------------------|
 | Object | Add · Edit · Delete |
 | Edit 2D | ← Object · Extrude |
-| Edit 3D | ← Object · Vertex · Edge · Face · Extrude |
+| Edit 3D | ← Object · Vertex · Edge · Face |
 | Grab active | ✓ Confirm · ✕ Cancel |
-| Face extrude | (same as Edit 3D — no separate state) |
 
-Face extrude on mobile is a gesture-only operation (tap → drag → release = confirm). The Extrude button stays visible but `disabled` while `_faceExtrude.active` to prevent re-triggering.
+Face extrude on mobile is a gesture-only operation (tap → drag → release = confirm). No Extrude button is shown in Edit 3D.
 
 ### Viewport-Aware Z-Index and Positioning
 
@@ -164,7 +163,7 @@ Face extrude on mobile is a gesture-only operation (tap → drag → release = c
 const bottomPx = this._isMobile() ? '96px' : '64px'
 ```
 
-On mobile, status text uses `_canvasStatusEl` (a semi-transparent pill at `top: 48px`) instead of `_headerStatusEl`, because the mobile header is too narrow. `setStatus()` and `setStatusRich()` always update both elements; `_applyMobileLayout()` controls which is visible via CSS. The Nodes button (`_nodeEditorBtn`) is desktop-only and hidden on mobile.
+On mobile, status text is shown in the footer info bar (`_infoEl`) instead of the header or canvas pill, because the mobile header is too narrow and keyboard hints are irrelevant on touch. `setStatus()` and `setStatusRich()` update `_infoEl` on mobile; `_setInfoText()` is a no-op on mobile. The `_canvasStatusEl` pill is always hidden (the footer replaces it on mobile; the header status replaces it on desktop). The Nodes button (`_nodeEditorBtn`) is desktop-only and hidden on mobile. The N-panel toggle button (`_nToggleBtn`) uses `marginLeft: auto` on mobile to stay right-aligned in the header.
 
 ---
 

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -500,24 +500,12 @@ export class AppController {
     }
 
     if (substate === '3d') {
-      // Always show all 5 buttons; Extrude is disabled until a face is selected.
-      // Fixed count prevents layout shifts when a face is selected.
-      const em         = this._editSelectMode
-      const hasFaceSel = em === 'face' && [...this._scene.editSelection].some(x => x instanceof Face)
+      const em = this._editSelectMode
       this._uiView.setMobileToolbar([
-        { icon: ICONS.back,    label: 'Object', onClick: () => this.setMode('object') },
-        { icon: ICONS.vertex,  label: 'Vertex', onClick: () => this._setEditSelectMode('vertex'), active: em === 'vertex' },
-        { icon: ICONS.edge,    label: 'Edge',   onClick: () => this._setEditSelectMode('edge'),   active: em === 'edge' },
-        { icon: ICONS.face,    label: 'Face',   onClick: () => this._setEditSelectMode('face'),   active: em === 'face' },
-        {
-          icon: ICONS.extrude, label: 'Extrude',
-          onClick: () => {
-            const sel = [...this._scene.editSelection].filter(x => x instanceof Face)
-            if (sel.length > 0) this._startFaceExtrude(sel[0])
-          },
-          // Also disabled while an extrude is already in progress (mid-drag)
-          disabled: !hasFaceSel || this._faceExtrude.active,
-        },
+        { icon: ICONS.back,   label: 'Object', onClick: () => this.setMode('object') },
+        { icon: ICONS.vertex, label: 'Vertex', onClick: () => this._setEditSelectMode('vertex'), active: em === 'vertex' },
+        { icon: ICONS.edge,   label: 'Edge',   onClick: () => this._setEditSelectMode('edge'),   active: em === 'edge' },
+        { icon: ICONS.face,   label: 'Face',   onClick: () => this._setEditSelectMode('face'),   active: em === 'face' },
       ])
     }
   }

--- a/src/view/UIView.js
+++ b/src/view/UIView.js
@@ -383,6 +383,8 @@ export class UIView {
 
   _setInfoText(mode, subtype = null) {
     this._infoEl.innerHTML = ''
+    // On mobile the footer shows live status text instead of keyboard hints.
+    if (this._isMobile()) return
 
     let shortcuts
     if (mode === 'object') {
@@ -542,6 +544,7 @@ export class UIView {
   setStatus(text) {
     this._headerStatusEl.innerHTML = ''
     this._canvasStatusPillEl.innerHTML = ''
+    if (this._isMobile()) this._infoEl.innerHTML = ''
     if (!text) return
     const mkSpan = (parent) => {
       const span = document.createElement('span')
@@ -551,6 +554,7 @@ export class UIView {
     }
     mkSpan(this._headerStatusEl)
     mkSpan(this._canvasStatusPillEl)
+    if (this._isMobile()) mkSpan(this._infoEl)
   }
 
   /**
@@ -581,6 +585,7 @@ export class UIView {
     }
     fill(this._headerStatusEl)
     fill(this._canvasStatusPillEl)
+    if (this._isMobile()) fill(this._infoEl)
   }
 
   /**
@@ -671,12 +676,15 @@ export class UIView {
     const mobile = this._isMobile()
     this._hamburgerBtn.style.display = mobile ? 'block' : 'none'
     this._nToggleBtn.style.display   = mobile ? 'block' : 'none'
+    this._nToggleBtn.style.marginLeft = mobile ? 'auto' : ''
     this._mobileToolbarEl.style.display = mobile ? 'flex' : 'none'
     // Nodes button is desktop-only (NodeEditorView is not mobile-optimised)
     this._nodeEditorBtn.style.display = mobile ? 'none' : 'flex'
-    // On mobile, status moves to the canvas overlay pill; hide it from header
+    // On mobile, status moves to the footer info bar; hide the header status and canvas pill
     this._headerStatusEl.style.display = mobile ? 'none' : 'flex'
-    this._canvasStatusEl.style.display = mobile ? 'flex' : 'none'
+    this._canvasStatusEl.style.display = 'none'
+    // Center the footer status text on mobile
+    this._infoEl.style.justifyContent = mobile ? 'center' : 'flex-start'
     if (mobile) {
       Object.assign(this._nPanelEl.style, {
         display:    'block',


### PR DESCRIPTION
- Footer (info bar) now shows live status text on mobile instead of keyboard shortcuts; _setInfoText() is a no-op on mobile
- setStatus/setStatusRich also write to _infoEl on mobile; _canvasStatusEl pill is always hidden
- Edit 3D toolbar: removed the permanently-disabled Extrude button; face extrude remains gesture-only (tap → drag → release)
- N-panel toggle button uses marginLeft: auto on mobile to stay right-aligned in the header

https://claude.ai/code/session_01LZRMd8HLVLcF6kKbMk2vhk