### PR TITLE
chore: update validation agent commands for ImportedMesh, MeasureLine, Stack, server-side async

### DIFF
--- a/.claude/commands/adr-validate.md
+++ b/.claude/commands/adr-validate.md
@@ -23,10 +23,14 @@ Only load the full text of relevant ADRs (to avoid unnecessary reads).
 |---|---|
 | `src/controller/AppController.js` | ADR-008, ADR-006, ADR-003 |
 | `src/domain/Cuboid.js`, `src/domain/Sketch.js` | ADR-009, ADR-010, ADR-012 |
+| `src/domain/ImportedMesh.js` | ADR-009, ADR-015 (read-only, no vertex graph) |
+| `src/domain/MeasureLine.js` | ADR-009, ADR-014 (not editable, no graph) |
 | `src/graph/Vertex.js`, `Edge.js`, `Face.js` | ADR-012 |
 | `src/model/SceneModel.js` | ADR-005, ADR-008, ADR-014 |
 | `src/service/SceneService.js` | ADR-011, ADR-013, ADR-015 |
 | `src/view/MeshView.js` | ADR-008 (visual state ownership) |
+| `src/view/ImportedMeshView.js` | ADR-008, ADR-015 |
+| `src/view/MeasureLineView.js` | ADR-008 (no-op interface completeness) |
 | `src/view/UIView.js` | ADR-002, ADR-004 |
 | `server/` | ADR-015, ADR-016, ADR-017 |
 | Any new modeling/geometry code | ADR-007 (cuboid representation, not voxel) |

--- a/.claude/commands/qc.md
+++ b/.claude/commands/qc.md
@@ -46,6 +46,10 @@ Read these before evaluating:
 - [ ] `Sketch.extrude()` returns a new `Cuboid` and does not mutate `Sketch` itself.
 - [ ] `SceneService.extrudeSketch()` is used for the entity swap (not direct `_objects` mutation).
 - [ ] `Cuboid` always exposes: `faces: Face[6]`, `edges: Edge[12]`, `move()`, `extrudeFace()`.
+- [ ] `ImportedMesh` has no `corners` / vertex graph; code that iterates selected objects and accesses `.corners` guards with `selObj.corners` or `instanceof ImportedMesh`.
+- [ ] `MeasureLine` holds `p1`/`p2` (`THREE.Vector3`) + `MeasureLineView`. It has no vertex/edge/face graph and must be excluded from `collectSnapTargets` and `_hitAnyObject` raycasting.
+- [ ] Edit Mode and Grab are blocked for both `ImportedMesh` and `MeasureLine`; blocks emit a toast before returning.
+- [ ] Every method called via `_meshView` in `AppController` exists as a no-op on `MeasureLineView` (see MENTAL_MODEL §1 — MeasureLineView No-Op Interface Completeness for the full required list).
 
 #### E. Event / Observable Contracts (ADR-013)
 
@@ -63,11 +67,26 @@ Read these before evaluating:
 - [ ] All mode changes go through `AppController.setMode(mode)`.
 - [ ] When switching active objects from Edit Mode, `setMode('object')` is called first.
 
-#### H. Vite / Build Config
+#### H. Mobile Toolbar Slots (MENTAL_MODEL §3)
+
+- [ ] Every mode exposes exactly **4 slots** (matching the widest mode, Edit 3D).
+
+| Mode | Slot 1 | Slot 2 | Slot 3 | Slot 4 |
+|------|--------|--------|--------|--------|
+| Object | Add | Edit | Delete | Stack |
+| Edit 2D sketch | ← Object | Extrude | *(spacer)* | *(spacer)* |
+| Edit 2D extrude | Confirm | Cancel | *(spacer)* | *(spacer)* |
+| Edit 3D | ← Object | Vertex | Edge | Face |
+| Grab active | Confirm | Stack | Cancel | *(spacer)* |
+
+- [ ] Slots that are absent for a given mode use `{ spacer: true }` (not conditional rendering), so toolbar width never changes.
+- [ ] Grab, Edit are disabled for `ImportedMesh` and `MeasureLine`. Delete remains enabled for all types.
+
+#### I. Vite / Build Config
 
 - [ ] `vite.config.js` `base` is `/easy-extrude/` — not changed to `/` or any other path.
 
-#### I. Documentation
+#### J. Documentation
 
 - [ ] New non-obvious design decisions have an ADR or reference an existing one.
 - [ ] `docs/adr/README.md` index is updated when a new ADR file is added.

--- a/.claude/commands/sqa.md
+++ b/.claude/commands/sqa.md
@@ -50,7 +50,23 @@ Use the Read tool on every identified file.
 
 - [ ] No off-by-one errors in index loops over `faces[6]` or `edges[12]`.
 - [ ] Geometry functions in `CuboidModel.js` are pure (no side effects, no `this`).
