### PR TITLE
Fix nested CoordinateFrame world position and connection line

### DIFF
--- a/docs/CODE_CONTRACTS.md
+++ b/docs/CODE_CONTRACTS.md
@@ -64,6 +64,7 @@ Detail: `docs/code_contracts/architecture.md`
 | CommandStack Clear After Init | Call `_commandStack.clear()` at the end of the constructor after `_addObject()` + `setMode()`; the auto-created initial solid must not appear in undo history |
 | Urban Placement Confirm No Auto-Select | `_confirmUrbanPlacement()` must NOT call `_switchActiveObject()` after creating the entity; previous selection is preserved and toolbar returns to initial object-mode slots |
 | Rect Selection Null Cuboid Guard | `_finalizeRectSelection()` must use `obj.meshView.cuboid?.visible` (optional chaining); Urban entities and CoordinateFrame return `null` for `.cuboid` and would throw TypeError without the guard |
+| CoordinateFrame.corners Is Local Space | `CoordinateFrame.corners` returns `[this.translation]` — a local offset, NOT a world position. `_updateWorldPoses()` and `createCoordinateFrame()` must branch on `parent instanceof CoordinateFrame` and use `_worldPoseCache` for the parent world position; using `parent.corners` as world space causes wrong nested-frame positions and connection lines anchored at world origin |
 
 ---
 

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -304,6 +304,39 @@ corresponding domain events — `objectRemoved` before the swap, `objectAdded` a
 
 ---
 
+### 21. Coordinate Spaces Are Statically Distinguished
+
+Every `Vector3` in the spatial computation layer belongs to exactly one coordinate space.
+The type system must enforce this — not documentation, not naming conventions, not code review.
+Mixing coordinate spaces produces wrong numeric results: valid JavaScript, no runtime exception,
+no stack trace. The bug is invisible until it manifests visually or physically.
+
+- **Local space** (`LocalVector3`): a position or offset expressed relative to a parent frame.
+  `CoordinateFrame.translation` and `CoordinateFrame.corners` are local space.
+- **World space** (`WorldVector3`): a position expressed in the scene's global coordinate system.
+  `Cuboid.corners`, `ImportedMesh.corners`, and every value in `_worldPoseCache` are world space.
+- Both are `THREE.Vector3` at runtime. Without branded types the compiler cannot distinguish them.
+
+**The failure mode is asymmetric and insidious**: geometry `corners` and frame `corners` share
+the same property name, the same JavaScript type, and the same shape — but their semantics are
+opposite. Code that works for geometry silently produces wrong results for frames.
+
+**Immediate measure**: branch on `instanceof CoordinateFrame` at every call site that reads
+`corners` for a spatial computation, and document the contract in CODE_CONTRACTS.
+
+**Permanent measure**: use JSDoc branded types so the type checker rejects misuse at compile time:
+
+```js
+/** @typedef {import('three').Vector3 & { _brand: 'world' }} WorldVector3 */
+/** @typedef {import('three').Vector3 & { _brand: 'local' }} LocalVector3 */
+```
+
+No runtime overhead. No TypeScript migration. `tsc --checkJs` enforces the distinction in CI.
+
+*Underlies CODE_CONTRACTS rules: CoordinateFrame.corners Is Local Space*
+
+---
+
 ## VIII. Living Documentation
 
 ### 19. Documentation Drift Is a Bug
