### PR TITLE
feat: Coordinate Space Type Safety Phase 3 — structural API separation

### DIFF
--- a/docs/CODE_CONTRACTS.md
+++ b/docs/CODE_CONTRACTS.md
@@ -64,7 +64,7 @@ Detail: `docs/code_contracts/architecture.md`
 | CommandStack Clear After Init | Call `_commandStack.clear()` at the end of the constructor after `_addObject()` + `setMode()`; the auto-created initial solid must not appear in undo history |
 | Urban Placement Confirm No Auto-Select | `_confirmUrbanPlacement()` must NOT call `_switchActiveObject()` after creating the entity; previous selection is preserved and toolbar returns to initial object-mode slots |
 | Rect Selection Null Cuboid Guard | `_finalizeRectSelection()` must use `obj.meshView.cuboid?.visible` (optional chaining); Urban entities and CoordinateFrame return `null` for `.cuboid` and would throw TypeError without the guard |
-| CoordinateFrame.corners Is Local Space | `CoordinateFrame.corners` returns `[this.translation]` — a local offset, NOT a world position. `_updateWorldPoses()` and `createCoordinateFrame()` must branch on `parent instanceof CoordinateFrame` and use `_worldPoseCache` for the parent world position; using `parent.corners` as world space causes wrong nested-frame positions and connection lines anchored at world origin |
+| CoordinateFrame.localOffset vs Geometry.corners | `CoordinateFrame` exposes `localOffset` (LocalVector3[]); geometry exposes `corners` (WorldVector3[]). `.corners` does NOT exist on `CoordinateFrame`. Use `_grabHandlesOf(obj)` for grab/move; use `_worldPoseCache` for world position. (PHILOSOPHY #21 Phase 3) |
 
 ---
 

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -312,28 +312,35 @@ Mixing coordinate spaces produces wrong numeric results: valid JavaScript, no ru
 no stack trace. The bug is invisible until it manifests visually or physically.
 
 - **Local space** (`LocalVector3`): a position or offset expressed relative to a parent frame.
-  `CoordinateFrame.translation` and `CoordinateFrame.corners` are local space.
+  `CoordinateFrame.translation` and `CoordinateFrame.localOffset` are local space.
 - **World space** (`WorldVector3`): a position expressed in the scene's global coordinate system.
-  `Cuboid.corners`, `ImportedMesh.corners`, and every value in `_worldPoseCache` are world space.
+  `Solid.corners`, `ImportedMesh.corners`, and every value in `_worldPoseCache` are world space.
 - Both are `THREE.Vector3` at runtime. Without branded types the compiler cannot distinguish them.
 
-**The failure mode is asymmetric and insidious**: geometry `corners` and frame `corners` share
-the same property name, the same JavaScript type, and the same shape — but their semantics are
-opposite. Code that works for geometry silently produces wrong results for frames.
+**The failure mode is asymmetric and insidious**: when geometry `corners` and frame `corners`
+shared the same property name, the same JavaScript type, and the same shape — but their semantics
+were opposite — code that worked for geometry silently produced wrong results for frames.
 
-**Immediate measure**: branch on `instanceof CoordinateFrame` at every call site that reads
-`corners` for a spatial computation, and document the contract in CODE_CONTRACTS.
+**Phase 1 — Hotfix**: branch on `instanceof CoordinateFrame` at every call site.
 
-**Permanent measure**: use JSDoc branded types so the type checker rejects misuse at compile time:
+**Phase 2 — Branded types**: JSDoc `WorldVector3`/`LocalVector3` brands; `tsc --checkJs` in CI.
+No runtime overhead. No TypeScript migration. The type checker rejects misuse.
 
 ```js
 /** @typedef {import('three').Vector3 & { _brand: 'world' }} WorldVector3 */
 /** @typedef {import('three').Vector3 & { _brand: 'local' }} LocalVector3 */
 ```
 
-No runtime overhead. No TypeScript migration. `tsc --checkJs` enforces the distinction in CI.
+**Phase 3 — Structural separation** (the full expression of this principle):
+`CoordinateFrame` no longer has a `corners` property. It exposes `localOffset` instead.
+Accessing `.corners` on a frame returns `undefined` — the API shape itself makes confusion
+impossible, not just detectable. This is aligned with PHILOSOPHY #2 ("Type Is the Capability
+Contract"): a `CoordinateFrame` does not have world-geometry corners, and its API reflects that.
 
-*Underlies CODE_CONTRACTS rules: CoordinateFrame.corners Is Local Space*
+The `_grabHandlesOf(obj)` helper centralises the one remaining `instanceof` branch so all
+grab/move/undo code stays clean without scattered checks.
+
+*Underlies CODE_CONTRACTS rules: CoordinateFrame.localOffset vs Geometry.corners*
 
 ---
 
@@ -390,4 +397,4 @@ For verification, give an agent a small named file list rather than `src/**/*.js
 | 18 | Emit the Event, Then Perform the Swap | Contracts | Entity Swap Emit |
 | 19 | Documentation Drift Is a Bug | Living Docs | CODE_CONTRACTS maintenance, ADR drift |
 | 20 | Narrow Focus Finds What Broad Scans Miss | Living Docs | DEVELOPMENT two-pass pattern |
-| 21 | Coordinate Spaces Are Statically Distinguished | Contracts | CoordinateFrame.corners Is Local Space |
+| 21 | Coordinate Spaces Are Statically Distinguished | Contracts | CoordinateFrame.localOffset vs Geometry.corners |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -228,20 +228,27 @@ and connection lines anchored at world origin.
 a WorldVector3 is expected produces a type error at `pnpm typecheck` — caught before merge.
 `pnpm typecheck` is now a required CI gate on every push to main/master.
 
-### Phase 3 — Structural separation (long-term, after Phase 2)
+### Phase 3 — Structural separation ✅ *2026-04-07*
 
-Evaluate whether `corners` should be split into semantically distinct interfaces so that
-the distinction is enforced by the API shape, not just by brands:
+**Chosen option**: Rename `CoordinateFrame.corners` → `localOffset`.
 
-| Option | Pros | Cons |
-|--------|------|------|
-| Rename `CoordinateFrame.corners` → `localOffset` | Impossible to confuse with world-space `corners` | Breaking change to all call sites; grab uses `allStartCorners` keyed by id |
-| Split `IWorldGeometry` / `ILocalOffset` interfaces | Fully structural; IDE navigation is clear | Refactor scope is large; existing grab/undo machinery uses unified `corners` contract |
-| Keep unified `corners` + Phase 2 brands | Minimal change; already ships | Relies on JSDoc discipline; brands are advisory until `strict` mode is universal |
+Phase 2 enforces coordinate-space safety via the type checker (brands), but `CoordinateFrame.corners`
+still existed as a property — the API shape allowed confusion even if the type checker warned.
+Phase 3 eliminates the confusion at the **API level**: accessing `.corners` on a CoordinateFrame
+now returns `undefined`. No branch, no annotation, no code review can save incorrect code —
+the property simply does not exist.
 
-**Decision gate**: revisit after Phase 2 is running in CI for ≥ 1 month.
-If brand violations are caught in practice, Phase 3 is worthwhile.
-If no violations appear, the brands alone may be sufficient.
+This aligns with PHILOSOPHY #2 ("Type Is the Capability Contract") and the full intent of
+PHILOSOPHY #21 ("The type system must enforce this — **not documentation, not naming conventions,
+not code review**").
+
+| Task | Details |
+|------|---------|
+| Rename `CoordinateFrame.get corners()` → `get localOffset()` | Property name encodes semantics; accessing `.corners` on a frame returns `undefined` |
+| Add `_grabHandlesOf(obj)` helper in AppController | Single `instanceof` branch; all grab/move/cancel/undo paths use it |
+| Fix nested-frame N-panel bug | `onFramePositionChange` used `parent.corners` as world pos for CF parents — now uses `worldPoseOf()` |
+| Update `MoveCommand.js` | Add `CoordinateFrame` import + `localOffset` branch |
+| Update `spatial.js` | `LocalVector3` comment refers to `localOffset`, not `corners` |
 
 ---
 

--- a/docs/code_contracts/architecture.md
+++ b/docs/code_contracts/architecture.md
@@ -111,28 +111,31 @@ this._measure.snapMeshView = null
 - **No selection ring**: the orange wireframe selection sphere was removed. Selection state is conveyed solely by the depth override (arrows pop to the front when selected).
 - **Axis label sprites** (`_labelX/Y/Z`): `THREE.Sprite` with `CanvasTexture` bearing the letter in the axis colour. Positioned at `AXIS_LENGTH + 0.09` along each axis so the letter sits just past the arrowhead. Must be included in the `depthTest`/`renderOrder` loop and their `material.map` must be disposed in `dispose()`.
 
-## CoordinateFrame.corners Is Local Space, Not World Space
+## CoordinateFrame.localOffset vs Geometry.corners (PHILOSOPHY #21 Phase 3)
 
-- **Principle**: `corners` is overloaded across entity types. For geometry objects (Cuboid, ImportedMesh, Sketch) it returns world-space vertex positions. For `CoordinateFrame` it returns `[this.translation]` — a **parent-relative local offset** — NOT a world position.
-- **Concrete Rule**: Never pass `CoordinateFrame.corners` (or their centroid) to any computation that expects a world-space position. Specifically, `SceneService._updateWorldPoses()` and `SceneService.createCoordinateFrame()` must branch on `parent instanceof CoordinateFrame` and use `_worldPoseCache.get(parent.id).position` for the parent world position. Failing to branch causes nested frames to compute wrong world positions (missing grandparent contributions) and to display dashed connection lines anchored at the world origin instead of the parent frame's actual position.
+- **Principle**: Geometry entities (`Solid`, `ImportedMesh`, `Profile`, Urban*) expose `get corners()` returning `WorldVector3[]`. `CoordinateFrame` exposes `get localOffset()` returning `LocalVector3[]` — a single-element array wrapping `this.translation`. **`CoordinateFrame` has no `corners` property.** Accessing `.corners` on a frame returns `undefined`.
+- **Why distinct names**: Phase 2 added JSDoc brands to distinguish the types at compile time. Phase 3 eliminates the shared property name so the API shape itself enforces the distinction — no branch, no annotation, no code review can accidentally treat `localOffset` as world space (PHILOSOPHY #21 Phase 3, PHILOSOPHY #2).
+- **Grab / move**: use the `_grabHandlesOf(obj)` helper in `AppController.js` (returns `obj.localOffset` for frames, `obj.corners` for geometry). Do NOT call `.corners` on an object that might be a `CoordinateFrame`.
+- **World position of a frame**: always read from `SceneService._worldPoseCache.get(id).position`. Never compute from `localOffset`.
+- **`SceneService._updateWorldPoses()` and `createCoordinateFrame()`**: branch on `parent instanceof CoordinateFrame` to use the world pose cache for frame parents; use `parent.corners` centroid for geometry parents.
 
 ```js
-// ✓ Correct — use world pose cache for frame parents
+// ✓ Correct — use world pose cache for frame parents; corners for geometry
 if (parent instanceof CoordinateFrame) {
-  const cached = this._worldPoseCache.get(parent.id)
-  parentWorldPos = cached.position          // true world position
+  parentWorldPos = this._worldPoseCache.get(parent.id).position  // true world position
 } else {
-  // geometry object — corners are world-space
   const centroid = new Vector3()
-  for (const c of parent.corners) centroid.add(c)
+  for (const c of parent.corners) centroid.add(c)        // geometry corners = WorldVector3
   centroid.divideScalar(parent.corners.length)
   parentWorldPos = centroid
 }
 
-// ✗ Wrong — treats CoordinateFrame.corners as world-space; it is local-space
-const centroid = new Vector3()
-for (const c of parent.corners) centroid.add(c)   // parent.corners = [frame.translation] ← local!
-centroid.divideScalar(parent.corners.length)
+// ✓ Correct — grab handles (AppController)
+const handles = _grabHandlesOf(selObj)    // localOffset for CF; corners for geometry
+handles.forEach((c, i) => c.copy(saved[i]))
+
+// ✗ Wrong — parent.corners is undefined when parent is a CoordinateFrame
+const centroid = getCentroid(parent.corners)   // TypeError or wrong result
 ```
 
 - **Ordering dependency**: `_updateWorldPoses()` topologically sorts frames (shallow first) before the loop so that when a child frame is processed its parent's world pose is already in `_worldPoseCache`. This invariant must be preserved if the loop structure is ever changed.

--- a/src/command/MoveCommand.js
+++ b/src/command/MoveCommand.js
@@ -14,13 +14,18 @@
  *   Required for CoordinateFrame world-pose cache invalidation; optional otherwise.
  * @returns {{label: string, execute(): void, undo(): void}}
  */
+import { CoordinateFrame } from '../domain/CoordinateFrame.js'
+
 export function createMoveCommand(label, startCornersMap, endCornersMap, sceneModel, sceneService = null) {
   function apply(cornersMap) {
     for (const [id, corners] of cornersMap) {
       const obj = sceneModel.getObject(id)
       if (!obj) continue
-      obj.corners.forEach((c, i) => c.copy(corners[i]))
-      obj.meshView.updateGeometry(obj.corners)
+      // CoordinateFrame exposes localOffset (LocalVector3[]); geometry exposes corners (WorldVector3[]).
+      // Use the appropriate accessor — accessing .corners on a CoordinateFrame returns undefined (PHILOSOPHY #21 Phase 3).
+      const handles = (obj instanceof CoordinateFrame) ? obj.localOffset : obj.corners
+      handles.forEach((c, i) => c.copy(corners[i]))
+      obj.meshView.updateGeometry(handles)
       obj.meshView.updateBoxHelper()
       if (sceneService) sceneService.invalidateWorldPose(id)
     }

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -416,9 +416,15 @@ export class AppController {
       const frame = this._activeObj
       if (!(frame instanceof CoordinateFrame) || frame.name === 'Origin') return
       const parent = this._scene.getObject(frame.parentId)
-      if (!parent || parent.corners.length === 0) return
+      if (!parent) return
       const parentRot = (parent instanceof CoordinateFrame) ? parent.rotation : new THREE.Quaternion()
-      const parentCentroid = getCentroid(parent.corners)
+      // For a geometry parent: centroid from world-space corners.
+      // For a CoordinateFrame parent: world position from cache (localOffset is NOT world pos).
+      // (PHILOSOPHY #21 Phase 3 — CoordinateFrame.corners does not exist)
+      const parentCentroid = (parent instanceof CoordinateFrame)
+        ? (this._service.worldPoseOf(parent.id)?.position?.clone() ?? null)
+        : (parent.corners.length > 0 ? getCentroid(parent.corners) : null)
+      if (!parentCentroid) return
       // val is in parent's local space; convert to world-space translation
       const localPos = frame.translation.clone().applyQuaternion(parentRot.clone().conjugate())
       localPos[axis] = val
@@ -515,9 +521,12 @@ export class AppController {
     return this._scene.activeObject
   }
 
-  /** Returns the active object's corners array */
+  /** Returns the grab-handle array for the active object.
+   *  Geometry → world-space corners; CoordinateFrame → localOffset. */
   get _corners() {
-    return this._scene.activeObject?.corners ?? []
+    const obj = this._scene.activeObject
+    if (!obj) return []
+    return _grabHandlesOf(obj)
   }
 
   /** Returns the active object's MeshView */
@@ -2567,7 +2576,7 @@ export class AppController {
     this._grab.allStartCorners = new Map()
     for (const id of this._selectedIds) {
       const selObj = this._scene.getObject(id)
-      if (selObj) this._grab.allStartCorners.set(id, selObj.corners.map(c => c.clone()))
+      if (selObj) this._grab.allStartCorners.set(id, _grabHandlesOf(selObj).map(c => c.clone()))
     }
     // segmentStartCorners tracks the start of each individual drag segment (touch).
     // Initially identical to allStartCorners; re-snapshotted on each touch re-down.
@@ -2612,7 +2621,7 @@ export class AppController {
     const endCornersMap = new Map()
     for (const id of this._selectedIds) {
       const obj = this._scene.getObject(id)
-      if (obj) endCornersMap.set(id, obj.corners.map(c => c.clone()))
+      if (obj) endCornersMap.set(id, _grabHandlesOf(obj).map(c => c.clone()))
     }
     if (endCornersMap.size > 0) {
       const label = endCornersMap.size === 1 ? 'Move' : `Move ${endCornersMap.size} objects`
@@ -2642,8 +2651,9 @@ export class AppController {
     for (const [id, startCorners] of this._grab.allStartCorners) {
       const selObj = this._scene.getObject(id)
       if (selObj) {
-        startCorners.forEach((c, i) => selObj.corners[i].copy(c))
-        selObj.meshView.updateGeometry(selObj.corners)
+        const handles = _grabHandlesOf(selObj)
+        startCorners.forEach((c, i) => handles[i].copy(c))
+        selObj.meshView.updateGeometry(handles)
         selObj.meshView.updateBoxHelper()
       }
     }
@@ -2875,7 +2885,7 @@ export class AppController {
     for (const id of this._selectedIds) {
       const selObj = this._scene.getObject(id)
       if (selObj) {
-        selObj.meshView.updateGeometry(selObj.corners)
+        selObj.meshView.updateGeometry(_grabHandlesOf(selObj))
         selObj.meshView.updateBoxHelper()
       }
     }
@@ -3739,7 +3749,7 @@ export class AppController {
           this._grab.segmentStartCorners = new Map()
           for (const id of this._selectedIds) {
             const selObj = this._scene.getObject(id)
-            if (selObj) this._grab.segmentStartCorners.set(id, selObj.corners.map(c => c.clone()))
+            if (selObj) this._grab.segmentStartCorners.set(id, _grabHandlesOf(selObj).map(c => c.clone()))
           }
           this._grab.startCorners = this._corners.map(c => c.clone())
           const grabCenter = (this._activeObj instanceof CoordinateFrame)
@@ -3909,7 +3919,10 @@ export class AppController {
         this._objDragAllStartCorners = new Map()
         for (const id of this._selectedIds) {
           const selObj = this._scene.getObject(id)
-          if (selObj?.corners) this._objDragAllStartCorners.set(id, selObj.corners.map(c => c.clone()))
+          // CoordinateFrame uses localOffset (not corners); exclude it from mouse-drag
+          // (frames are moved via G-key grab only — PHILOSOPHY #21 Phase 3).
+          if (selObj && !(selObj instanceof CoordinateFrame))
+            this._objDragAllStartCorners.set(id, selObj.corners.map(c => c.clone()))
         }
 
         this._objDragging      = true
@@ -4491,6 +4504,24 @@ export class AppController {
 }
 
 // ── Module-level helpers ──────────────────────────────────────────────────────
+
+/**
+ * Returns the mutable handle array used by the grab / move system.
+ *
+ * - Geometry entities (Solid, Profile, MeasureLine, ImportedMesh, Urban*):
+ *   `obj.corners` — WorldVector3[], positions in world space.
+ * - CoordinateFrame: `obj.localOffset` — LocalVector3[], the translation offset
+ *   relative to the parent centroid.
+ *
+ * Using `.corners` on a CoordinateFrame returns undefined (PHILOSOPHY #21 Phase 3).
+ * This helper centralises the branching so call sites stay clean.
+ *
+ * @param {object} obj  scene entity
+ * @returns {import('three').Vector3[]}
+ */
+function _grabHandlesOf(obj) {
+  return (obj instanceof CoordinateFrame) ? obj.localOffset : obj.corners
+}
 
 /**
  * Returns 8 AABB corners for objects that don't have a `corners` property

--- a/src/domain/CoordinateFrame.js
+++ b/src/domain/CoordinateFrame.js
@@ -40,7 +40,7 @@
  *   World pose: SceneService._worldPoseCache[id].position = parentCentroid + translation
  *
  * ─── Grab / move mechanics ───────────────────────────────────────────────────
- *   `get corners()` returns `[this.translation]` — a single-element array.
+ *   `get localOffset()` returns `[this.translation]` — a single-element array.
  *   The grab system saves `[translation.clone()]` at grab-start; on cancel it
  *   restores `translation.copy(saved)`. SceneService._updateWorldPoses() then
  *   recomputes the correct world position from the restored translation.
@@ -48,6 +48,11 @@
  *   NOTE: The drag plane center in AppController._startGrab() must use
  *   SceneService.worldPoseOf(frame.id).position (not translation) so the plane
  *   passes through the frame's actual world position.
+ *
+ *   NOTE: CoordinateFrame intentionally does NOT have a `corners` property.
+ *   Geometry entities expose `corners` (WorldVector3[]); CoordinateFrame exposes
+ *   `localOffset` (LocalVector3[]) — distinct names enforce the semantic
+ *   distinction at the API level (PHILOSOPHY #21, Phase 3).
  *
  * ─── Capability matrix ───────────────────────────────────────────────────────
  *   Edit Mode:         blocked (no vertex graph)
@@ -101,21 +106,22 @@ export class CoordinateFrame {
    * to the frame's mutable translation vector.
    *
    * Used by the grab system for save/restore (cancel restores translation):
-   *  - `startCorners = corners.map(c => c.clone())` saves [translation.clone()]
-   *  - `move(startCorners, delta)` updates translation in-place
-   *  - Cancel: `corners[0].copy(saved)` = `translation.copy(saved)` ✓
+   *  - `startHandles = localOffset.map(c => c.clone())` saves [translation.clone()]
+   *  - `move(startHandles, delta)` updates translation in-place
+   *  - Cancel: `localOffset[0].copy(saved)` = `translation.copy(saved)` ✓
    *
-   * NOTE: getCentroid(corners) = translation, not world position.
-   * AppController._startGrab() special-cases CoordinateFrame to use
-   * SceneService.worldPoseOf(id).position for the drag plane center.
+   * NOTE: getCentroid(localOffset) = translation, NOT world position.
+   * AppController._startGrab() uses SceneService.worldPoseOf(id).position
+   * for the drag plane center.
    *
    * CONTRACT: returns LocalVector3 (local offset from parent), NOT WorldVector3.
-   * Any spatial computation layer reading corners must branch on instanceof CoordinateFrame
-   * and use _worldPoseCache instead (see PHILOSOPHY #21, CODE_CONTRACTS architecture.md).
+   * Distinct property name (`localOffset`, not `corners`) enforces the semantic
+   * distinction at the API level — accessing `.corners` on a CoordinateFrame
+   * returns undefined (PHILOSOPHY #21 Phase 3, CODE_CONTRACTS architecture.md).
    *
    * @returns {[import('../types/spatial.js').LocalVector3]}
    */
-  get corners() { return /** @type {[import('../types/spatial.js').LocalVector3]} */ ([this.translation]) }
+  get localOffset() { return /** @type {[import('../types/spatial.js').LocalVector3]} */ ([this.translation]) }
 
   /**
    * Translates the frame by `delta` from its grab-start translation.
@@ -125,10 +131,10 @@ export class CoordinateFrame {
    * SceneService._updateWorldPoses() picks up the updated translation on the
    * next frame and recomputes the world pose in the cache.
    *
-   * @param {[Vector3]} startCorners  saved [translation] at grab start
-   * @param {Vector3}   delta         world-space movement vector
+   * @param {[Vector3]} startLocalOffset  saved [translation] at grab start
+   * @param {Vector3}   delta             world-space movement vector
    */
-  move(startCorners, delta) {
-    this.translation.copy(startCorners[0]).add(delta)
+  move(startLocalOffset, delta) {
+    this.translation.copy(startLocalOffset[0]).add(delta)
   }
 }

--- a/src/service/SceneService.js
+++ b/src/service/SceneService.js
@@ -647,10 +647,10 @@ export class SceneService extends EventEmitter {
       if (!parent) continue
 
       // Resolve parent world position.
-      // CoordinateFrame.corners returns [this.translation] — a LocalVector3 offset, not a WorldVector3.
+      // CoordinateFrame exposes `localOffset` (LocalVector3), NOT `corners`.
       // When the parent is a CoordinateFrame, use the world pose cache (already populated by the
       // topological sort above). When the parent is a geometry object, derive its centroid from
-      // its world-space corners as before (PHILOSOPHY #21, CODE_CONTRACTS architecture.md).
+      // its world-space corners as before (PHILOSOPHY #21 Phase 3, CODE_CONTRACTS architecture.md).
       /** @type {import('../types/spatial.js').WorldVector3|null} */
       let parentWorldPos = null
       if (parent instanceof CoordinateFrame) {
@@ -1225,9 +1225,9 @@ export class SceneService extends EventEmitter {
 
     // Initialise the world pose cache and visual position at parent world position.
     // translation = (0,0,0) so the frame starts exactly at the parent origin.
-    // When the parent is a CoordinateFrame its corners return a LocalVector3 offset, not a
-    // WorldVector3 — use the world pose cache instead (mirrors _updateWorldPoses logic,
-    // PHILOSOPHY #21, CODE_CONTRACTS architecture.md).
+    // CoordinateFrame exposes `localOffset` (LocalVector3), NOT `corners`.
+    // When the parent is a CoordinateFrame, use the world pose cache instead
+    // (mirrors _updateWorldPoses logic, PHILOSOPHY #21 Phase 3, CODE_CONTRACTS architecture.md).
     /** @type {import('../types/spatial.js').WorldVector3|null} */
     let initialWorldPos = null
     if (parent instanceof CoordinateFrame) {

--- a/src/types/spatial.js
+++ b/src/types/spatial.js
@@ -26,7 +26,7 @@
 /**
  * A THREE.Vector3 expressed relative to a parent frame's world position.
  * - CoordinateFrame.translation
- * - CoordinateFrame.corners  (returns [this.translation])
+ * - CoordinateFrame.localOffset  (returns [this.translation])
  *
  * Passing a LocalVector3 where a WorldVector3 is expected (or vice versa)
  * produces a tsc type error at `pnpm typecheck`.


### PR DESCRIPTION
CoordinateFrame.corners → localOffset (PHILOSOPHY #21 Phase 3)

The shared `corners` property name was the root cause of the 2026-04-07
nested-frame bug: geometry corners are WorldVector3[], frame corners were
LocalVector3[], but they looked identical to every call site.

Phase 2 added JSDoc brands so `tsc --checkJs` could detect misuse.
Phase 3 eliminates the ambiguous API: CoordinateFrame no longer has a
`corners` property. Accessing `.corners` on a frame returns undefined.
No annotation, no discipline, no code review can silently confuse
localOffset with world-space corners — the API shape makes it impossible.

Changes:
- CoordinateFrame.get corners() → get localOffset() (LocalVector3[])
- CoordinateFrame.move() param startCorners → startLocalOffset
- Add _grabHandlesOf(obj) helper in AppController.js:
  returns obj.localOffset for CoordinateFrame, obj.corners for geometry;
  all grab/move/cancel/undo paths use it
- MoveCommand.js: add instanceof CoordinateFrame branch for localOffset
- Fix nested-frame N-panel bug: onFramePositionChange used parent.corners
  as world centroid for CF parents — now uses worldPoseOf() (was wrong
  even before Phase 3, now forced visible as TypeError without fix)
- Update SceneService.js comments; _updateWorldPoses / createCoordinateFrame
  instanceof branches were already correct (Phase 1 fix) — no logic change
- Update spatial.js LocalVector3 comment
- ROADMAP Phase 3 marked ✅; CODE_CONTRACTS rule renamed;
  PHILOSOPHY #21 updated to document the three-phase arc

Verified: pnpm typecheck (clean), pnpm vite build (✓ 58 modules)

https://claude.ai/code/session_01XBDp8ALgu1doVik5PhAF9W