### PR TITLE
feat: add /sqa, /qc, /adr-validate, /ux validator slash commands

### DIFF
--- a/.claude/commands/adr-validate.md
+++ b/.claude/commands/adr-validate.md
@@ -1,0 +1,109 @@
+# ADR Validator — Architecture Decision Record Compliance
+
+Validate that recently changed code (or the files in `$ARGUMENTS`) complies with the project's accepted ADRs.
+
+## Steps
+
+### 1. Identify target files
+
+- If `$ARGUMENTS` is provided, review those files.
+- Otherwise, run `git diff --name-only HEAD~1 HEAD` (fallback: `git status --short`) and collect modified `.js` files under `src/` and `server/src/`.
+
+### 2. Load the ADR index
+
+Read `docs/adr/README.md` and note all **Accepted** ADRs.
+Skip ADRs with status `Rejected` or `Superseded`.
+
+### 3. Select relevant ADRs
+
+For each target file, match it against the table below to determine which ADRs govern it.
+Only load the full text of relevant ADRs (to avoid unnecessary reads).
+
+| File pattern | Relevant ADRs |
+|---|---|
+| `src/controller/AppController.js` | ADR-008, ADR-006, ADR-003 |
+| `src/domain/Cuboid.js`, `src/domain/Sketch.js` | ADR-009, ADR-010, ADR-012 |
+| `src/graph/Vertex.js`, `Edge.js`, `Face.js` | ADR-012 |
+| `src/model/SceneModel.js` | ADR-005, ADR-008, ADR-014 |
+| `src/service/SceneService.js` | ADR-011, ADR-013, ADR-015 |
+| `src/view/MeshView.js` | ADR-008 (visual state ownership) |
+| `src/view/UIView.js` | ADR-002, ADR-004 |
+| `server/` | ADR-015, ADR-016, ADR-017 |
+| Any new modeling/geometry code | ADR-007 (cuboid representation, not voxel) |
+| Any mode/state transition code | ADR-008 |
+| Any orbit/mouse control change | ADR-006 (right-click = cancel) |
+
+Read each relevant ADR file from `docs/adr/`.
+
+### 4. Check compliance per ADR
+
+For each relevant ADR, verify the changed code follows its **Decision** and **Consequences** sections.
+
+Key contracts to enforce:
+
+**ADR-007** — Shape Representation is Cuboid-based (not voxel).
+- No integer-snap grid, no voxel coordinates. Shapes are axis-aligned cuboids with float corners.
+
+**ADR-008** — Mode Transition State Machine.
+- All mode changes via `AppController.setMode()`. No direct `_selectionMode` mutation outside `setMode`.
+- `setMode('object')` called before any active-object swap when in edit mode.
+
+**ADR-009 / ADR-010** — Entity types and behaviour.
+- `Sketch` and `Cuboid` are the only entity classes. No plain objects used as scene entities.
+- Behaviour methods (`move`, `extrudeFace`, `extrude`, `rename`) live on entities — not in the controller.
+
+**ADR-011** — ApplicationService layer.
+- `SceneService` is the sole entry point for entity lifecycle operations.
+- Controllers must not call `SceneModel` directly for entity creation / deletion.
+
+**ADR-012** — Graph-based geometry (`Vertex`, `Edge`, `Face`).
+- `Cuboid` has `vertices: Vertex[]`, `edges: Edge[12]`, `faces: Face[6]`.
+- `get corners()` on `Cuboid` / `Sketch` provides backward-compat access.
+- `extrudeFace` takes a `Face` object, not a numeric index.
+
+**ADR-013** — Domain Events / Observable.
+- `SceneService` emits events for all state changes. Views must not be updated by direct controller calls after a domain event is defined.
+
+**ADR-014** — Edit Mode Sub-Element Selection.
+- `SceneModel.editSelection` is a `Set<Vertex|Edge|Face>`.
+- Edit select mode is one of `'vertex'`, `'edge'`, `'face'`.
+
+**ADR-015** — BFF Architecture.
+- Frontend (`src/`) contains only View + Controller + domain model.
+- Geometry computation and STEP import live in `server/`.
+- Communication via REST (`/api`) and WebSocket (`/api/ws`).
+
+**ADR-016** — Transform Graph.
+- Spatial relationships between objects are stored as SE(3) transforms (position + quaternion).
+- No Euler angles in the graph layer.
+
+**ADR-017** — WebSocket Session Design.
+- WebSocket path: `/api/ws`. One session per connection. `SessionManager` handles lifecycle.
+
+### 5. Report findings
+
+For each violation:
+
+```
+[ADR-NNN] File:line — Description of the violation
+  ADR rule: <quoted snippet from the ADR decision>
+  Suggested fix: <one-line suggestion>
+```
+
+If no violations are found, output: `✓ ADR-validate: all checked ADRs satisfied in <file list>`.
+
+### 6. Flag gaps (optional but encouraged)
+
+If the diff introduces a non-obvious design choice that is **not** covered by any existing ADR, output:
+
+```
+[GAP] File:line — <describe the uncovered decision>
+  Suggestion: consider creating ADR-NNN for this.
+```
+
+### 7. Summary
+
+```
+ADR-validate result: N violations, G gaps across X files.
+ADRs checked: ADR-NNN, ADR-NNN, ...
+```