-- [ ] `instanceof` type guards match MENTAL_MODEL §1 contracts (`instanceof Sketch` = 2D, `instanceof Cuboid` = 3D).
+- [ ] `instanceof` type guards match MENTAL_MODEL §1 contracts (`instanceof Sketch` = 2D, `instanceof Cuboid` = 3D, `instanceof ImportedMesh` / `instanceof MeasureLine` = read-only).
+- [ ] Every code path that accesses `.corners` on a selected object guards with `selObj.corners` or `instanceof ImportedMesh` check — `ImportedMesh` has no vertex graph.
+- [ ] Every code path that calls `setMode('edit')` or `_startGrab()` for `ImportedMesh` / `MeasureLine` emits a `showToast('Imported geometry is read-only')` before returning.
+
+#### G. Server-Side Async (Node.js BFF) — MENTAL_MODEL §3.5
+
+- [ ] Every call to `sceneStore.getScene()`, `sceneStore.updateScene()`, `sceneStore.createScene()`, `sceneStore.deleteScene()` is `await`ed. Functions calling these are declared `async`.
+- [ ] Fire-and-forget wrappers (e.g. `_autosave`) are `async` and wrap all `await` calls in `try/catch`.
+- [ ] `PRAGMA journal_mode = WAL` is run as a standalone `await db.execute(...)` call, **not** inside `db.batch()`.
+- [ ] `JSON.parse(row.data)` in the DB layer is wrapped in `try/catch` and re-throws a structured error.
+- [ ] `occt-import-js` geometry is extracted at the mesh level (`mesh.attributes?.position?.array`), not at `mesh.faces[n].position` which is always `undefined`.
+- [ ] After `updateGeometryBuffers` for an `ImportedMesh`, `SceneView.fitCameraToSphere()` is triggered (via `geometryApplied` event) to prevent far-clip cutoff.
+
+#### H. Memory Management — WsChannel
+
+- [ ] In `WsChannel._connect()`, bound event handlers are stored as instance properties (`_onWsOpen`, `_onWsMessage`, `_onWsClose`, `_onWsError`).
+- [ ] In `WsChannel.close()`, all four handlers are removed via `removeEventListener` before `ws.close()` and `this._ws = null`.
 
 ### 4. Report findings
 

--- a/.claude/commands/ux.md
+++ b/.claude/commands/ux.md
@@ -21,13 +21,20 @@ Read these before evaluating:
 
 #### A. Mobile Toolbar Stability (MENTAL_MODEL §3)
 
-- [ ] Every mode shows a **fixed set of buttons** — no hiding buttons that should be `disabled`.
-  - Object mode: Add · Edit · Delete
-  - Edit 2D: ← Object · Extrude
-  - Edit 3D: ← Object · Vertex · Edge · Face
-  - Grab active: ✓ Confirm · ✕ Cancel
+- [ ] Every mode exposes exactly **4 slots** (matching the widest mode, Edit 3D). Missing slots use `{ spacer: true }` (not conditional rendering), so toolbar width never changes.
+
+| Mode | Slot 1 | Slot 2 | Slot 3 | Slot 4 |
+|------|--------|--------|--------|--------|
+| Object | Add | Edit | Delete | Stack |
+| Edit 2D sketch | ← Object | Extrude | *(spacer)* | *(spacer)* |
+| Edit 2D extrude | Confirm | Cancel | *(spacer)* | *(spacer)* |
+| Edit 3D | ← Object | Vertex | Edge | Face |
+| Grab active | Confirm | Stack | Cancel | *(spacer)* |
+
 - [ ] Buttons that are temporarily unavailable use `disabled: true`, not conditional rendering.
+- [ ] Grab and Edit are `disabled` for `ImportedMesh` and `MeasureLine`. Delete remains enabled for all types.
 - [ ] No layout shifts between mode transitions that would cause misclicks.
+- [ ] Object-mode Stack button pre-sets `_grab.stackMode` before a grab gesture. Grab active Stack button toggles `stackMode` mid-grab.`_startGrab()` does **not** reset `stackMode`, preserving the pre-set.
 
 #### B. Touch Event Handling (MENTAL_MODEL §2)
 
@@ -55,25 +62,42 @@ Read these before evaluating:
 - [ ] Numeric input (e.g. typing a distance during Grab) is clearly shown in the status bar.
 - [ ] `Escape` / right-click always cancels an in-progress operation with visible feedback.
 - [ ] Confirm (`Enter`) finalises the operation and returns to the previous mode.
+- [ ] Stack mode: **S** toggles it during grab (desktop); the Stack toolbar button toggles it on mobile (Object-mode pre-set and Grab-active mid-grab). Status bar shows stack indicator when `_grab.stacking` is true.
 
