### PR TITLE
Mobile UX: Stack in Object mode, measure hold-to-snap, MeasureLine delete fix

### DIFF
--- a/.claude/MENTAL_MODEL.md
+++ b/.claude/MENTAL_MODEL.md
@@ -153,7 +153,7 @@ if (e.target !== this._sceneView.renderer.domElement) return
 
 | Mode | Slot 1 | Slot 2 | Slot 3 | Slot 4 |
 |------|--------|--------|--------|--------|
-| Object | Add | Edit | Delete | *(spacer)* |
+| Object | Add | Edit | Delete | Stack |
 | Edit 2D sketch | ← Object | Extrude | *(spacer)* | *(spacer)* |
 | Edit 2D extrude | Confirm | Cancel | *(spacer)* | *(spacer)* |
 | Edit 3D | ← Object | Vertex | Edge | Face |
@@ -161,10 +161,17 @@ if (e.target !== this._sceneView.renderer.domElement) return
 
 `{ spacer: true }` renders as a `visibility: hidden` div of identical dimensions. It occupies layout space without being tappable.
 
-Grab and Edit are disabled for `ImportedMesh`; Grab is additionally disabled for `MeasureLine`. All four Object-mode slots have consistent disabled states so slot positions never shift.
+Grab, Edit, and Stack are disabled for `ImportedMesh` and `MeasureLine`. Delete remains enabled for all object types including `MeasureLine`. All four Object-mode slots maintain consistent disabled states so slot positions never shift.
+
+The Object-mode Stack button pre-sets `_grab.stackMode` before a grab gesture. `_startGrab()` does not reset `stackMode`, so the pre-set is respected. `_confirmGrab()` and `_cancelGrab()` reset it to `false` when the grab ends.
 
 Face extrude on mobile is a gesture-only operation (tap → drag → release = confirm). No Extrude button is shown in Edit 3D.
-Grab on mobile is also a gesture (touch object → drag) — no toolbar button needed. Stack is an explicit constraint mode, so it has a dedicated toolbar button.
+Grab on mobile is also a gesture (touch object → drag) — no toolbar button needed. Stack is an explicit constraint mode, so it has a dedicated toolbar button (Object mode: pre-grab toggle; Grab active mode: mid-grab toggle).
+
+### Measure Point Placement (Mobile: Hold-to-Snap, Release-to-Confirm)
+
+- **Principle**: On touch devices, placement of a single point requires the user to see snap feedback before committing. A tap-and-release offers no time to adjust; hold-and-release does.
+- **Concrete Rule**: Measure point confirmation happens in `_onPointerUp`, not `_onPointerDown`. On `pointerdown`, set `_measure.pressing = true` and `_activeDragPointerId`. On `pointerup`, if `_measure.pressing && _activeDragPointerId === e.pointerId`, call `_confirmMeasurePoint()`. During the hold, `_onPointerMove` continues updating snap candidates so the user sees live snap feedback. `_cancelMeasure()` also resets `pressing = false`.
 
 ### Stack Mode (Grab)
 

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -86,6 +86,8 @@ export class AppController {
       snappedTarget: null,
       /** Three.js Line for preview before entity is created */
       previewLine:  null,
+      /** True while the user is holding a pointer down to snap a point */
+      pressing:     false,
     }
 
     // ── Sketch drawing state (Edit Mode · 2D) ──────────────────────────────
