### PR TITLE
docs: translate validation files to English and add server READMEs

### DIFF
--- a/docs/validation/2026-03-22-phase-c.md
+++ b/docs/validation/2026-03-22-phase-c.md
@@ -14,111 +14,111 @@
 | ADR | 1 missing ADR recommended | ℹ Info |
 | UX  | 2 (1 A11Y, 1 TOOLBAR) | ⚠ Pass with notes |
 
-全体として実装品質は良好。クリティカルな問題ゼロ、ハイ severity ゼロ。
-主な課題はドキュメント未更新と WebSocket 境界での入力検証不足。
+Overall implementation quality is good. Zero critical issues, zero high severity.
+Main issues are missing documentation updates and insufficient input validation at the WebSocket boundary.
 
 ---
 
 ## SQA — Software Quality Assurance
 
-### [MEDIUM] SceneService.js:144 — WebSocket ペイロードの配列検証なし
+### [MEDIUM] SceneService.js:144 — No array validation for WebSocket payload
 
-`_applyGeometryUpdate()` が受け取る `positions`/`normals`/`indices` を検証せずに
-`Float32BufferAttribute` へ渡している。サーバーが `null` / 非配列を送ると TypeError でクラッシュ。
+`_applyGeometryUpdate()` passes the received `positions`/`normals`/`indices` to
+`Float32BufferAttribute` without validation. If the server sends `null` or a non-array value, a TypeError crash occurs.
 
-- **違反ルール**: B (システム境界での入力検証)、C (エラーハンドリング)
-- **修正案**: `_applyGeometryUpdate` 冒頭に `Array.isArray(positions)` ガードを追加するか、`updateGeometryBuffers()` 呼び出しを try/catch で囲む
+- **Violated rule**: B (input validation at system boundaries), C (error handling)
+- **Fix**: Add an `Array.isArray(positions)` guard at the top of `_applyGeometryUpdate`, or wrap the `updateGeometryBuffers()` call in try/catch
 
-### [MEDIUM] SceneService.js:144 — objectId が null/undefined の場合にゴーストエンティティ生成
+### [MEDIUM] SceneService.js:144 — Ghost entity created when objectId is null/undefined
 
-WebSocket ペイロードの `objectId` が未定義の場合、`Import_undefined` という名前のエンティティが
-サイレントに SceneModel に登録される。
+When the WebSocket payload's `objectId` is undefined, an entity named `Import_undefined` is
+silently registered in SceneModel.
 
-- **違反ルール**: B (システム境界での入力検証)
-- **修正案**: `if (!objectId) return` を `_applyGeometryUpdate` の先頭に追加
+- **Violated rule**: B (input validation at system boundaries)
+- **Fix**: Add `if (!objectId) return` at the top of `_applyGeometryUpdate`
 
-### [LOW] OutlinerView.js:97 — resize リスナーの dispose なし
+### [LOW] OutlinerView.js:97 — resize listener not removed on dispose
 
-コンストラクタで `window.addEventListener('resize', ...)` を登録しているが、
-`dispose()` メソッドが存在しないためリスナーが永続化する。
+A `window.addEventListener('resize', ...)` is registered in the constructor, but no
+`dispose()` method exists, so the listener persists indefinitely.
 
-- **違反ルール**: D (イベントリスナーのライフサイクル対称性)
-- **修正案**: リスナー参照を保持し、`dispose()` で `removeEventListener` を呼ぶ
+- **Violated rule**: D (event listener lifecycle symmetry)
+- **Fix**: Store the listener reference and call `removeEventListener` in `dispose()`
 
 ---
 
 ## QC — Code Quality & Standards Compliance
 
-### [DOCS] docs/ARCHITECTURE.md:100 — SceneObject の説明が旧式
+### [DOCS] docs/ARCHITECTURE.md:100 — SceneObject description is outdated
 
-「A SceneObject is either a `Cuboid` or a `Sketch`」の記述が Phase C で obsolete になった。
-`ImportedMesh` が第三のエンティティ型として追加されている。
+The statement "A SceneObject is either a `Cuboid` or a `Sketch`" became obsolete in Phase C.
+`ImportedMesh` has been added as a third entity type.
 
