### PR TITLE
docs(src): standardize README coverage across all src subdirectories

### DIFF
--- a/src/controller/README.md
+++ b/src/controller/README.md
@@ -1,0 +1,73 @@
+# Controller Layer — Input Handling & MVC Coordination
+
+**Responsibility**: Translate raw input events (pointer, keyboard, touch) into
+`SceneService` / `SceneModel` calls and `View` updates. The Controller is
+intentionally thin — business logic must not live here.
+
+Files: `AppController.js`
+
+---
+
+## Meta Model: Thin Coordinator
+
+The Controller is the only layer that is permitted to depend on both the
+Service layer and the View layer at the same time. It must not contain business
+logic, domain calculations, or rendering code.
+
+| Permitted | Prohibited |
+|-----------|------------|
+| Reading `SceneModel` state | Geometry computation (belongs in `CuboidModel`) |
+| Calling `SceneService` factory/CRUD methods | `new Cuboid()` / `new Sketch()` directly |
+| Calling `View` render/update methods | `THREE.*` object creation or manipulation |
+| Subscribing to `SceneService` events | Duplicating domain logic from entities |
+
+## Mode Transition Contract (ADR-008, MENTAL_MODEL §1)
+
+`AppController.setMode(mode)` is the **single entry point** for all mode
+transitions. Before switching the active object, always call `setMode('object')`
+first if currently in Edit mode. This guarantees all in-progress operations
+and visual states are cleaned up before the swap.
+
+```js
+if (this._selectionMode === 'edit') this.setMode('object')
+// ... then _switchActiveObject(newId, true)
+```
+
+## Event Routing Pattern
+
+The Controller subscribes to `SceneService` events and delegates to View:
+
+```js
+this._scene.on('objectAdded',   obj  => this._outliner.addItem(obj))
+this._scene.on('objectRemoved', id   => this._outliner.removeItem(id))
+this._scene.on('objectRenamed', obj  => this._outliner.renameItem(obj))
+this._scene.on('activeChanged', obj  => this._outliner.setActive(obj?.id))
+```
+
+The Controller must never call `SceneService` from inside View callbacks, or
+call View methods from inside Service methods — these would create circular
+dependencies.
+
+## Entity Type Guards
+
+Before invoking Edit Mode, Grab, or drag operations, the Controller must check
+entity type and show user feedback for unsupported types:
+
+```js
+if (obj instanceof ImportedMesh || obj instanceof MeasureLine) {
+  this._uiView.showToast('...')
+  return
+}
+```
+
+See `MENTAL_MODEL.md §1` for the full list of read-only entity types and
+required feedback messages.
+
+## References
+
+- ADR-008 — Mode transition state machine
+- ADR-011 — Service as entity factory (Controller must not call `new` on entities)
+- ADR-013 — Observable pattern (Controller↔Service event wiring)
+- `docs/ARCHITECTURE.md` — Layer dependency diagram
+- `docs/STATE_TRANSITIONS.md` — Mode transition diagram
+- `MENTAL_MODEL.md §1–2` — Mode transition and interaction rules

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,0 +1,40 @@
+# Core Layer — Shared Infrastructure Utilities
+
+**Responsibility**: Minimal, dependency-free utilities shared across all
+other layers.
+
+Files: `EventEmitter.js`
+
+---
+
+## Meta Model: Zero Dependencies
+
+Code in this layer **must have no imports** from any other `src/` layer or
+from external libraries. It is the innermost ring — nothing inside the project
+depends on nothing else inside the project.
+
+| Prohibited | Reason |
+|------------|--------|
+| `import` from `three` | Rendering concern — belongs in View. |
+| `import` from `src/domain/` or any other layer | Core must not depend inward. |
+| Async dispatch / wildcard events | Keep surface minimal; not needed in-process. |
+
+## EventEmitter
+
+A minimal synchronous publish/subscribe bus used to implement the Observable
+pattern (ADR-013) on `SceneService`.
+
+```js
+emitter.on('objectAdded', listener)   // subscribe
+emitter.off('objectAdded', listener)  // unsubscribe
+emitter.emit('objectAdded', obj)      // notify all listeners synchronously
+```
+
+All listeners are called synchronously and in registration order. There are no
+wildcard events, no async dispatch, and no error isolation between listeners —
+keep listeners lightweight and side-effect-free where possible.
+
+## References
+
+- ADR-013 — Observable / event-driven Controller↔Service wiring
+- `docs/ARCHITECTURE.md` — Layer dependency diagram