--- a/.claude/commands/qc.md
+++ b/.claude/commands/qc.md
@@ -1,0 +1,94 @@
+# QC Validator — Code Quality & Standards Compliance
+
+Perform a QC review on the files specified in `$ARGUMENTS`, or on all recently changed source files if no argument is given.
+
+## Steps
+
+### 1. Identify target files
+
+- If `$ARGUMENTS` is provided, review those files.
+- Otherwise, run `git diff --name-only HEAD~1 HEAD` (fallback: `git status --short`) and review modified `.js` files under `src/` and `server/src/`.
+
+### 2. Read reference documents
+
+Read these before evaluating:
+- `docs/ARCHITECTURE.md` — layer responsibilities and ownership contracts
+- `.claude/MENTAL_MODEL.md` — accumulated rules from real bugs
+
+### 3. Read each target file in full
+
+### 4. Evaluate against the QC checklist
+
+#### A. Layer Responsibility (ARCHITECTURE.md §Layer Responsibilities)
+
+- [ ] `CuboidModel.js` contains **only pure functions** — no `this`, no side effects, no Three.js imports.
+- [ ] `SceneModel.js` holds state only — no DOM access, no Three.js scene manipulation.
+- [ ] `SceneService.js` is the sole entry point for entity creation, CRUD, and `extrudeSketch`. Controllers do not create entities directly.
+- [ ] View classes (`MeshView`, `UIView`, `SceneView`, etc.) do not mutate domain state directly.
+- [ ] `AppController` handles input and view coordination only — no domain logic.
+
+#### B. Import Conventions
+
+- [ ] Three.js addons imported from `three/addons/...` (not `three/examples/...`).
+- [ ] No circular imports between `domain/`, `model/`, `service/`, `view/`, `controller/`.
+- [ ] `server/` code does not import from `src/` (browser-side code).
+
+#### C. Naming Conventions
+
+- [ ] Files: `PascalCase.js` for classes, `camelCase.js` for utilities.
+- [ ] Private class members prefixed with `_`.
+- [ ] Event names: `camelCase` strings (`objectAdded`, `objectRenamed`, etc.).
+- [ ] ADR files: `ADR-NNN-kebab-case-title.md`.
+
+#### D. DDD / Entity Contracts (MENTAL_MODEL §1, ADR-009–012)
+
+- [ ] Type dispatch uses `instanceof Sketch` / `instanceof Cuboid` — not a `dimension` property.
+- [ ] `Sketch.extrude()` returns a new `Cuboid` and does not mutate `Sketch` itself.
+- [ ] `SceneService.extrudeSketch()` is used for the entity swap (not direct `_objects` mutation).
+- [ ] `Cuboid` always exposes: `faces: Face[6]`, `edges: Edge[12]`, `move()`, `extrudeFace()`.
+
+#### E. Event / Observable Contracts (ADR-013)
+
+- [ ] `SceneService` emits domain events (`objectAdded`, `objectRemoved`, `objectRenamed`, `activeChanged`) for every state change that views need to react to.
+- [ ] Views subscribe via `SceneService.on(event, handler)` — not via direct polling or controller callbacks.
+
+#### F. Visual State Ownership (MENTAL_MODEL §1)
+
+- [ ] `hlMesh.visible` set only inside `setFaceHighlight()`.
+- [ ] `cuboid.visible` / `wireframe.visible` set only inside `setVisible()`.
+- [ ] `boxHelper.visible` set only inside `setObjectSelected()`.
+
+#### G. Mode Transition Contract (ADR-008, MENTAL_MODEL §1)
+
+- [ ] All mode changes go through `AppController.setMode(mode)`.
+- [ ] When switching active objects from Edit Mode, `setMode('object')` is called first.
+
+#### H. Vite / Build Config
+
+- [ ] `vite.config.js` `base` is `/easy-extrude/` — not changed to `/` or any other path.
+
+#### I. Documentation
+
+- [ ] New non-obvious design decisions have an ADR or reference an existing one.
+- [ ] `docs/adr/README.md` index is updated when a new ADR file is added.
+- [ ] `CLAUDE.md` navigation table references new docs if added.
+
+### 5. Report findings
+
+For each issue:
+
+```
+[CATEGORY] File:line — Description
+  Rule violated: <checklist item letter>
+  Suggested fix: <one-line suggestion>
+```
+
+Categories: **LAYER** · **IMPORT** · **NAMING** · **DDD** · **EVENT** · **VISUAL** · **MODE** · **BUILD** · **DOCS**
+
+If no issues are found, output: `✓ QC: no issues found in <file list>`.
+
+### 6. Summary
+
+```
+QC result: N issues across X files. Categories: <list of categories with counts>.
+```