-- **違反ルール**: I (設計決定のドキュメント更新)
-- **修正案**: SceneObject セクションに ImportedMesh を追記
+- **Violated rule**: I (documentation must reflect design decisions)
+- **Fix**: Add ImportedMesh to the SceneObject section
 
-### [DOCS] docs/ARCHITECTURE.md:12 — ファイルツリーに新ファイル未記載
+### [DOCS] docs/ARCHITECTURE.md:12 — New files missing from file tree
 
-`domain/ImportedMesh.js` と `view/ImportedMeshView.js` がファイルツリーに含まれていない。
+`domain/ImportedMesh.js` and `view/ImportedMeshView.js` are not listed in the file tree.
 
-- **違反ルール**: I
-- **修正案**: ツリーの該当層に2ファイルを追加
+- **Violated rule**: I
+- **Fix**: Add both files to their respective layers in the tree
 
-### [DDD] AppController.js:49 — objectAdded ハンドラの型判別が不完全
+### [DDD] AppController.js:49 — Incomplete type dispatch in objectAdded handler
 
-Sketch も Cuboid も `type = 'cuboid'` として OutlinerView に渡しているため、
-アウトライナーアイコンで Sketch と Cuboid が区別できない。
-Phase C の `'imported'` 型追加によって露呈した既存の問題。
+Both Sketch and Cuboid are passed to OutlinerView as `type = 'cuboid'`, so the outliner
+icon cannot distinguish between them.
+An existing issue made visible by the addition of the `'imported'` type in Phase C.
 
-- **違反ルール**: D (`instanceof` 型判別が不完全)
-- **修正案**: `instanceof Sketch` の分岐を追加して `type = 'sketch'` を渡す
+- **Violated rule**: D (incomplete `instanceof` type dispatch)
+- **Fix**: Add an `instanceof Sketch` branch to pass `type = 'sketch'`
 
 ---
 
 ## ADR — Architecture Decision Records
 
-### [推奨] ADR-018 — ImportedMesh thin-client エンティティ
+### [Recommended] ADR-018 — ImportedMesh thin-client entity
 
-Phase C は非自明かつ後から変えにくい設計選択を複数含むが ADR が存在しない。
+Phase C contains several non-obvious and hard-to-reverse design choices but has no ADR.
 
-**記録すべき内容:**
-1. なぜ ImportedMesh を Cuboid のフラグにせず別エンティティとするか
-2. Edit Mode 除外ポリシー（ローカルグラフなし → 編集不可）
-3. `geometry.update` 受信時のオートクリエイト戦略
-4. `instanceof ImportedMesh` によるADR-009型判別の拡張
+**What to record:**
+1. Why ImportedMesh is a separate entity rather than a flag on Cuboid
+2. Edit Mode exclusion policy (no local graph → non-editable)
+3. Auto-create strategy on receiving `geometry.update`
+4. Extension of ADR-009 type dispatch via `instanceof ImportedMesh`
 
-ROADMAP.md が Phase C の意図を記述しているが、型契約と編集除外ポリシーは
-将来の開発者向けに ADR として残す価値がある。
+ROADMAP.md documents the intent of Phase C, but the type contract and edit exclusion policy
+are worth preserving as an ADR for future developers.
 
 ---
 
 ## UX — User Experience & UI Consistency
 
-### [A11Y] OutlinerView.js:203 — アイコンが色のみで種別を表現
+### [A11Y] OutlinerView.js:203 — Icon conveys type by colour alone
 
-インポートメッシュのアウトライナーアイコン（⬡）が灰色のみで
-編集可/不可を区別している。スクリーンリーダーや色覚特性のあるユーザーには伝わらない。
+The outliner icon for imported meshes (⬡) uses grey colour alone to indicate read-only status.
+This is not perceivable by screen-reader users or users with colour vision deficiencies.
 
-- **違反ルール**: F (色のみの状態表現)
-- **修正案**: `iconEl` に `title="Read-only imported mesh"` を追加
+- **Violated rule**: F (state expressed by colour only)
+- **Fix**: Add `title="Read-only imported mesh"` to the `iconEl`
 
-### [TOOLBAR] AppController.js:49 — アウトライナーで Sketch と Cuboid のアイコンが同一
+### [TOOLBAR] AppController.js:49 — Sketch and Cuboid share the same outliner icon
 