-#### F. Accessibility Basics
+#### F. Read-Only Entity Feedback
+
+- [ ] Attempting Grab (G key or touch-drag) on `ImportedMesh` or `MeasureLine` emits `showToast('Imported geometry is read-only')` before returning — the keypress must not be silently swallowed.
+- [ ] Attempting Edit Mode (Tab / E key) on `ImportedMesh` or `MeasureLine` emits the same toast. `e.preventDefault()` is called only when a real mode transition occurs (not for read-only blocks).
+
+#### G. MeasureLine / Measure Tool UX
+
+- [ ] **M key** and **Shift+A → Measure** start measure placement mode; status bar shows placement instructions.
+- [ ] Snap candidates (V/E/F snapping) are shown during measure pointer movement via `_measure.snapMeshView` (not `_meshView` of the active `MeasureLine`).
+- [ ] **Desktop**: click places p1; next click places p2 and confirms the measurement.
+- [ ] **Mobile** (hold-to-snap): `pointerdown` starts pressing (`_measure.pressing = true`); `pointerup` confirms the point — not `pointerdown`. Live snap feedback visible during the hold.
+- [ ] Distance label (amber) updates every animation frame via `MeasureLineView.updateLabelPosition(camera)`.
+- [ ] `_cancelMeasure()` clears `_measure.snapMeshView` and calls `clearSnapDisplay()` on it.
+
+#### H. Accessibility Basics
 
 - [ ] Interactive DOM elements (`button`, `input`) have discernible labels (text content or `aria-label`).
 - [ ] Focus is not lost unexpectedly when switching modes.
 - [ ] Colour alone is not the only indicator of state (e.g. selected vs unselected should also differ in shape or label).
 
-#### G. Keyboard Shortcuts (Desktop)
+#### I. Keyboard Shortcuts (Desktop)
 
 - [ ] Shift+A opens the Add menu.
-- [ ] G starts Grab; X/Y/Z constrain axis; Enter confirms; Escape / right-click cancels.
+- [ ] G starts Grab; X/Y/Z constrain axis; S toggles Stack during grab; Enter confirms; Escape / right-click cancels.
+- [ ] M key (or Shift+A → Measure) starts measure placement.
 - [ ] Tab cycles edit sub-modes in Edit 3D (Vertex / Edge / Face).
 - [ ] Shortcuts are surfaced in the status bar while the relevant operation is active.
 
-#### H. Visual Feedback Consistency
+#### J. Visual Feedback Consistency
 
 - [ ] Hovered faces highlight immediately on `pointermove` (desktop).
 - [ ] Selected sub-elements (vertices, edges, faces) have a distinct colour from hovered ones.
 - [ ] `setObjectSelected(true)` is restored when returning to Object mode from Edit mode (MENTAL_MODEL §1 — State Restoration on Mode Exit).
+- [ ] Measure distance label (amber) is visible and updates position every animation frame via `MeasureLineView.updateLabelPosition(camera)`.
 
 ### 5. Report findings
 
@@ -85,7 +109,7 @@ For each issue:
   Suggested fix: <one-line suggestion>
 ```
 
-Categories: **TOOLBAR** · **TOUCH** · **ORBIT** · **STATUS** · **GRAB** · **A11Y** · **KEYBOARD** · **VISUAL**
+Categories: **TOOLBAR** · **TOUCH** · **ORBIT** · **STATUS** · **GRAB** · **READONLY** · **MEASURE** · **A11Y** · **KEYBOARD** · **VISUAL**
 
 If no issues are found, output: `✓ UX: no issues found in <file list>`.
 


### PR DESCRIPTION
sqa.md
- Add §G Server-Side Async: DB await rules, PRAGMA outside batch, JSON.parse try/catch,
  occt-import-js mesh-level geometry extraction, fitCameraToSphere after import
- Add §H WsChannel: bound handler storage + removeEventListener on close
- Extend §F: ImportedMesh corners guard, read-only early-return toast contract

qc.md
- Extend DDD §D: ImportedMesh (no vertex graph), MeasureLine (no graph, excluded from
  snap/raycast), read-only toast contract, MeasureLineView no-op interface completeness
- Add §H Mobile Toolbar Slots: 4-slot table with Stack column, spacer rule,
  disabled-not-hidden contract for ImportedMesh/MeasureLine
- Rename old §H→§I Documentation

adr-validate.md
- Add file-pattern rows for ImportedMesh.js, MeasureLine.js, ImportedMeshView.js,
  MeasureLineView.js with governing ADRs

ux.md
- Expand §A toolbar to 4-slot table including Stack column; add Stack pre-set contract
- Add §E Stack mode row (S key, toolbar, status bar indicator)
- Add §F Read-Only Entity Feedback (toast + e.preventDefault guard)
- Add §G MeasureLine/Measure Tool UX (M key, snap via snapMeshView, hold-to-snap mobile,
  label per-frame update, _cancelMeasure cleanup)
- Rename §F→§H A11Y, §G→§I Keyboard (add M key, S grab), §H→§J Visual Feedback
- Add MeasureLineView label to §J
- Add READONLY/MEASURE categories to report format

https://claude.ai/code/session_01Q7i5Yex1Zccyp5njEpoUoh