--- a/.claude/commands/sqa.md
+++ b/.claude/commands/sqa.md
@@ -1,0 +1,74 @@
+# SQA Validator — Software Quality Assurance
+
+Perform a focused SQA review on the files specified in `$ARGUMENTS`, or on all recently changed source files if no argument is given.
+
+## Steps
+
+### 1. Identify target files
+
+- If `$ARGUMENTS` is provided, review those files.
+- Otherwise, run `git diff --name-only HEAD~1 HEAD` (fallback: `git status --short`) and review all modified `.js` files under `src/` and `server/src/`.
+
+### 2. Read each target file in full
+
+Use the Read tool on every identified file.
+
+### 3. Evaluate each file against the following SQA checklist
+
+#### A. Memory Management (Three.js) — MENTAL_MODEL §4
+
+- [ ] Every `scene.add()` in a constructor has a matching `scene.remove()` + `.dispose()` in `dispose()`.
+- [ ] Every `new THREE.BufferGeometry()` / `new THREE.Material()` has `.dispose()` in `dispose()`.
+- [ ] No dangling mesh references after `deleteObject()`.
+
+#### B. Input / Boundary Validation
+
+- [ ] User inputs (pointer coordinates, keyboard values, WebSocket messages, REST request bodies) are validated at the system boundary before being passed inward.
+- [ ] Numeric inputs from UI (type-in distances, extrude heights) have NaN / bounds checks.
+- [ ] No `eval()`, `innerHTML` with unsanitised strings, or similar XSS vectors.
+
+#### C. Error Handling
+
+- [ ] `fetch` / `WebSocket` calls handle network failures (`.catch()` or `try/catch`).
+- [ ] Errors that reach the user surface a toast or status message — they are never silently swallowed.
+- [ ] No unguarded `.` access on values that can be `null` or `undefined` at runtime.
+
+#### D. State Consistency
+
+- [ ] Event listeners added in constructors or `start()` are removed in `dispose()` / `stop()`.
+- [ ] No shared mutable state mutated from multiple unrelated paths without synchronization.
+- [ ] Pointer-event lifecycle: `pointerdown` → `pointermove` → `pointerup` always paired; no leaked `_activeDragPointerId`.
+
+#### E. Security (OWASP-relevant)
+
+- [ ] No command injection in server-side shell calls.
+- [ ] No SQL injection (use parameterised queries / prepared statements for SQLite).
+- [ ] No path traversal in file-serving endpoints.
+- [ ] CORS / Content-Security-Policy headers present on BFF responses.
+
+#### F. Code Correctness
+
+- [ ] No off-by-one errors in index loops over `faces[6]` or `edges[12]`.
+- [ ] Geometry functions in `CuboidModel.js` are pure (no side effects, no `this`).
+- [ ] `instanceof` type guards match MENTAL_MODEL §1 contracts (`instanceof Sketch` = 2D, `instanceof Cuboid` = 3D).
+
+### 4. Report findings
+
+For each issue found:
+
+```
+[SEVERITY] File:line — Description
+  Rule violated: <checklist item letter>
+  Suggested fix: <one-line suggestion>
+```
+
+Severity levels: **CRITICAL** (data loss / security) · **HIGH** (crash / memory leak) · **MEDIUM** (silent wrong behaviour) · **LOW** (style / robustness).
+
+If no issues are found, output: `✓ SQA: no issues found in <file list>`.
+
+### 5. Summary
+
+Output a one-line summary:
+```
+SQA result: N issues (C critical, H high, M medium, L low) across X files.
+```