-`objectAdded` ハンドラが Sketch を `type = 'cuboid'` として渡すため、
-Sketch 行が Cuboid と同じ青い ⬡ アイコンになる。
+The `objectAdded` handler passes Sketch as `type = 'cuboid'`, so Sketch rows display the
+same blue ⬡ icon as Cuboid rows.
 
-- **違反ルール**: A (モード間の視覚フィードバック一貫性)
-- **修正案**: `instanceof Sketch` チェックを追加し `type = 'sketch'` を渡す
+- **Violated rule**: A (consistent visual feedback across modes)
+- **Fix**: Add an `instanceof Sketch` check and pass `type = 'sketch'`
 
 ---
 
-## アクション優先度
+## Action Priority
 
-| 優先度 | 内容 | 難易度 |
-|--------|------|--------|
-| 🔴 P1 | `_applyGeometryUpdate` に `objectId` + `positions` 配列ガード追加 | 低 |
-| 🟡 P2 | `docs/ARCHITECTURE.md` を ImportedMesh 含む内容に更新 | 低 |
-| 🟡 P2 | `objectAdded` ハンドラに `type='sketch'` 分岐追加 | 低 |
-| 🟢 P3 | ADR-018 作成 (ImportedMesh thin-client contract) | 中 |
-| 🟢 P3 | OutlinerView アイコンに `title` 属性追加 (A11Y) | 低 |
-| 🔵 P4 | OutlinerView に `dispose()` 追加 (resize リスナー) | 低 |
+| Priority | Item | Effort |
+|----------|------|--------|
+| 🔴 P1 | Add `objectId` + `positions` array guard to `_applyGeometryUpdate` | Low |
+| 🟡 P2 | Update `docs/ARCHITECTURE.md` to include ImportedMesh | Low |
+| 🟡 P2 | Add `type='sketch'` branch to `objectAdded` handler | Low |
+| 🟢 P3 | Create ADR-018 (ImportedMesh thin-client contract) | Medium |
+| 🟢 P3 | Add `title` attribute to OutlinerView icon (A11Y) | Low |
+| 🔵 P4 | Add `dispose()` to OutlinerView (resize listener) | Low |

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -1,12 +1,12 @@
 # Validation Reports
 
-各フェーズ完了時に実施した SQA / QC / ADR / UX バリデーションの記録。
+Records of SQA / QC / ADR / UX validation runs conducted upon completion of each phase.
 
 ## Index
 
 | Date | Phase | SQA | QC | ADR | UX | Report |
 |------|-------|-----|----|-----|----|--------|
-| 2026-03-22 | BFF Phase C — ImportedMesh thin-client entity | 3 issues (0C/0H/2M/1L) | 3 issues | ADR-018 推奨 | 2 issues | [report](2026-03-22-phase-c.md) |
+| 2026-03-22 | BFF Phase C — ImportedMesh thin-client entity | 3 issues (0C/0H/2M/1L) | 3 issues | ADR-018 recommended | 2 issues | [report](2026-03-22-phase-c.md) |
 
 ## How to add a new report
 

--- a/server/src/db/README.md
+++ b/server/src/db/README.md
@@ -1,0 +1,47 @@
+# DB Layer — SQLite Database Setup
+
+**Responsibility**: Initialize the database connection and define the schema.
+
+Files: `database.js`
+
+---
+
+## Meta Model
+
+| Permitted | Prohibited |
+|-----------|------------|
+| Schema DDL (`CREATE TABLE IF NOT EXISTS`) | Business logic or query construction |
+| `PRAGMA` configuration | Calling service or route functions |
+| Exporting the `db` client instance | Direct use by routes (must go through `services/`) |
+
+This layer is the single source of truth for the connection handle.
+All other server layers that need DB access must import `db` from here.
+
+## Key Contracts
+
+- **Journal mode**: `PRAGMA journal_mode = WAL` **must** execute as a standalone `db.execute()` call *before* any `db.batch()`. Running it inside `batch()` causes a `LibsqlBatchError` (see MENTAL_MODEL §3.5).
+- **Schema migration**: DDL changes go in `db.batch()` after the PRAGMA call. Use `CREATE TABLE IF NOT EXISTS` to make startup idempotent.
+- **Data directory**: The database file is created at `server/data/scenes.db`. The directory is created automatically via `mkdirSync` at startup.
+
+## Schema
+
+```
+scenes
+  id          TEXT PRIMARY KEY
+  name        TEXT NOT NULL
+  data        TEXT NOT NULL        — JSON string (scene payload)
+  created_at  TEXT NOT NULL
+  updated_at  TEXT NOT NULL
+```
+
+The `data` column stores a JSON object with the shape:
+
+```json
+{
+  "objects": [],
+  "transformGraph": { "nodes": [], "edges": [] },
+  "operationGraph": { "nodes": [], "edges": [] }
+}
+```
+
+See ADR-015, ADR-016.