@@ -330,6 +332,7 @@ export class AppController {
     this._measure.snapping     = false
     this._measure.snappedTarget = null
     this._measure.snapTargets  = []
+    this._measure.pressing     = false
     if (this._measure.previewLine) {
       this._sceneView.scene.remove(this._measure.previewLine)
       this._measure.previewLine.geometry.dispose()
@@ -340,6 +343,48 @@ export class AppController {
     this._uiView.setCursor('default')
     this._refreshObjectModeStatus()
     this._updateMobileToolbar()
+  }
+
+  /**
+   * Confirms the current snapped cursor position as a measure point.
+   * Phase 1: sets p1. Phase 2: creates the MeasureLine entity.
+   * Called from _onPointerUp so mobile users can hold-to-snap before releasing.
+   */
+  _confirmMeasurePoint() {
+    const pt = this._measurePickPoint()
+    if (!pt) return
+    if (!this._measure.p1) {
+      // Phase 1 → Phase 2: record start point
+      this._measure.p1 = pt.clone()
+      this._updateMeasureStatus()
+    } else {
+      // Phase 2: record end point → create entity
+      const p2 = pt.clone()
+      if (this._measure.previewLine) {
+        this._sceneView.scene.remove(this._measure.previewLine)
+        this._measure.previewLine.geometry.dispose()
+        this._measure.previewLine.material.dispose()
+        this._measure.previewLine = null
+      }
+      this._meshView?.clearSnapDisplay()
+      this._measure.active        = false
+      const p1                    = this._measure.p1
+      this._measure.p1            = null
+      this._measure.p2            = null
+      this._measure.snapTargets   = []
+      this._measure.snapping      = false
+      this._measure.snappedTarget = null
+      const obj = this._service.createMeasureLine(
+        p1, p2,
+        this._camera,
+        this._sceneView.renderer,
+        document.body,
+      )
+      this._switchActiveObject(obj.id, true)
+      this._uiView.setCursor('default')
+      this._refreshObjectModeStatus()
+      this._updateMobileToolbar()
+    }
   }
 
   _updateMeasureStatus() {
@@ -488,6 +533,7 @@ export class AppController {
 
     this._refreshObjectModeStatus()
     this._updateNPanel()
+    this._updateMobileToolbar()
   }
 
   _setObjectVisible(id, visible) {
@@ -641,7 +687,8 @@ export class AppController {
       // Always show the same 4 buttons; Edit/Delete are disabled when no
       // object is selected. Fixed count prevents layout shifts on selection.
       const hasObj  = this._objSelected
-      const canEdit = hasObj && !(this._activeObj instanceof ImportedMesh)
+      const canEdit = hasObj && !(this._activeObj instanceof ImportedMesh) && !(this._activeObj instanceof MeasureLine)
+      const canGrab = hasObj && !(this._activeObj instanceof ImportedMesh) && !(this._activeObj instanceof MeasureLine)
       this._uiView.setMobileToolbar([
         {
           icon: ICONS.add, label: 'Add',
@@ -654,7 +701,7 @@ export class AppController {
         },
         { icon: ICONS.edit,   label: 'Edit',   onClick: () => this.setMode('edit'),                                     disabled: !canEdit },
         { icon: ICONS.delete, label: 'Delete', onClick: () => this._deleteObject(this._scene.activeId), danger: hasObj, disabled: !hasObj },
-        { spacer: true },
+        { icon: ICONS.stack,  label: 'Stack',  onClick: () => { this._grab.stackMode = !this._grab.stackMode; this._updateMobileToolbar() }, active: this._grab.stackMode, disabled: !canGrab },
       ])
       return
     }
@@ -2066,41 +2113,10 @@ export class AppController {
     if (this._measure.active) {
       if (e.button === 2) { this._cancelMeasure(); return }
       if (e.button === 0) {
-        const pt = this._measurePickPoint()
-        if (!pt) return
-        if (!this._measure.p1) {
-          // Phase 1 → Phase 2: record start point
-          this._measure.p1 = pt.clone()
-          this._updateMeasureStatus()
-        } else {
-          // Phase 2: record end point → create entity
-          const p2 = pt.clone()
-          if (this._measure.previewLine) {
-            this._sceneView.scene.remove(this._measure.previewLine)
-            this._measure.previewLine.geometry.dispose()
-            this._measure.previewLine.material.dispose()
-            this._measure.previewLine = null
-          }
-          this._meshView?.clearSnapDisplay()
-          this._measure.active = false
-          const p1 = this._measure.p1
-          this._measure.p1 = null
-          this._measure.p2 = null
-          this._measure.snapTargets  = []
-          this._measure.snapping     = false
-          this._measure.snappedTarget = null
-          // Create entity via service
-          const obj = this._service.createMeasureLine(
-            p1, p2,
-            this._camera,
-            this._sceneView.renderer,
-            document.body,
-          )
-          this._switchActiveObject(obj.id, true)
-          this._uiView.setCursor('default')
-          this._refreshObjectModeStatus()
-          this._updateMobileToolbar()
-        }
+        // Hold to snap, release to confirm — handled in _onPointerUp.
+        // This lets mobile users slide their finger to the snap target before lifting.
+        this._measure.pressing = true
+        this._activeDragPointerId = e.pointerId
         return
       }
       return
@@ -2218,6 +2234,17 @@ export class AppController {
 
   _onPointerUp(e) {
     if (e.button !== 0) return
+
+    // ── Measure point confirmation (hold-to-snap, release-to-confirm) ─────
+    if (this._measure.active && this._measure.pressing) {
+      if (this._activeDragPointerId === e.pointerId) {
+        this._activeDragPointerId = null
+        this._measure.pressing    = false
+        this._confirmMeasurePoint()
+      }
+      return
+    }
+
     // wasDragging: a canvas drag started for this pointer (via _onPointerDown)
     const wasDragging = this._activeDragPointerId === e.pointerId
     if (wasDragging) this._activeDragPointerId = null


### PR DESCRIPTION
- Object mode toolbar slot 4 is now a Stack button (was spacer).
  Tapping it pre-toggles _grab.stackMode before starting a grab gesture,
  so the Stack active indicator is already lit when the grab begins.
  Stack/Edit are disabled for ImportedMesh and MeasureLine.

- Measure mode point placement moved to pointerup (hold-to-snap UX).
  pointerdown sets _measure.pressing + _activeDragPointerId; pointerup
  calls _confirmMeasurePoint() using the live-snapped position.
  This lets mobile users slide their finger to snap a vertex/edge/face
  before lifting, matching the face-extrude and sketch-draw gesture patterns.
  Logic extracted into _confirmMeasurePoint() helper.

- Fixed: selecting a MeasureLine from the outliner now enables the mobile
  Delete button. _switchActiveObject() was not calling _updateMobileToolbar(),
  so the toolbar kept its previous disabled state. Added the call there.

MENTAL_MODEL updated: 4-slot table, Stack pre-grab contract, measure
hold-to-snap rule.

https://claude.ai/code/session_01CtZhKqmRxq6oDJMf5mSUDU