--- a/.claude/commands/ux.md
+++ b/.claude/commands/ux.md
@@ -1,0 +1,96 @@
+# UX Validator — User Experience & UI Consistency
+
+Perform a UX review on the files specified in `$ARGUMENTS`, or on all recently changed View / Controller files if no argument is given.
+
+## Steps
+
+### 1. Identify target files
+
+- If `$ARGUMENTS` is provided, review those files.
+- Otherwise, run `git diff --name-only HEAD~1 HEAD` and filter for `src/view/`, `src/controller/`, and any `.css` / `.html` files.
+
+### 2. Read reference documents
+
+Read these before evaluating:
+- `.claude/MENTAL_MODEL.md` §2 (Touch/Pointer events), §3 (UI & Layout)
+- `docs/ROADMAP.md` — Mobile Support section
+
+### 3. Read each target file in full
+
+### 4. Evaluate against the UX checklist
+
+#### A. Mobile Toolbar Stability (MENTAL_MODEL §3)
+
+- [ ] Every mode shows a **fixed set of buttons** — no hiding buttons that should be `disabled`.
+  - Object mode: Add · Edit · Delete
+  - Edit 2D: ← Object · Extrude
+  - Edit 3D: ← Object · Vertex · Edge · Face
+  - Grab active: ✓ Confirm · ✕ Cancel
+- [ ] Buttons that are temporarily unavailable use `disabled: true`, not conditional rendering.
+- [ ] No layout shifts between mode transitions that would cause misclicks.
+
+#### B. Touch Event Handling (MENTAL_MODEL §2)
+
+- [ ] `_onPointerDown` re-runs hit tests (e.g. `_hitFace()`) for touch devices before dispatching clicks — not relying on a prior `pointermove` for hover state.
+- [ ] Face extrude on mobile is **gesture-only**: tap → drag → release (no Extrude button in Edit 3D).
+- [ ] `_confirmFaceExtrude()` is called in `_onPointerUp`, not `_onPointerDown`.
+- [ ] `_onPointerDown` returns early for events not originating from the canvas (`e.target !== renderer.domElement`).
+
+#### C. Multi-touch / Orbit Coexistence (MENTAL_MODEL §2)
+
+- [ ] Rect selection does not disable OrbitControls (`_controls.enabled` not set to `false` for rect sel).
+- [ ] Second touch during rect selection cancels rect sel and lets OrbitControls take the two-finger gesture.
+- [ ] Only `_objDragging` and `_sketch.drawing` legitimately set `_controls.enabled = false`.
+
+#### D. Toast & Status Positioning (MENTAL_MODEL §3)
+
+- [ ] `showToast()` uses `bottom: 96px` on mobile, `bottom: 64px` on desktop.
+- [ ] Status text on mobile updates `_infoEl` (footer bar), not the canvas pill or header.
+- [ ] `_canvasStatusEl` pill is always hidden.
+- [ ] Nodes button (`_nodeEditorBtn`) is hidden on mobile.
+- [ ] N-panel toggle (`_nToggleBtn`) uses `marginLeft: auto` on mobile for right-aligned placement.
+
+#### E. Grab / Numeric Input UX
+
+- [ ] Numeric input (e.g. typing a distance during Grab) is clearly shown in the status bar.
+- [ ] `Escape` / right-click always cancels an in-progress operation with visible feedback.
+- [ ] Confirm (`Enter`) finalises the operation and returns to the previous mode.
+
+#### F. Accessibility Basics
+
+- [ ] Interactive DOM elements (`button`, `input`) have discernible labels (text content or `aria-label`).
+- [ ] Focus is not lost unexpectedly when switching modes.
+- [ ] Colour alone is not the only indicator of state (e.g. selected vs unselected should also differ in shape or label).
+
+#### G. Keyboard Shortcuts (Desktop)
+
+- [ ] Shift+A opens the Add menu.
+- [ ] G starts Grab; X/Y/Z constrain axis; Enter confirms; Escape / right-click cancels.
+- [ ] Tab cycles edit sub-modes in Edit 3D (Vertex / Edge / Face).
+- [ ] Shortcuts are surfaced in the status bar while the relevant operation is active.
+
+#### H. Visual Feedback Consistency
+
+- [ ] Hovered faces highlight immediately on `pointermove` (desktop).
+- [ ] Selected sub-elements (vertices, edges, faces) have a distinct colour from hovered ones.
+- [ ] `setObjectSelected(true)` is restored when returning to Object mode from Edit mode (MENTAL_MODEL §1 — State Restoration on Mode Exit).
+
+### 5. Report findings
+
+For each issue:
+
+```
+[CATEGORY] File:line — Description
+  Rule violated: <checklist item letter>
+  Suggested fix: <one-line suggestion>
+```
+
+Categories: **TOOLBAR** · **TOUCH** · **ORBIT** · **STATUS** · **GRAB** · **A11Y** · **KEYBOARD** · **VISUAL**
+
+If no issues are found, output: `✓ UX: no issues found in <file list>`.
+
+### 6. Summary
+
+```
+UX result: N issues across X files. Categories: <list with counts>.
+```


### PR DESCRIPTION
Four Claude Code slash commands for systematic review of changes:
- /sqa — memory management, input validation, error handling, security (OWASP)
- /qc  — layer responsibilities, imports, naming, DDD/entity contracts, visual state ownership
- /adr-validate — checks changed code against all Accepted ADRs (ADR-007–017), flags uncovered design gaps
- /ux  — mobile toolbar stability, touch event lifecycle, toast/status positioning, a11y basics

Each validator auto-targets git-changed files when no argument is given,
and produces a structured report with severity/category tags and a one-line summary.

https://claude.ai/code/session_01WR87GVV8XT92pXUCcqt2uP