--- a/src/domain/README.md
+++ b/src/domain/README.md
@@ -2,7 +2,7 @@
 
 **Responsibility**: Represent business logic and domain entities.
 
-Files: `Cuboid.js`, `Sketch.js`, `ImportedMesh.js`
+Files: `Cuboid.js`, `Sketch.js`, `ImportedMesh.js`, `MeasureLine.js`
 
 ---
 
@@ -30,6 +30,7 @@ Domain depends on nothing. Every other layer depends on Domain.
 - `instanceof Sketch` = 2D, not yet extruded. Operations: `extrude(height)`, `rename(name)`
 - `instanceof Cuboid` = 3D. Operations: `move()`, `extrudeFace(face, ...)`, `rename(name)`
 - `instanceof ImportedMesh` = arbitrary triangle mesh (read-only geometry). Operations: `rename(name)` only
+- `instanceof MeasureLine` = two-point measurement annotation. Holds `p1`, `p2` (`THREE.Vector3`) and a `MeasureLineView`. Operations: none beyond display. Has **no** vertex/edge/face graph.
 - `Sketch.extrude()` must **not** mutate the Sketch — it returns a new `Cuboid`
 - Use `instanceof` for entity type dispatch; never use the `dimension` scalar
 

--- a/src/graph/README.md
+++ b/src/graph/README.md
@@ -1,0 +1,53 @@
+# Graph Layer — Geometric Topology Primitives
+
+**Responsibility**: Represent the topological elements (vertices, edges, faces)
+that make up the geometry of domain entities.
+
+Files: `Vertex.js`, `Edge.js`, `Face.js`
+
+---
+
+## Meta Model: Pure Data, Stable Identity
+
+Graph primitives are pure value objects with stable `id`s. They hold no
+rendering state and perform no side effects. They are owned exclusively by
+`Cuboid` (and `Sketch` for vertices).
+
+| Prohibited | Reason |
+|------------|--------|
+| `import` from `three` (except `Vector3` type hint) | Rendering concern — belongs in View. |
+| References to `SceneModel`, `SceneService`, or any View | Graph must not depend outward. |
+| Mutable `id` fields | IDs are the stable identity used for selection tracking. |
+
+## Ownership Contracts (ADR-012)
+
+```
+Cuboid.vertices : Vertex[8]   — 8 corners of the box
+Cuboid.edges    : Edge[12]    — 12 edges connecting pairs of vertices
+Cuboid.faces    : Face[6]     — 6 faces, each referencing 4 vertices in CCW order
+```
+
+`Sketch.vertices` holds the 4 corner `Vertex` objects of the 2D rectangle.
+`Sketch.edges` and `Sketch.faces` are not present — they exist only on `Cuboid`.
+
+`ImportedMesh` and `MeasureLine` have **no** vertex/edge/face graph. Any code
+that iterates selected objects and accesses `.corners`, `.edges`, or `.faces`
+must guard with `instanceof Cuboid` (or check `obj.faces != null`).
+
+## Element Summary
+
+| Class | Fields | Notes |
+|-------|--------|-------|
+| `Vertex` | `id`, `position: THREE.Vector3` | `position` is mutable; use `clone()` to snapshot |
+| `Edge` | `id`, `v0: Vertex`, `v1: Vertex` | References live `Vertex` objects — position changes propagate automatically |
+| `Face` | `id`, `vertices: Vertex[4]`, `name`, `index` | `get corners()` returns `Vector3[]` for compatibility with `CuboidModel` pure functions |
+
+`Face.index` is the 0-based position in `Cuboid.faces` (0–5). It is stored on
+the `Face` so callers can pass a `Face` object to methods that still accept an
+index (e.g. `MeshView.setFaceHighlight(face.index, ...)`).
+
+## References
+
+- ADR-012 — Graph-based geometry model (Phases 5-1 through 5-3)
+- `src/domain/README.md` — Entity capability contracts
+- `MENTAL_MODEL.md §1` — Entity capability contracts and `instanceof` guards


### PR DESCRIPTION
Add README.md to src/core, src/graph, and src/controller — the three
directories that were missing documentation. Update src/domain/README.md
to include MeasureLine.js in the file list and entity capability contracts.

Each README follows the established format: responsibility, meta model table,
key rules/contracts, and ADR references.

https://claude.ai/code/session_01RtU36KjyEFXQ8re8mNpFWm