--- a/server/src/geometry/README.md
+++ b/server/src/geometry/README.md
@@ -1,0 +1,49 @@
+# Geometry Layer — Operation Graph & Evaluation
+
+**Responsibility**: Define the DAG data structure, evaluate geometry nodes in topological order,
+and encode results for transmission over WebSocket.
+
+Files: `geometryGraph.js`, `evaluator.js`, `nodeTypes.js`, `meshEncoder.js`
+
+---
+
+## Meta Model
+
+| Permitted | Prohibited |
+|-----------|------------|
+| Pure graph mutations and traversals | Any DB access |
+| Geometry computation (positions, normals, indices) | WebSocket or HTTP I/O |
+| Serialisation to / from plain JSON | Referencing Express or `ws` objects |
+
+All functions in this layer are **pure** (deterministic, no I/O side effects) except for
+`cachedGeometry` being written onto node objects (intentional mutable cache).
+
+## Files
+
+| File | Responsibility |
+|------|----------------|
+| `geometryGraph.js` | `OperationGraph` class — nodes, edges, cycle detection (DFS), topological sort, JSON serialisation |
+| `evaluator.js` | `evaluateGraph()` (full pass) and `evaluateSubgraph()` (incremental dirty-propagation) |
+| `nodeTypes.js` | Registry of node type handlers — each handler exposes `evaluate(node, inputs)` and `defaultParams` |
+| `meshEncoder.js` | `encodeGeometryUpdate()`, `encodeGraphSnapshot()` — encode geometry for WebSocket transport |
+
+## Key Contracts (ADR-017)
+
+- `OperationGraph.addEdge()` throws `CycleError` if the edge would create a cycle. Callers must catch this.
+- `evaluateGraph()` runs all nodes; `evaluateSubgraph(graph, changedNodeId)` marks the changed node and all its downstream dependants dirty, then re-evaluates only those nodes.
+- `node.cachedGeometry` is the mutable cache written by the evaluator. It is excluded from `toJSON()` serialisation.
+- `OperationGraph.fromJSON()` reconstructs a graph from a plain object (stored in the DB `data` column under `operationGraph`).
+
+## Node geometry format
+
+Every node handler's `evaluate()` returns:
+
+```js
+{
+  positions: number[],   // flat Float32 XYZ triples
+  normals:   number[],   // flat Float32 XYZ triples (same length as positions)
+  indices:   number[],   // triangle index triples
+}
+```
+
+An empty result (`positions.length === 0`) is excluded from the results map.

--- a/server/src/middleware/README.md
+++ b/server/src/middleware/README.md
@@ -1,0 +1,32 @@
+# Middleware Layer — HTTP Request Processing
+
+**Responsibility**: Cross-cutting concerns applied to incoming HTTP requests before they reach route handlers.
+
+Files: `auth.js`
+
+---
+
+## Meta Model
+
+| Permitted | Prohibited |
+|-----------|------------|
+| Inspecting and validating request headers | Business logic or DB access |
+| Attaching derived data to `req` (e.g. `req.user`) | Modifying response bodies directly (use `next(err)` instead) |
+| Short-circuiting with `res.status(4xx)` for auth failures | Calling geometry or scene store functions |
+
+## auth.js — JWT Authentication
+
+Phase A policy: requests without a token are accepted in development.
+Set `BFF_REQUIRE_AUTH=true` to enforce token validation.
+
+| Condition | Behaviour |
+|-----------|-----------|
+| No `Authorization` header, `BFF_REQUIRE_AUTH` is unset | Allowed; `req.user = { sub: 'anonymous', role: 'dev' }` |
+| No `Authorization` header, `BFF_REQUIRE_AUTH=true` | Rejected with `401 Unauthorised` |
+| Valid `Bearer <token>` | Allowed; `req.user` populated from JWT claims |
+| Invalid or expired token | Rejected with `401 Invalid token` |
+
+**Secret**: `JWT_SECRET` environment variable (default: `'easy-extrude-dev-secret'`).
+Override in production. A dev token is available from `GET /api/auth/token` (no credentials needed in Phase A).
+
+**Phase B plan**: Replace with proper user auth via a User Service.