@@ -357,3 +390,4 @@ For verification, give an agent a small named file list rather than `src/**/*.js
 | 18 | Emit the Event, Then Perform the Swap | Contracts | Entity Swap Emit |
 | 19 | Documentation Drift Is a Bug | Living Docs | CODE_CONTRACTS maintenance, ADR drift |
 | 20 | Narrow Focus Finds What Broad Scans Miss | Living Docs | DEVELOPMENT two-pass pattern |
+| 21 | Coordinate Spaces Are Statically Distinguished | Contracts | CoordinateFrame.corners Is Local Space |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -187,6 +187,61 @@ serializer) is complete.  The phases below cover the rendering and UI layers.
 
 ---
 
+## Coordinate Space Type Safety
+
+**Goal**: eliminate the class of bugs where `LocalVector3` is silently used where
+`WorldVector3` is required (or vice versa) by making the distinction enforceable at
+compile time. Root cause documented in PHILOSOPHY #21.
+
+**Root cause of the nested-frame bug (2026-04-07)**:
+`CoordinateFrame.corners` returns `[this.translation]` — a parent-relative local offset.
+Geometry `corners` return world-space positions. Both are `Vector3[]`. The spatial
+computation layer treated them uniformly, producing wrong world positions for nested frames
+and connection lines anchored at world origin.
+
+### Phase 1 — Hotfix ✅ *2026-04-07*
+
+| Task | Details |
+|------|---------|
+| `instanceof` branch in `_updateWorldPoses()` | For `CoordinateFrame` parents: read world position from `_worldPoseCache`; for geometry: compute centroid from `corners` as before |
+| `instanceof` branch in `createCoordinateFrame()` | Same branching for initial world position on frame creation |
+| CODE_CONTRACTS rule | "CoordinateFrame.corners Is Local Space" added to `architecture.md` and index |
+| PHILOSOPHY principle | #21 "Coordinate Spaces Are Statically Distinguished" added |
+
+### Phase 2 — Branded type annotations (JSDoc)
+
+**Approach**: JSDoc intersection types create compile-time brands with zero runtime overhead.
+`tsc --checkJs` enforces them without a TypeScript migration.
+
+| Task | Details |
+|------|---------|
+| Add branded type aliases | `src/types/spatial.js` — export `@typedef WorldVector3` and `LocalVector3` as branded `THREE.Vector3` intersections |
+| Annotate `corners` return types | `/** @returns {WorldVector3[]} */` on Cuboid, ImportedMesh, Sketch; `/** @returns {LocalVector3[]} */` on CoordinateFrame |
+| Annotate `_worldPoseCache` values | `{ position: WorldVector3, quaternion: THREE.Quaternion }` |
+| Annotate `_updateWorldPoses()` locals | `parentWorldPos: WorldVector3`, `worldPos: WorldVector3` |
+| Annotate `createCoordinateFrame()` locals | `initialWorldPos: WorldVector3` |
+| Wire `tsc --checkJs` into CI | Add `tsconfig.json` (`checkJs: true`, `strict: true`, `noEmit: true`); add `pnpm typecheck` script; CI step after build |
+
+**Expected outcome**: any future code that passes `frame.corners[0]` (LocalVector3) where
+a WorldVector3 is expected produces a type error at `pnpm typecheck` — caught before merge.
+
+### Phase 3 — Structural separation (long-term, after Phase 2)
+
+Evaluate whether `corners` should be split into semantically distinct interfaces so that
+the distinction is enforced by the API shape, not just by brands:
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Rename `CoordinateFrame.corners` → `localOffset` | Impossible to confuse with world-space `corners` | Breaking change to all call sites; grab uses `allStartCorners` keyed by id |
+| Split `IWorldGeometry` / `ILocalOffset` interfaces | Fully structural; IDE navigation is clear | Refactor scope is large; existing grab/undo machinery uses unified `corners` contract |
+| Keep unified `corners` + Phase 2 brands | Minimal change; already ships | Relies on JSDoc discipline; brands are advisory until `strict` mode is universal |
+
+**Decision gate**: revisit after Phase 2 is running in CI for ≥ 1 month.
+If brand violations are caught in practice, Phase 3 is worthwhile.
+If no violations appear, the brands alone may be sufficient.
+
+---
+
 ## Backlog (frontend features)
 
 | Priority | Item | Complexity | ADR / Notes |

--- a/docs/code_contracts/architecture.md
+++ b/docs/code_contracts/architecture.md
@@ -111,6 +111,32 @@ this._measure.snapMeshView = null
 - **No selection ring**: the orange wireframe selection sphere was removed. Selection state is conveyed solely by the depth override (arrows pop to the front when selected).
 - **Axis label sprites** (`_labelX/Y/Z`): `THREE.Sprite` with `CanvasTexture` bearing the letter in the axis colour. Positioned at `AXIS_LENGTH + 0.09` along each axis so the letter sits just past the arrowhead. Must be included in the `depthTest`/`renderOrder` loop and their `material.map` must be disposed in `dispose()`.
 
+## CoordinateFrame.corners Is Local Space, Not World Space
+
+- **Principle**: `corners` is overloaded across entity types. For geometry objects (Cuboid, ImportedMesh, Sketch) it returns world-space vertex positions. For `CoordinateFrame` it returns `[this.translation]` — a **parent-relative local offset** — NOT a world position.
+- **Concrete Rule**: Never pass `CoordinateFrame.corners` (or their centroid) to any computation that expects a world-space position. Specifically, `SceneService._updateWorldPoses()` and `SceneService.createCoordinateFrame()` must branch on `parent instanceof CoordinateFrame` and use `_worldPoseCache.get(parent.id).position` for the parent world position. Failing to branch causes nested frames to compute wrong world positions (missing grandparent contributions) and to display dashed connection lines anchored at the world origin instead of the parent frame's actual position.
+
+```js
+// ✓ Correct — use world pose cache for frame parents
+if (parent instanceof CoordinateFrame) {
+  const cached = this._worldPoseCache.get(parent.id)
+  parentWorldPos = cached.position          // true world position
+} else {
+  // geometry object — corners are world-space
+  const centroid = new Vector3()
+  for (const c of parent.corners) centroid.add(c)
+  centroid.divideScalar(parent.corners.length)
+  parentWorldPos = centroid
+}
+
+// ✗ Wrong — treats CoordinateFrame.corners as world-space; it is local-space
+const centroid = new Vector3()
+for (const c of parent.corners) centroid.add(c)   // parent.corners = [frame.translation] ← local!
+centroid.divideScalar(parent.corners.length)
+```
+
+- **Ordering dependency**: `_updateWorldPoses()` topologically sorts frames (shallow first) before the loop so that when a child frame is processed its parent's world pose is already in `_worldPoseCache`. This invariant must be preserved if the loop structure is ever changed.
+
 ## Auto Origin Frame on 3D Object Creation
 
 - **Principle**: Every 3D geometry object should have a visible origin coordinate frame so the user can immediately read its reference direction.

--- a/src/service/SceneService.js
+++ b/src/service/SceneService.js
@@ -644,14 +644,27 @@ export class SceneService extends EventEmitter {
 
     for (const frame of allFrames) {
       const parent = this._model.getObject(frame.parentId)
-      if (!parent || parent.corners.length === 0) continue
+      if (!parent) continue
 
-      // Compute parent centroid inline (parent.corners may be from any LocalGeometry type)
-      const parentCentroid = new Vector3()
-      for (const c of parent.corners) parentCentroid.add(c)
-      parentCentroid.divideScalar(parent.corners.length)
+      // Resolve parent world position.
+      // CoordinateFrame.corners returns [this.translation] — a local offset, not a world position.
+      // When the parent is a CoordinateFrame, use the world pose cache (already populated by the
+      // topological sort above). When the parent is a geometry object, derive its centroid from
+      // its world-space corners as before.
+      let parentWorldPos
+      if (parent instanceof CoordinateFrame) {
+        const cached = this._worldPoseCache.get(parent.id)
+        if (!cached) continue               // parent not yet resolved (shouldn't happen after sort)
+        parentWorldPos = cached.position
+      } else {
+        if (parent.corners.length === 0) continue
+        const centroid = new Vector3()
+        for (const c of parent.corners) centroid.add(c)
+        centroid.divideScalar(parent.corners.length)
+        parentWorldPos = centroid
+      }
 
-      const worldPos = parentCentroid.clone().add(frame.translation)
+      const worldPos = parentWorldPos.clone().add(frame.translation)
 
       // Update cache
       const entry = this._worldPoseCache.get(frame.id)
@@ -664,7 +677,7 @@ export class SceneService extends EventEmitter {
 
       // Update view
       frame.meshView.updatePosition(worldPos)
-      frame.meshView.updateConnectionLine(parentCentroid)
+      frame.meshView.updateConnectionLine(parentWorldPos)
     }
 
     // Re-resolve all anchored MeasureLine endpoints so they follow their
@@ -1207,15 +1220,26 @@ export class SceneService extends EventEmitter {
     const meshView = new CoordinateFrameView(this._threeScene)
     const frame    = new CoordinateFrame(id, name, parentObjectId, meshView)
 
-    // Initialise the world pose cache and visual position at parent centroid.
+    // Initialise the world pose cache and visual position at parent world position.
     // translation = (0,0,0) so the frame starts exactly at the parent origin.
-    const corners = parent.corners
-    if (corners.length > 0) {
-      const centroid = new Vector3()
-      for (const c of corners) centroid.add(c)
-      centroid.divideScalar(corners.length)
-      this._worldPoseCache.set(frame.id, { position: centroid.clone(), quaternion: frame.rotation })
-      meshView.updatePosition(centroid)
+    // When the parent is a CoordinateFrame its corners return a local offset, not a world
+    // position — use the world pose cache instead (mirrors _updateWorldPoses logic).
+    let initialWorldPos = null
+    if (parent instanceof CoordinateFrame) {
+      const cached = this._worldPoseCache.get(parent.id)
+      if (cached) initialWorldPos = cached.position.clone()
+    } else {
+      const corners = parent.corners
+      if (corners.length > 0) {
+        const centroid = new Vector3()
+        for (const c of corners) centroid.add(c)
+        centroid.divideScalar(corners.length)
+        initialWorldPos = centroid
+      }
+    }
+    if (initialWorldPos) {
+      this._worldPoseCache.set(frame.id, { position: initialWorldPos.clone(), quaternion: frame.rotation })
+      meshView.updatePosition(initialWorldPos)
     }
 
     this._model.addObject(frame)


### PR DESCRIPTION
CoordinateFrame.corners returns [this.translation] — a parent-relative
local offset — not a world-space position. _updateWorldPoses() and
createCoordinateFrame() were treating it as world space, causing two bugs:

1. (Visual) Dashed connection line from a child frame to its parent frame
   was anchored at the local translation offset instead of the parent's
   true world position — appearing to connect to world origin.

2. (Functional) When the grandparent geometry was grabbed/moved, nested
   frames were computed as (parent.translation + child.translation),
   missing the grandparent's contribution, so child frames were left
   behind at the wrong position.

Fix: branch on `parent instanceof CoordinateFrame` in both methods.
For frame parents, read the world position from _worldPoseCache (already
populated by the topological sort). For geometry parents, compute the
centroid from corners as before.

Add CODE_CONTRACTS rule: "CoordinateFrame.corners Is Local Space".

https://claude.ai/code/session_01D6A6jR3vTiJLzhQzuk9XhQ