### PR TITLE
feat: MeasureLine snap measure tool with V/E/F snapping

### DIFF
--- a/.claude/MENTAL_MODEL.md
+++ b/.claude/MENTAL_MODEL.md
@@ -73,6 +73,12 @@ if (this._activeObj && !this._objSelected) {
   - `extrudeFace` signature: `(face: Face, savedFaceCorners, normal, dist)` — callers pass a `Face` object (`_dragFace`), not an index. `Face.index` is used where an index is still needed (e.g. `MeshView.setFaceHighlight`).
   - `Cuboid` must always have: `move()`, `extrudeFace(face, ...)`, `faces: Face[6]`, `edges: Edge[12]`.
   - `Sketch` only needs: `extrude(height)`, `rename(name)`, `sketchRect`.
+  - `MeasureLine` holds two `THREE.Vector3` endpoints (`p1`, `p2`) and a `MeasureLineView`. It has no `vertices`/`edges`/`faces` graph and must be excluded from `collectSnapTargets` loops and `_hitAnyObject` raycasting (guard with `instanceof MeasureLine`). Edit Mode and Grab are blocked for MeasureLine.
+
+### MeasureLineView Label Lifecycle
+
+- **Principle**: HTML labels that overlay a Three.js canvas must be repositioned every animation frame because the camera may have moved.
+- **Concrete Rule**: `MeasureLineView.updateLabelPosition()` must be called once per frame from the animation loop for every `MeasureLine` in the scene. The label uses `position: fixed` and is projected from world-space midpoint via `Vector3.project(camera)`. It is appended to `document.body` and removed in `dispose()`.
 
 ### Visual State Ownership
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ Three.js `camera.up = (0,0,1)`. XY plane (Z=0) is the ground plane.
 
 Full log → `docs/SESSION_LOG.md`
 
+- **2026-03-22**: MeasureLine snap measure tool — `MeasureLine` domain entity, `MeasureLineView` (dashed amber line + HTML distance label), `SceneService.createMeasureLine()`, measure placement mode in `AppController` (M key + Shift+A → Measure; V/E/F snap; click p1 → click p2 → confirm); Outliner ↔ amber icon; animation-loop label refresh. MENTAL_MODEL updated.
 - **2026-03-22**: Mobile toolbar button count unification (#17) — `{ spacer: true }` in `UIView.setMobileToolbar`; all modes padded to 4 slots in `AppController._updateMobileToolbar` (Object: 3+1 spacer; Edit 2D/Grab: 2+2 spacers; Edit 3D: unchanged). Eliminates layout-shift mis-taps on mode transition. MENTAL_MODEL updated with 4-slot table.
 - **2026-03-22**: Validation improvement plan (Priority 7) — `isNaN` guards for `parseFloat` in AppController; STEP face validation in `import.js`/`sessionManager.js`; `SceneService` emits `'geometryError'`; `ImportedMeshView` guards `positions.length % 3`. Item #17 (mobile toolbar count) deferred.
 - **2026-03-22**: Validation review & improvement plan — executed Phases A–F (24 items). CRITICAL async fixes in `sessionManager.js`; JSON.parse guards; WsChannel cleanup; layer fix (`_deserializeEntities`); ADR-008/009/013 gaps; UX toasts + A11Y ARIA labels. Plan: `docs/validation/2026-03-22-improvement-plan.md`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -98,11 +98,11 @@ Candidate tasks:
 
 | Priority | Item | Complexity | ADR / Notes |
 |----------|------|-----------|-------------|
+| 🔴 High | MeasureLine Edit Mode · 1D — endpoint drag to reposition after placement | Medium | ADR-005 |
 | 🟡 Medium | Object hierarchy + Outliner tree view | Medium | ADR-005 |
 | 🟡 Medium | Right-click context menu (currently: cancel only) | Low | ADR-006 |
 | 🟡 Medium | Multi-face extrude (Shift+click) | Medium | — |
 | 🟡 Medium | Export (OBJ / GLTF) | Low | Phase C via Geometry Service |
-| 🟢 Low | 1D objects: MeasureLine, reference line | Medium | ADR-005 |
 | 🟢 Low | Assembly groups (virtual TransformNode pivot) | Medium | ADR-016 |
 | 🟢 Low | Revolute / prismatic constraints in Node Editor | High | ADR-016 |
 
@@ -112,6 +112,7 @@ Candidate tasks:
 
 | Item | Date |
 |------|------|
+| MeasureLine — 1D measure tool: M key / Shift+A → Measure; V/E/F snap during placement; amber dashed line + HTML distance label; Outliner ↔ icon | 2026-03-22 |
 | BFF Phase C — ImportedMesh thin-client entity, ImportedMeshView, SceneService.createImportedMesh(), _applyGeometryUpdate() routing, OutlinerView type icon, AppController guards | 2026-03-22 |
 | BFF Phase B — Geometry Service (DAG evaluator), WebSocket session (ADR-017), Node Editor UI prototype, STEP import (REST + WS), BffClient WsChannel | 2026-03-21 |
 | BFF Phase A — Express BFF scaffold, SQLite scene persistence, TransformGraph storage (ADR-016), BffClient, SceneSerializer, Vite proxy, pnpm workspace | 2026-03-21 |

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -24,6 +24,7 @@ import {
 import { SceneService }    from '../service/SceneService.js'
 import { Sketch }          from '../domain/Sketch.js'
 import { ImportedMesh }    from '../domain/ImportedMesh.js'
+import { MeasureLine }     from '../domain/MeasureLine.js'
 import { Face }            from '../graph/Face.js'
 import { ICONS }           from '../view/UIView.js'
 import { NodeEditorView }  from '../view/NodeEditorView.js'
@@ -46,7 +47,13 @@ export class AppController {
 
     // ── Domain event subscriptions — keep View in sync with domain state ──
     this._service.on('objectAdded',   obj       => {
-      const type = obj instanceof ImportedMesh ? 'imported' : obj instanceof Sketch ? 'sketch' : 'cuboid'
+      const type = obj instanceof ImportedMesh
+        ? 'imported'
+        : obj instanceof MeasureLine
+          ? 'measure'
+          : obj instanceof Sketch
+            ? 'sketch'
+            : 'cuboid'
       outlinerView?.addObject(obj.id, obj.name, type)
     })
     this._service.on('objectRemoved', id        => outlinerView?.removeObject(id))
@@ -60,6 +67,25 @@ export class AppController {
     this._service.on('geometryError', ({ message }) =>
       this._uiView.showToast(`Geometry error: ${message}`)
     )
+
+    // ── Measure placement state ────────────────────────────────────────────
+    // Active while the user is placing a MeasureLine (M key / Add → Measure).
+    // Phase 1: waiting for first click (p1 = null)
+    // Phase 2: p1 set, waiting for second click (preview line shown)
+    this._measure = {
+      active:       false,
+      /** @type {THREE.Vector3|null} fixed first endpoint */
+      p1:           null,
+      /** @type {THREE.Vector3|null} live cursor position (snapped) */
+      p2:           null,
+      /** @type {{label:string, position:THREE.Vector3, type:string}[]} */
+      snapTargets:  [],
+      snapping:     false,
+      /** @type {{label:string, position:THREE.Vector3, type:string}|null} */
+      snappedTarget: null,
+      /** Three.js Line for preview before entity is created */
+      previewLine:  null,
+    }
 
     // ── Sketch drawing state (Edit Mode · 2D) ──────────────────────────────
     this._sketch = {
@@ -255,10 +281,11 @@ export class AppController {
 
   /**
    * Adds a new object of the given type.
-   * @param {'box'|'sketch'} [type='box']
+   * @param {'box'|'sketch'|'measure'} [type='box']
    */
   _addObject(type = 'box') {
-    if (type === 'sketch') { this._addSketchObject(); return }
+    if (type === 'sketch')  { this._addSketchObject();    return }
+    if (type === 'measure') { this._startMeasurePlacement(); return }
 
     // Exit Edit Mode cleanly before adding, so the previous object's visual state is cleared
     if (this._scene.selectionMode === 'edit') this.setMode('object')
@@ -274,6 +301,123 @@ export class AppController {
     const obj = this._service.createSketch()
     this._switchActiveObject(obj.id, true)
     this.setMode('edit')  // enters Edit Mode · 2D
+  }
+
+  /** Enters measure placement mode: click p1, then p2 to create a MeasureLine. */
+  _startMeasurePlacement() {
+    if (this._scene.selectionMode === 'edit') this.setMode('object')
+    this._measure.active       = true
+    this._measure.p1           = null
+    this._measure.p2           = null
+    this._measure.snapTargets  = []
+    this._measure.snapping     = false
+    this._measure.snappedTarget = null
+    this._uiView.setCursor('crosshair')
+    this._updateMeasureStatus()
+    this._updateMobileToolbar()
+  }
+
+  _cancelMeasure() {
+    if (!this._measure.active) return
+    this._measure.active       = false
+    this._measure.p1           = null
+    this._measure.p2           = null
+    this._measure.snapping     = false
+    this._measure.snappedTarget = null
+    this._measure.snapTargets  = []
+    if (this._measure.previewLine) {
+      this._sceneView.scene.remove(this._measure.previewLine)
+      this._measure.previewLine.geometry.dispose()
+      this._measure.previewLine.material.dispose()
+      this._measure.previewLine = null
+    }
+    this._meshView?.clearSnapDisplay()
+    this._uiView.setCursor('default')
+    this._refreshObjectModeStatus()
+    this._updateMobileToolbar()
+  }
+
+  _updateMeasureStatus() {
+    if (!this._measure.active) return
+    if (!this._measure.p1) {
+      this._uiView.setStatusRich([
+        { text: 'Measure', bold: true, color: '#f9a825' },
+        { text: 'Click to set start point', color: '#888' },
+        { text: 'ESC cancel', color: '#444' },
+      ])
+    } else {
+      const parts = [
+        { text: 'Measure', bold: true, color: '#f9a825' },
+        { text: 'Click to set end point', color: '#888' },
+      ]
+      if (this._measure.p2) {
+        const d = this._measure.p1.distanceTo(this._measure.p2)
+        const f = d < 1 ? `${(d * 100).toFixed(1)} cm` : `${d.toFixed(3)} m`
+        parts.push({ text: f, bold: true, color: '#f9a825' })
+      }
+      if (this._measure.snapping && this._measure.snappedTarget) {
+        parts.push({ text: `Snap: ${this._measure.snappedTarget.label}`, color: '#ff9800' })
+      }
+      parts.push({ text: 'ESC cancel', color: '#444' })
+      this._uiView.setStatusRich(parts)
+    }
+  }
+
+  /**
+   * Finds the nearest V/E/F snap target to the current mouse cursor.
+   * Returns the snapped world position (or ground-plane fallback).
+   * Also updates this._measure.snapping / snappedTarget / snapTargets.
+   */
+  _measurePickPoint() {
+    const SNAP_PX = 25
+    const mx = (this._mouse.x + 1) / 2 * innerWidth
+    const my = (-this._mouse.y + 1) / 2 * innerHeight
+
+    const targets = collectSnapTargets(this._scene.objects, 'all')
+    this._measure.snapTargets = targets
+
+    let bestDist   = SNAP_PX
+    let bestTarget = null
+    const camMat = this._camera.matrixWorldInverse
+    for (const t of targets) {
+      const camPos = t.position.clone().applyMatrix4(camMat)
+      if (camPos.z >= 0) continue
+      const s = this._projectToScreen(t.position)
+      const d = Math.hypot(mx - s.x, my - s.y)
+      if (d < bestDist) { bestDist = d; bestTarget = t }
+    }
+
+    if (bestTarget) {
+      this._measure.snapping      = true
+      this._measure.snappedTarget = bestTarget
+      return bestTarget.position.clone()
+    }
+
+    // Fallback: intersect ground plane (Z=0)
+    this._measure.snapping      = false
+    this._measure.snappedTarget = null
+    this._raycaster.setFromCamera(this._mouse, this._camera)
+    const pt = new THREE.Vector3()
+    if (this._raycaster.ray.intersectPlane(this._groundPlane, pt)) return pt
+    return null
+  }
+
+  /** Builds or updates the dashed preview line shown during measure placement phase 2. */
+  _updateMeasurePreview(p1, p2) {
+    const pts = [p1.x, p1.y, p1.z, p2.x, p2.y, p2.z]
+    if (!this._measure.previewLine) {
+      const geo  = new THREE.BufferGeometry()
+      const mat  = new THREE.LineDashedMaterial({
+        color: 0xf9a825, dashSize: 0.15, gapSize: 0.08, depthTest: false,
+      })
+      this._measure.previewLine = new THREE.Line(geo, mat)
+      this._measure.previewLine.renderOrder = 1
+      this._sceneView.scene.add(this._measure.previewLine)
+    }
+    const geo = this._measure.previewLine.geometry
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(pts, 3))
+    geo.attributes.position.needsUpdate = true
+    this._measure.previewLine.computeLineDistances()
   }
 
   _deleteObject(id) {
@@ -414,7 +558,7 @@ export class AppController {
   _hitAnyObject() {
     this._raycaster.setFromCamera(this._mouse, this._camera)
     const meshes = [...this._scene.objects.values()]
-      .filter(o => o.meshView.cuboid.visible)
+      .filter(o => !(o instanceof MeasureLine) && o.meshView.cuboid?.visible)
       .map(o => o.meshView.cuboid)
     const hits = this._raycaster.intersectObjects(meshes)
     if (!hits.length) return null
@@ -500,6 +644,7 @@ export class AppController {
             window.innerWidth / 2, window.innerHeight / 2,
             () => this._addObject('box'),
             () => this._addObject('sketch'),
+            () => this._addObject('measure'),
           ),
         },
         { icon: ICONS.edit,   label: 'Edit',   onClick: () => this.setMode('edit'),                                     disabled: !canEdit },
@@ -683,9 +828,9 @@ export class AppController {
 
   // ─── Mode management ───────────────────────────────────────────────────────
   setMode(mode) {
-    // ImportedMesh is read-only — block Edit Mode entry and notify the user
-    if (mode === 'edit' && this._activeObj instanceof ImportedMesh) {
-      this._uiView.showToast('Imported geometry is read-only')
+    // ImportedMesh and MeasureLine are read-only — block Edit Mode entry and notify the user
+    if (mode === 'edit' && (this._activeObj instanceof ImportedMesh || this._activeObj instanceof MeasureLine)) {
+      this._uiView.showToast('This object type is read-only')
       return
     }
 
@@ -1006,8 +1151,8 @@ export class AppController {
 
   _startGrab() {
     if (!this._objSelected) return
-    if (this._activeObj instanceof ImportedMesh) {
-      this._uiView.showToast('Imported geometry is read-only')
+    if (this._activeObj instanceof ImportedMesh || this._activeObj instanceof MeasureLine) {
+      this._uiView.showToast('This object type is read-only')
       return
     }
 
@@ -1602,6 +1747,33 @@ export class AppController {
       return
     }
 
+    // ── Measure placement hover ───────────────────────────────────────────
+    if (this._measure.active) {
+      const pt = this._measurePickPoint()
+      if (pt) {
+        this._measure.p2 = pt
+        // Show snap candidates on the active object's mesh view (if any)
+        if (this._meshView) {
+          this._meshView.showSnapCandidates(this._measure.snapTargets)
+          if (this._measure.snapping && this._measure.snappedTarget) {
+            this._meshView.showSnapLocked(
+              this._measure.snappedTarget.position,
+              this._measure.snappedTarget.type,
+              pt,
+            )
+          } else {
+            this._meshView.clearSnapLocked()
+          }
+        }
+        // Phase 2: draw preview line
+        if (this._measure.p1) {
+          this._updateMeasurePreview(this._measure.p1, pt)
+        }
+      }
+      this._updateMeasureStatus()
+      return
+    }
+
     if (this._scene.selectionMode === 'object') {
       if (this._rectSel.active) {
         this._rectSel.currentPx = { x: e.clientX, y: e.clientY }
@@ -1795,6 +1967,50 @@ export class AppController {
         return
       }
       if (e.button === 2) { this._cancelFaceExtrude(); return }
+      return
+    }
+
+    // ── Measure placement clicks ──────────────────────────────────────────
+    if (this._measure.active) {
+      if (e.button === 2) { this._cancelMeasure(); return }
+      if (e.button === 0) {
+        const pt = this._measurePickPoint()
+        if (!pt) return
+        if (!this._measure.p1) {
+          // Phase 1 → Phase 2: record start point
+          this._measure.p1 = pt.clone()
+          this._updateMeasureStatus()
+        } else {
+          // Phase 2: record end point → create entity
+          const p2 = pt.clone()
+          if (this._measure.previewLine) {
+            this._sceneView.scene.remove(this._measure.previewLine)
+            this._measure.previewLine.geometry.dispose()
+            this._measure.previewLine.material.dispose()
+            this._measure.previewLine = null
+          }
+          this._meshView?.clearSnapDisplay()
+          this._measure.active = false
+          const p1 = this._measure.p1
+          this._measure.p1 = null
+          this._measure.p2 = null
+          this._measure.snapTargets  = []
+          this._measure.snapping     = false
+          this._measure.snappedTarget = null
+          // Create entity via service
+          const obj = this._service.createMeasureLine(
+            p1, p2,
+            this._camera,
+            this._sceneView.renderer,
+            document.body,
+          )
+          this._switchActiveObject(obj.id, true)
+          this._uiView.setCursor('default')
+          this._refreshObjectModeStatus()
+          this._updateMobileToolbar()
+        }
+        return
+      }
       return
     }
 
@@ -2013,6 +2229,12 @@ export class AppController {
       return
     }
 
+    // ── Measure placement keys ─────────────────────────────────────────────
+    if (this._measure.active) {
+      if (e.key === 'Escape') { this._cancelMeasure(); return }
+      return
+    }
+
     // ── Sketch phase keys ──────────────────────────────────────────────────
     if (this._scene.editSubstate === '2d-sketch') {
       if (e.key === 'Enter') {
@@ -2100,7 +2322,8 @@ export class AppController {
       // For ImportedMesh, setMode('edit') is a no-op — swallow the key only
       // when switching to object mode or when the active object is editable.
       const enteringEdit = this._scene.selectionMode === 'object'
-      if (!enteringEdit || !(this._activeObj instanceof ImportedMesh)) {
+      const isReadOnly = this._activeObj instanceof ImportedMesh || this._activeObj instanceof MeasureLine
+      if (!enteringEdit || !isReadOnly) {
         e.preventDefault()
         this.setMode(enteringEdit ? 'edit' : 'object')
       }
@@ -2112,6 +2335,11 @@ export class AppController {
     }
 
     if (this._scene.selectionMode === 'object') {
+      // M: start measure placement
+      if (e.key === 'm' || e.key === 'M') {
+        this._startMeasurePlacement()
+        return
+      }
       // Shift+D: duplicate active object and immediately grab (Blender-style)
       if (e.key === 'D' && e.shiftKey && this._objSelected) {
         e.preventDefault()
@@ -2131,6 +2359,7 @@ export class AppController {
         this._uiView.showAddMenu(screenX, screenY,
           () => this._addObject('box'),
           () => this._addObject('sketch'),
+          () => this._addObject('measure'),
         )
         return
       }
@@ -2171,6 +2400,10 @@ export class AppController {
       requestAnimationFrame(loop)
       this._sceneView.render()
       if (this._gizmoView) this._gizmoView.update()
+      // Keep MeasureLine HTML labels positioned over the correct screen pixel
+      for (const obj of this._scene.objects.values()) {
+        if (obj instanceof MeasureLine) obj.meshView.updateLabelPosition()
+      }
     }
     loop()
 

--- a/src/domain/MeasureLine.js
+++ b/src/domain/MeasureLine.js
@@ -1,0 +1,54 @@
+/**
+ * MeasureLine — domain entity for a 1D measurement line.
+ *
+ * Stores two world-space endpoints and exposes a `distance` getter.
+ * Immutable geometry after creation (endpoints are set during placement).
+ * Editing endpoints via Edit Mode · 1D is a planned future extension.
+ *
+ * Type identity:
+ *   `instanceof MeasureLine` → read-only 1D measurement; limited Edit Mode.
+ *   `instanceof Cuboid`      → locally-editable deformable box.
+ *   `instanceof Sketch`      → 2D sketch awaiting extrusion.
+ *   `instanceof ImportedMesh`→ server-side read-only geometry.
+ */
+import * as THREE from 'three'
+
+export class MeasureLine {
+  /**
+   * @param {string}        id
+   * @param {string}        name
+   * @param {THREE.Vector3} p1   start endpoint (world space)
+   * @param {THREE.Vector3} p2   end endpoint (world space)
+   * @param {import('../view/MeasureLineView.js').MeasureLineView} meshView
+   */
+  constructor(id, name, p1, p2, meshView) {
+    this.id       = id
+    this.name     = name
+    /** @type {THREE.Vector3} */
+    this.p1       = p1.clone()
+    /** @type {THREE.Vector3} */
+    this.p2       = p2.clone()
+    this.meshView = meshView
+  }
+
+  /** World-space distance between the two endpoints (metres). */
+  get distance() {
+    return this.p1.distanceTo(this.p2)
+  }
+
+  /** Renames the entity. */
+  rename(name) {
+    this.name = name
+  }
+
+  /**
+   * Updates both endpoints and refreshes the view.
+   * @param {THREE.Vector3} p1
+   * @param {THREE.Vector3} p2
+   */
+  setEndpoints(p1, p2) {
+    this.p1.copy(p1)
+    this.p2.copy(p2)
+    this.meshView?.update(this.p1, this.p2)
+  }
+}

--- a/src/service/SceneService.js
+++ b/src/service/SceneService.js
@@ -42,6 +42,8 @@ import { BffClient, BffUnavailableError, WsChannel } from './BffClient.js'
 import { serializeScene } from './SceneSerializer.js'
 import { ImportedMesh } from '../domain/ImportedMesh.js'
 import { ImportedMeshView } from '../view/ImportedMeshView.js'
+import { MeasureLine } from '../domain/MeasureLine.js'
+import { MeasureLineView } from '../view/MeasureLineView.js'
 
 export class SceneService extends EventEmitter {
   /**
@@ -432,6 +434,29 @@ export class SceneService extends EventEmitter {
   createImportedMesh(id, name) {
     const meshView = new ImportedMeshView(this._threeScene)
     const entity   = new ImportedMesh(id, name, meshView)
+    this._model.addObject(entity)
+    this.emit('objectAdded', entity)
+    return entity
+  }
+
+  /**
+   * Creates a MeasureLine entity + MeasureLineView and registers it in the scene.
+   *
+   * @param {THREE.Vector3} p1         start endpoint (world space)
+   * @param {THREE.Vector3} p2         end endpoint (world space)
+   * @param {THREE.Camera}  camera     used by MeasureLineView for label projection
+   * @param {THREE.WebGLRenderer} renderer  used for canvas bounds
+   * @param {HTMLElement}   container  DOM element for the HTML label
+   * @returns {import('../domain/MeasureLine.js').MeasureLine}
+   */
+  createMeasureLine(p1, p2, camera, renderer, container) {
+    const idx  = this._model.objects.size
+    const id   = `ml_${idx}_${Date.now()}`
+    const name = `Measure.${String(idx).padStart(3, '0')}`
+
+    const meshView = new MeasureLineView(this._threeScene, container, camera, renderer)
+    const entity   = new MeasureLine(id, name, p1, p2, meshView)
+    meshView.update(p1, p2)
     this._model.addObject(entity)
     this.emit('objectAdded', entity)
     return entity

--- a/src/view/MeasureLineView.js
+++ b/src/view/MeasureLineView.js
@@ -1,0 +1,199 @@
+/**
+ * MeasureLineView — 1D measurement line renderer (Phase D).
+ *
+ * Renders:
+ *  - A dashed Three.js Line from p1 to p2
+ *  - An HTML label at the midpoint showing the distance in metres
+ *  - A BoxHelper for selection highlight (reuses BoxHelper convention from MeshView)
+ *
+ * Exposes the minimal interface expected by AppController / SceneService:
+ *   setVisible(v), setObjectSelected(v), dispose(scene)
+ *   + edit-mode no-ops to keep setMode() safe.
+ *
+ * Note: the `cuboid` property alias is intentionally absent — MeasureLine
+ * objects are excluded from raycasting in AppController._hitAnyObject().
+ */
+import * as THREE from 'three'
+
+export class MeasureLineView {
+  /**
+   * @param {THREE.Scene}   scene       Three.js scene to add objects to
+   * @param {HTMLElement}   container   DOM element to append the label to (typically document.body)
+   * @param {THREE.Camera}  camera      Camera used to project world→screen for label placement
+   * @param {HTMLElement}   renderer    renderer.domElement — used to get canvas bounds
+   */
+  constructor(scene, container, camera, renderer) {
+    this._scene    = scene
+    this._container = container
+    this._camera   = camera
+    this._renderer = renderer
+
+    // ── Line geometry ──────────────────────────────────────────────────────
+    this._geo = new THREE.BufferGeometry()
+    this._mat = new THREE.LineDashedMaterial({
+      color:       0xf9a825,   // amber — clearly distinct from grid / wireframe
+      dashSize:    0.15,
+      gapSize:     0.08,
+      linewidth:   1,          // only 1 is guaranteed cross-browser
+      depthTest:   false,
+    })
+    this._line = new THREE.Line(this._geo, this._mat)
+    this._line.renderOrder = 1
+    scene.add(this._line)
+
+    // ── End-point markers (small spheres) ──────────────────────────────────
+    const dotGeo = new THREE.SphereGeometry(0.05, 8, 8)
+    const dotMat = new THREE.MeshBasicMaterial({ color: 0xf9a825, depthTest: false })
+    this._dot1 = new THREE.Mesh(dotGeo, dotMat)
+    this._dot2 = new THREE.Mesh(dotGeo, dotMat)
+    this._dot1.renderOrder = 1
+    this._dot2.renderOrder = 1
+    scene.add(this._dot1)
+    scene.add(this._dot2)
+    this._dotGeo = dotGeo
+    this._dotMat = dotMat
+
+    // ── BoxHelper for object-selected highlight ────────────────────────────
+    // We attach to an invisible helper object whose bounding-box wraps the line.
+    this._helperObj = new THREE.Object3D()
+    scene.add(this._helperObj)
+    this.boxHelper = new THREE.BoxHelper(this._helperObj, 0xf9a825)
+    this.boxHelper.visible = false
+    scene.add(this.boxHelper)
+
+    // ── HTML distance label ────────────────────────────────────────────────
+    this._label = document.createElement('div')
+    Object.assign(this._label.style, {
+      position:      'fixed',
+      pointerEvents: 'none',
+      userSelect:    'none',
+      background:    'rgba(30, 30, 30, 0.82)',
+      color:         '#f9a825',
+      fontSize:      '12px',
+      fontFamily:    'monospace',
+      padding:       '2px 6px',
+      borderRadius:  '3px',
+      border:        '1px solid #f9a825',
+      whiteSpace:    'nowrap',
+      display:       'none',
+      zIndex:        '50',
+    })
+    container.appendChild(this._label)
+
+    // ── Internal state ─────────────────────────────────────────────────────
+    /** @type {THREE.Vector3} */
+    this._p1 = new THREE.Vector3()
+    /** @type {THREE.Vector3} */
+    this._p2 = new THREE.Vector3()
+  }
+
+  // ── Geometry update ────────────────────────────────────────────────────────
+
+  /**
+   * Updates both endpoints and refreshes geometry + label.
+   * @param {THREE.Vector3} p1
+   * @param {THREE.Vector3} p2
+   */
+  update(p1, p2) {
+    this._p1.copy(p1)
+    this._p2.copy(p2)
+
+    const pts = [p1.x, p1.y, p1.z, p2.x, p2.y, p2.z]
+    this._geo.setAttribute('position', new THREE.Float32BufferAttribute(pts, 3))
+    this._geo.attributes.position.needsUpdate = true
+    this._line.computeLineDistances()     // required for LineDashedMaterial
+
+    this._dot1.position.copy(p1)
+    this._dot2.position.copy(p2)
+
+    // Reposition helper object so BoxHelper wraps the line
+    const mid = p1.clone().add(p2).multiplyScalar(0.5)
+    this._helperObj.position.copy(mid)
+    if (this.boxHelper.visible) this.boxHelper.update()
+
+    this._updateLabel(p1, p2)
+  }
+
+  /**
+   * Projects midpoint to screen and updates label position + text.
+   * Must be called once per frame (from AppController._animate) while the
+   * measure line is visible, so the label tracks camera movement.
+   */
+  updateLabelPosition() {
+    if (!this._line.visible) return
+    this._updateLabel(this._p1, this._p2)
+  }
+
+  _updateLabel(p1, p2) {
+    const dist = p1.distanceTo(p2)
+    const mid  = p1.clone().add(p2).multiplyScalar(0.5)
+
+    // Project to NDC then to screen pixels
+    const ndc = mid.clone().project(this._camera)
+    const canvas = this._renderer.domElement
+    const rect   = canvas.getBoundingClientRect()
+    const sx = (ndc.x  + 1) / 2 * rect.width  + rect.left
+    const sy = (-ndc.y + 1) / 2 * rect.height + rect.top
+
+    // Hide label if behind camera
+    if (ndc.z > 1) {
+      this._label.style.display = 'none'
+      return
+    }
+
+    const formatted = dist < 0.001
+      ? '0 m'
+      : dist < 1
+        ? `${(dist * 100).toFixed(1)} cm`
+        : `${dist.toFixed(3)} m`
+
+    this._label.textContent  = formatted
+    this._label.style.display = 'block'
+    this._label.style.left   = `${Math.round(sx + 8)}px`
+    this._label.style.top    = `${Math.round(sy - 10)}px`
+  }
+
+  // ── Visual state ───────────────────────────────────────────────────────────
+
+  setVisible(visible) {
+    this._line.visible = visible
+    this._dot1.visible = visible
+    this._dot2.visible = visible
+    this._label.style.display = visible ? 'block' : 'none'
+  }
+
+  setObjectSelected(sel) {
+    this.boxHelper.visible = sel
+    if (sel) this.boxHelper.update()
+  }
+
+  // ── Edit-mode no-ops (keeps AppController.setMode() safe) ─────────────────
+
+  setFaceHighlight()     {}
+  clearExtrusionDisplay() {}
+  clearSketchRect()      {}
+  clearVertexHover()     {}
+  clearEdgeHover()       {}
+  clearEditSelection()   {}
+  clearPivotDisplay()    {}
+  clearSnapDisplay()     {}
+
+  // ── Lifecycle ──────────────────────────────────────────────────────────────
+
+  /**
+   * Removes all Three.js objects from the scene and the label from the DOM.
+   * @param {THREE.Scene} scene
+   */
+  dispose(scene) {
+    scene.remove(this._line)
+    scene.remove(this._dot1)
+    scene.remove(this._dot2)
+    scene.remove(this._helperObj)
+    scene.remove(this.boxHelper)
+    this._geo.dispose()
+    this._mat.dispose()
+    this._dotGeo.dispose()
+    this._dotMat.dispose()
+    this._label.remove()
+  }
+}

--- a/src/view/OutlinerView.js
+++ b/src/view/OutlinerView.js
@@ -138,7 +138,7 @@ export class OutlinerView {
   /**
    * @param {string} id
    * @param {string} name
-   * @param {'cuboid'|'sketch'|'imported'} [type='cuboid']
+   * @param {'cuboid'|'sketch'|'imported'|'measure'} [type='cuboid']
    */
   addObject(id, name, type = 'cuboid') {
     const { rowEl, eyeEl, nameEl } = this._createRow(id, name, type)
@@ -198,12 +198,18 @@ export class OutlinerView {
       lineHeight: '1',
     })
 
-    // Mesh icon — blue for editable objects, gray for read-only imports
+    // Mesh icon — blue for editable objects, gray for read-only imports, amber for measure
     const iconEl = document.createElement('span')
-    iconEl.textContent = '⬡'
-    if (type === 'imported') iconEl.title = 'Imported mesh (read-only)'
+    if (type === 'measure') {
+      iconEl.textContent = '↔'
+      iconEl.title = 'Measure line'
+    } else {
+      iconEl.textContent = '⬡'
+      if (type === 'imported') iconEl.title = 'Imported mesh (read-only)'
+    }
+    const iconColor = type === 'imported' ? '#888888' : type === 'measure' ? '#f9a825' : '#4fc3f7'
     Object.assign(iconEl.style, {
-      color: type === 'imported' ? '#888888' : '#4fc3f7',
+      color: iconColor,
       fontSize: '12px',
       flexShrink: '0',
       lineHeight: '1',

--- a/src/view/UIView.js
+++ b/src/view/UIView.js
@@ -457,8 +457,9 @@ export class UIView {
    * @param {number} y - screen Y
    * @param {() => void} onBox
    * @param {() => void} onSketch
+   * @param {() => void} [onMeasure]
    */
-  showAddMenu(x, y, onBox, onSketch) {
+  showAddMenu(x, y, onBox, onSketch, onMeasure) {
     this.hideAddMenu()
     const menu = document.createElement('div')
     Object.assign(menu.style, {
@@ -487,8 +488,9 @@ export class UIView {
     menu.appendChild(title)
 
     const items = [
-      { label: 'Box', hint: 'Shift+A', cb: onBox },
-      { label: 'Sketch', hint: '', cb: onSketch },
+      { label: 'Box',     hint: 'Shift+A', cb: onBox },
+      { label: 'Sketch',  hint: '',        cb: onSketch },
+      ...(onMeasure ? [{ label: 'Measure', hint: 'M', cb: onMeasure }] : []),
     ]
     items.forEach(({ label, hint, cb }) => {
       const item = document.createElement('div')


### PR DESCRIPTION
Adds a 1D measure tool that snaps to Vertex, Edge midpoints, and Face
centers of existing Cuboids during endpoint placement.

New files:
- src/domain/MeasureLine.js — entity with p1/p2 endpoints and distance getter
- src/view/MeasureLineView.js — dashed amber line + HTML label (cm/m), BoxHelper,
  updateLabelPosition() called every animation frame

Changed files:
- SceneService: createMeasureLine(p1, p2, camera, renderer, container)
- AppController:
    - _startMeasurePlacement() / _cancelMeasure() / _updateMeasureStatus()
    - _measurePickPoint() — collectSnapTargets + ground-plane fallback
    - _updateMeasurePreview() — dashed preview line before entity creation
    - _onPointerMove: snap candidate display during hover
    - _onPointerDown: click-p1 / click-p2 two-phase placement
    - _onKeyDown: M key to start, ESC to cancel; Shift+A → Measure
    - animation loop: updateLabelPosition() for all MeasureLine objects
    - _hitAnyObject: skip MeasureLine (no cuboid mesh)
    - setMode/startGrab: block edit/grab for MeasureLine (read-only)
- UIView.showAddMenu: optional onMeasure callback → 'Measure' (M hint)
- OutlinerView.addObject: 'measure' type → ↔ amber icon

MENTAL_MODEL updated: MeasureLine entity contract + label lifecycle rule.
ROADMAP: MeasureLine completed; Edit Mode · 1D endpoint drag raised to 🔴 High.

https://claude.ai/code/session_01SdpppUgyveP4Nw6Wo8z3Pe