--- a/server/src/routes/README.md
+++ b/server/src/routes/README.md
@@ -1,0 +1,54 @@
+# Routes Layer — REST API Endpoints
+
+**Responsibility**: Define Express route handlers for the BFF REST API.
+Translate HTTP requests into service calls and return JSON responses.
+
+Files: `scenes.js`, `auth.js`, `import.js`
+
+---
+
+## Meta Model
+
+| Permitted | Prohibited |
+|-----------|------------|
+| Parsing and validating request bodies | Direct DB queries (must go through `services/`) |
+| Calling `services/` functions | Geometry computation (must go through `geometry/`) |
+| Setting HTTP status codes and JSON bodies | Holding in-memory state across requests |
+
+Route handlers are thin. Business logic belongs in `services/`; geometry in `geometry/`.
+
+## Endpoints
+
+### scenes.js — mounted at `/api/scenes`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET`    | `/`      | List all scenes (id, name, timestamps) |
+| `POST`   | `/`      | Create a new scene |
+| `GET`    | `/:id`   | Get full scene (objects + transformGraph + operationGraph) |
+| `PUT`    | `/:id`   | Update scene (name and/or data payload) |
+| `DELETE` | `/:id`   | Delete scene |
+
+Scene `data` payload always contains `objects[]` and `transformGraph` (ADR-016).
+Missing fields are initialised to empty defaults on create and update.
+
+### auth.js — mounted at `/api/auth`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/token` | Issue a dev JWT (Phase A — no credentials required) |
+
+### import.js — mounted at `/api/import`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/step` | Parse an uploaded STEP file and return geometry buffers |
+
+The `/import/step` route is a REST alternative to the WebSocket `import.step` op.
+It uses `occt-import-js` for parsing (see MENTAL_MODEL §3.5 for geometry structure notes).
+
+## Validation rules
+
+- `name` must be a non-empty string on create; optional on update.
+- `data` must be a non-null object on create; optional on update.
+- `404` is returned when a scene id does not exist.

--- a/server/src/services/README.md
+++ b/server/src/services/README.md
@@ -1,0 +1,52 @@
+# Services Layer — Data Access
+
+**Responsibility**: All database read/write operations for scene persistence.
+Provides a typed async API over the raw `db` client.
+
+Files: `sceneStore.js`
+
+---
+
+## Meta Model
+
+| Permitted | Prohibited |
+|-----------|------------|
+| SQL queries via `db` from `db/database.js` | HTTP or WebSocket I/O |
+| JSON serialisation / deserialisation of scene data | Business logic or geometry computation |
+| Throwing structured errors on malformed data | Direct use of `req` / `res` objects |
+
+## sceneStore.js — Public API
+
+All functions are `async` and must be `await`ed by callers (see MENTAL_MODEL §3.5).
+
+| Function | Signature | Returns |
+|----------|-----------|---------|
+| `listScenes()` | `()` | `{ id, name, created_at, updated_at }[]` |
+| `getScene(id)` | `(string)` | `{ id, name, data, created_at, updated_at } \| null` |
+| `createScene({ id, name, data })` | `(object)` | `{ id, name, created_at, updated_at }` |
+| `updateScene(id, patch)` | `(string, { name?, data? })` | `{ id, name, updated_at } \| null` |
+| `deleteScene(id)` | `(string)` | `boolean` |
+
+## Key Contracts
+
+- `getScene()` returns `null` when the id is not found. Callers must check before use.
+- `getScene()` throws a structured `Error` (not a `SyntaxError`) when the stored `data` column is not valid JSON. Callers should propagate this as a `DB_ERROR` response.
+- `updateScene()` returns `null` when the id is not found. Callers must check before use.
+- `deleteScene()` returns `true` if the row was deleted, `false` if it did not exist.
+- The `data` field is a plain JavaScript object (parsed from JSON). Callers receive and supply objects, not strings.
+
+## Scene document shape
+
+```js
+{
+  objects: SceneObjectDTO[],       // serialised Cuboid / Sketch entities
+  transformGraph: {                // ADR-016
+    nodes: TransformNode[],
+    edges: TransformEdge[]
+  },
+  operationGraph: {                // ADR-017 (Phase B)
+    nodes: OperationNode[],
+    edges: OperationEdge[]
+  }
+}
+```

--- a/server/src/ws/README.md
+++ b/server/src/ws/README.md
@@ -1,0 +1,64 @@
+# WebSocket Layer — Session Management
+
+**Responsibility**: Manage per-connection WebSocket sessions, dispatch incoming messages to
+graph operation handlers, and stream geometry results back to clients.
+
+Files: `sessionManager.js`
+
+---
+
+## Meta Model
+
+| Permitted | Prohibited |
+|-----------|------------|
+| Creating and removing `Session` objects | Direct DB queries (must go through `services/`) |
+| Dispatching ops to geometry handlers | HTTP routing or Express middleware |
+| Calling `geometry/` functions for evaluation | Holding shared mutable state across sessions |
+
+Each session is isolated. Sessions do **not** share graph state.
+
+## Session Lifecycle
+
+```
+WebSocket connect  →  createSession(ws)    →  send session.ready
+                                           →  client sends session.resume
+WebSocket close    →  removeSession(id)
+```
+
+Sessions are stored in-memory only. All sessions are lost on BFF restart.
+Clients must reconnect and send `session.resume` to restore graph state from the DB.
+
+## WebSocket Protocol (ADR-017)
+
+### Client → Server (`op` field)
+
+| op | Payload | Description |
+|----|---------|-------------|
+| `session.resume` | `{ sceneId? }` | Resume or start a session; loads graph from DB if sceneId is provided |
+| `graph.node.add` | `{ node }` | Add a node to the operation graph |
+| `graph.node.remove` | `{ nodeId }` | Remove a node and its connected edges |
+| `graph.edge.add` | `{ edge }` | Connect two nodes; throws if it would create a cycle |
+| `graph.edge.remove` | `{ edgeId }` | Disconnect two nodes |
+| `graph.node.setParam` | `{ nodeId, param, value }` | Update a node parameter and re-evaluate downstream |
+| `import.step` | `{ jobId, filename, data: base64, scale? }` | Parse a STEP file and add it as a `stepImport` node |
+
+### Server → Client (`type` field)
+
+| type | Payload | Description |
+|------|---------|-------------|
+| `session.ready` | `{ sessionId }` | Sent immediately on connect |
+| `graph.snapshot` | `{ nodes, edges }` | Full graph state after `session.resume` |
+| `graph.node.add` | `{ node }` | Echo after a node is successfully added |
+| `graph.node.remove` | `{ nodeId }` | Echo after a node is removed |
+| `graph.edge.add` | `{ edge }` | Echo after an edge is added |
+| `graph.edge.remove` | `{ edgeId }` | Echo after an edge is removed |
+| `graph.node.setParam` | `{ nodeId, param, value }` | Echo after a param is updated |
+| `geometry.update` | `{ objectId, positions, normals, indices }` | Geometry buffers for a node |
+| `import.progress` | `{ jobId, percent, status }` | STEP import progress |
+| `error` | `{ code, message, requestOp }` | Structured error response |
+
+## Autosave
+
+After every mutating op, `_autosave(session)` fire-and-forgets a DB write of the current
+graph state back to the scene row. Errors are logged but never propagated to the client.
+See MENTAL_MODEL §3.5 for the async/await contract.


### PR DESCRIPTION
- Translate remaining Japanese text in docs/validation/README.md and
  docs/validation/2026-03-22-phase-c.md to English
- Add README.md to all six server/src subdirectories (db, geometry,
  middleware, routes, services, ws) following the same format as the
  client-side layer READMEs

https://claude.ai/code/session_015A6sP34jd7Gw6socLcgKS7