### PR TITLE
feat: replace Urban 3D placement with 2D Map Mode (orthographic top-down)

### DIFF
--- a/docs/SCREEN_DESIGN.md
+++ b/docs/SCREEN_DESIGN.md
@@ -471,54 +471,95 @@ G = Grab   X = Delete   Lynch class: Node / Landmark
 
 ---
 
-### S-14: Urban Placement — UrbanPolyline
+### S-14: 2D Map Mode — No Active Tool (Pan / Zoom)
 
-Entered via Add menu → "Urban Path" or "Urban Edge".
+Entered from the **Map** button in the header or from the mobile toolbar of a selected Urban entity.
 
-#### [C] 3D Viewport
-- Already-placed vertices shown as small circles connected by preview line
-- Cursor snaps to nearest geometry (V/E/F snap, same as Measure tool)
-- Mouse hover shows candidate next vertex
+#### [C] Viewport (Orthographic Top-Down)
+- Full-screen orthographic camera looking straight down along −Z
+- Existing 3D objects and Urban entities visible from above
+- Ground-plane grid visible
+- OrbitControls disabled; custom 2D pan/zoom active
 
-#### [D] N Panel
-- Vertex count: live counter
+#### [G] Left Map Toolbar (desktop)
+| Button | Color | Tooltip |
+|--------|-------|---------|
+| ⟿ (Path) | #4A90D9 | Path (Linear) |
+| ⟿ (Edge) | #E74C3C | Edge (Boundary) |
+| ⬡ (District) | #27AE60 | District (Area) |
+| ⬤ (Node) | #F39C12 | Node (Junction) |
+| ⬤ (Landmark) | #9B59B6 | Landmark (Point) |
+| ← | #aaa | Exit Map Mode |
+
+All type buttons toggle the active drawing tool.
 
 #### [E] Status Bar
 ```
-Click to add point. Enter / RMB = confirm. Escape = cancel.
+Map Mode — select a Lynch type on the left to start drawing
 ```
 
-#### [F] Mobile Toolbar
-| Slot | Button | State |
-|------|--------|-------|
-| 1 | Confirm | enabled (≥ 2 vertices) |
-| 2 | Undo pt | enabled |
-| 3 | (spacer) | — |
-| 4 | Cancel | enabled |
+#### [F] Mobile Toolbar (1 slot used)
+| Slot | Button |
+|------|--------|
+| 1 | ← Exit Map |
+| 2–4 | (spacers) |
+
+#### Interaction
+| Input | Action |
+|-------|--------|
+| Left-drag (no tool) | Pan camera |
+| Middle-drag | Pan camera |
+| Scroll wheel | Zoom in/out (frustumSize ±15%) |
+| ESC (no tool) | Exit map mode |
 
 ---
 
-### S-15: Urban Placement — UrbanPolygon
+### S-15: 2D Map Mode — Drawing (Polyline / Polygon)
 
-#### [C] 3D Viewport
-- Vertices + preview ring; auto-close highlight when hovering near first vertex
+Active when a Path, Edge, or District tool is selected in the map toolbar.
+
+#### [C] Viewport
+- Cursor dot (Lynch color) follows mouse
+- Preview line connects confirmed vertices to cursor
+- Polygon: preview ring closes when cursor is near first vertex (< 20 px)
+
+#### [G] Left Map Toolbar
+- Active type button highlighted with Lynch color border
+- Confirm button (✓, green) shown when ≥ 2 pts (polyline) or ≥ 3 pts (polygon)
+- Cancel button (✕, red) shown while drawing
 
 #### [E] Status Bar
 ```
-Click to add point. Click first point / Enter = close. Escape = cancel.
+[Type]  N pts  click to add  Enter / RMB = confirm   ESC cancel
 ```
+
+#### Interaction
+| Input | Action |
+|-------|--------|
+| Left-click | Add vertex |
+| Click near first vertex (polygon ≥ 3 pts) | Confirm and close polygon |
+| Enter / RMB (≥ 2 pts polyline, ≥ 3 pts polygon) | Confirm shape |
+| ESC | Cancel drawing (stay in map mode) |
+
+After confirmation the entity is created with the Lynch class matching the tool type.
+The same tool remains active for rapid repeated placement.
 
 ---
 
-### S-16: Urban Placement — UrbanMarker
+### S-16: 2D Map Mode — Drawing (Marker)
 
-#### [C] 3D Viewport
-- Single marker preview follows cursor (snaps to geometry)
+Active when Node or Landmark tool is selected.
+
+#### [C] Viewport
+- Cursor dot follows mouse in Lynch color
 
 #### [E] Status Bar
 ```
-Click to place marker. Escape = cancel.
+[Type]  Click to place.   ESC cancel
 ```
+
+#### Interaction
+Single left-click places the marker immediately; the tool remains active.
 
 ---
 

--- a/docs/STATE_TRANSITIONS.md
+++ b/docs/STATE_TRANSITIONS.md
@@ -7,16 +7,21 @@ See ADR-008 for implementation details.
 
 ## Top-level Modes
 
-A two-state machine held in `SceneModel.selectionMode`.
-
 ```
                     Tab
   ┌─────────────────────────────────────────────────┐
   |                                                 |
   v                                                 |
 OBJECT MODE  ──────────────────────────────> EDIT MODE
+  |     |                                           |
+  |     | Map button / _enterMapMode()              | (dispatches on active object dimension)
+  |     v                                           |
+  |  MAP MODE  (orthographic top-down camera)       |
+  |     |                                           |
+  |     | Escape (no tool) / Exit Map button        |
+  |     | _exitMapMode() → OBJECT MODE              |
   |                                                 |
-  | Shift+A → Add Box                               | (dispatches on active object dimension)
+  | Shift+A → Add Box                               |
   |   → _addObject('box') → OBJECT MODE             |
   |                                                 |
   | Shift+A → Add Sketch                            |
@@ -25,6 +30,39 @@ OBJECT MODE  ──────────────────────�
   | X / Delete (selected)                           |
   |   → _deleteObject() → OBJECT MODE               |
   └─────────────────────────────────────────────────┘
+```
+
+### Map Mode (2D Urban Modeling)
+
+`_mapMode.active = true` — orthographic top-down camera; OrbitControls disabled.
+`_mapMode.tool` — the Lynch type currently being drawn, or `null` (pan-only).
+
+```
+OBJECT MODE
+    |
+    Map button header click → _enterMapMode()
+    |
+    v
+MAP MODE  (_mapMode.active = true)
+    |
+    ├─ No tool active
+    │    Left-drag (or middle-drag) → pan camera (XY)
+    │    Scroll wheel               → zoom (frustumSize ±15%)
+    │    ESC → _exitMapMode() → OBJECT MODE
+    │
+    ├─ Click Lynch type in left toolbar → _setMapTool(type)
+    │       |
+    │       v
+    │   DRAWING  (_mapMode.tool set, _mapMode.points accumulate)
+    │       |
+    │       ├─ Click (marker)     → immediate confirm → DRAWING (same tool)
+    │       ├─ Click (polyline/polygon) → add vertex
+    │       ├─ Enter / RMB (≥2 pts polyline, ≥3 pts polygon) → _mapConfirmDrawing()
+    │       ├─ Click near first vertex (polygon, ≥3 pts)      → _mapConfirmDrawing()
+    │       ├─ _mapConfirmDrawing() → create entity, keep tool active
+    │       └─ ESC → _mapCancelDrawing() → MAP MODE (no tool)
+    │
+    └─ Exit Map button / ESC (no tool) → _exitMapMode() → OBJECT MODE
 ```
 
 ---
@@ -311,6 +349,7 @@ App state                   Toolbar buttons (→ always the same count)
 ──────────────────────────────────────────────────────────────────────────
 grab.active                 [✓ Confirm]  [✕ Cancel]
 faceExtrude.active          [✓ Confirm]  [✕ Cancel]
+mapMode.active              [← Exit Map]  (left-side map toolbar handles drawing)
 ──────────────────────────────────────────────────────────────────────────
 Object Mode                 [+ Add]  [Edit*]  [Delete*]
   * disabled if no selection

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -38,14 +38,14 @@ import { createDeleteCommand }        from '../command/DeleteCommand.js'
 import { createRenameCommand }        from '../command/RenameCommand.js'
 import { createFrameRotateCommand }   from '../command/FrameRotateCommand.js'
 import { createSetIfcClassCommand }   from '../command/SetIfcClassCommand.js'
-import { createSetLynchClassCommand } from '../command/SetLynchClassCommand.js'
+import { createSetLynchClassCommand } from '../command/SetLynchClassCommand.js' // N-panel Lynch class change (post-hoc push)
 import { createReparentFrameCommand } from '../command/ReparentFrameCommand.js'
 import { downloadSceneJson }          from '../service/SceneExporter.js'
 import { parseImportJson }            from '../service/SceneImporter.js'
 import { UrbanPolyline } from '../domain/UrbanPolyline.js'
 import { UrbanPolygon }  from '../domain/UrbanPolygon.js'
 import { UrbanMarker }   from '../domain/UrbanMarker.js'
-import { getLynchClassesByGeometry, getLynchClassEntry } from '../domain/LynchClassRegistry.js'
+import { getLynchClassEntry } from '../domain/LynchClassRegistry.js'
 
 export class AppController {
   /**
@@ -176,21 +176,27 @@ export class AppController {
       snapMeshView: null,
     }
 
-    // ── Urban entity placement state (ADR-026) ────────────────────────────
-    // 'type': 'path' | 'edge' | 'district' | 'node' | 'landmark'
-    // lynchClassMap for placement type → Lynch class name
-    this._urbanPlacement = {
-      active:  false,
-      /** @type {'path'|'edge'|'district'|'node'|'landmark'|null} */
-      type:    null,
-      /** @type {THREE.Vector3[]} confirmed vertices */
-      points:  [],
-      /** @type {THREE.Vector3|null} live cursor position (ground-plane pick) */
-      cursor:  null,
-      /** Preview line object (THREE.Line) shown while placing */
+    // ── 2D Map Mode state ─────────────────────────────────────────────────
+    // Entered via the "Map" header button.  Uses an orthographic top-down
+    // camera (SceneView.useOrthoCamera) for distortion-free 2D placement.
+    this._mapMode = {
+      /** Whether map mode is currently active */
+      active: false,
+      /** Active drawing tool: 'path'|'edge'|'district'|'node'|'landmark'|null */
+      tool:   null,
+      /** @type {THREE.Vector3[]} confirmed vertex positions (Z=0 plane) */
+      points: [],
+      /** @type {THREE.Vector3|null} live cursor world position */
+      cursor: null,
+      /** THREE.Line preview drawn while placing */
       previewLine: null,
-      /** Cursor dot (THREE.Mesh) shown at cursor position */
-      cursorDot: null,
+      /** THREE.Mesh cursor dot */
+      cursorDot:   null,
+      /** Panning state */
+      isPanning:   false,
+      panStart:    null,   // { screenX, screenY, camX, camY }
+      /** Current orthographic frustum height (world units) */
+      frustumSize: 50,
     }
 
     // ── Sketch drawing state (Edit Mode · 2D) ──────────────────────────────
@@ -500,6 +506,9 @@ export class AppController {
       this._refreshUndoRedoState()
     })
 
+    // ── Map Mode entry ────────────────────────────────────────────────────
+    uiView.onMapModeClick(() => this._enterMapMode())
+
     this._bindEvents()
 
     // Create the initial object
@@ -548,11 +557,6 @@ export class AppController {
     if (type === 'sketch')  { this._addProfileObject();    return }
     if (type === 'measure') { this._startMeasurePlacement(); return }
     if (type === 'frame')   { this._addCoordinateFrame();  return }
-    // Urban entity placement types (ADR-026)
-    if (type === 'path' || type === 'edge' || type === 'district' ||
-        type === 'node' || type === 'landmark') {
-      this._startUrbanPlacement(type); return
-    }
 
     // Exit Edit Mode cleanly before adding, so the previous object's visual state is cleared
     if (this._scene.selectionMode === 'edit') this.setMode('object')
@@ -1088,19 +1092,38 @@ export class AppController {
     }
   }
 
-  // ── Urban entity placement (ADR-026) ─────────────────────────────────────
+  // ── 2D Map Mode ──────────────────────────────────────────────────────────
 
-  /**
-   * Returns the Lynch class name for a placement type.
-   * 'path'→'Path', 'edge'→'Edge', 'district'→'District', 'node'→'Node', 'landmark'→'Landmark'
-   * @param {string} type
-   */
-  _lynchClassForType(type) {
-    return type.charAt(0).toUpperCase() + type.slice(1)
+  /** Enters 2D Map Mode: switches to orthographic top-down camera, shows map toolbar. */
+  _enterMapMode() {
+    if (this._mapMode.active) return
+    if (this._scene.selectionMode === 'edit') this.setMode('object')
+    this._mapMode.active = true
+    this._mapMode.tool   = null
+    this._mapMode.points = []
+    this._mapMode.cursor = null
+    this._mapMode.isPanning = false
+    this._sceneView.useOrthoCamera(true, this._mapMode.frustumSize)
+    this._uiView.setCursor('default')
+    this._uiView.setStatus('Map Mode — select a Lynch type on the left to start drawing')
+    this._refreshMapToolbar()
+    this._updateMobileToolbar()
+  }
+
+  /** Exits 2D Map Mode: restores perspective camera, removes map toolbar. */
+  _exitMapMode() {
+    this._mapCancelDrawing()
+    this._mapMode.active      = false
+    this._mapMode.isPanning   = false
+    this._sceneView.useOrthoCamera(false)
+    this._uiView.hideMapToolbar()
+    this._uiView.setCursor('default')
+    this._refreshObjectModeStatus()
+    this._updateMobileToolbar()
   }
 
   /**
-   * Returns the entity geometry kind for a placement type.
+   * Returns the geometry kind for a Lynch placement type.
    * @param {string} type
    * @returns {'polyline'|'polygon'|'marker'}
    */
@@ -1110,181 +1133,203 @@ export class AppController {
     return 'polyline'
   }
 
+  /** Returns the Lynch class name capitalised from a placement type string. */
+  _lynchClassForType(type) {
+    return type.charAt(0).toUpperCase() + type.slice(1)
+  }
+
   /**
-   * Starts urban entity placement mode for the given type.
-   * @param {'path'|'edge'|'district'|'node'|'landmark'} type
+   * Sets the active map drawing tool.
+   * @param {string} type  'path'|'edge'|'district'|'node'|'landmark'
    */
-  _startUrbanPlacement(type) {
-    if (this._scene.selectionMode === 'edit') this.setMode('object')
-    this._cancelUrbanPlacement()   // clear any previous state
-    this._urbanPlacement.active = true
-    this._urbanPlacement.type   = type
-    this._urbanPlacement.points = []
-    this._urbanPlacement.cursor = null
-    if (window.matchMedia('(pointer: coarse)').matches) this._controls.enabled = false
+  _setMapTool(type) {
+    this._mapCancelDrawing()   // clear any in-progress drawing
+    this._mapMode.tool   = type
+    this._mapMode.points = []
+    this._mapMode.cursor = null
     this._uiView.setCursor('crosshair')
-    this._updateUrbanPlacementStatus()
-    this._updateMobileToolbar()
+    this._refreshMapToolbar()
+    this._updateMapStatus()
   }
 
-  /** Cancels urban placement mode and cleans up preview objects. */
-  _cancelUrbanPlacement() {
-    if (!this._urbanPlacement.active) return
-    this._clearUrbanPreview()
-    this._urbanPlacement.active = false
-    this._urbanPlacement.type   = null
-    this._urbanPlacement.points = []
-    this._urbanPlacement.cursor = null
-    if (window.matchMedia('(pointer: coarse)').matches) this._controls.enabled = true
+  /** Cancels the current drawing without creating an entity. */
+  _mapCancelDrawing() {
+    this._clearMapPreview()
+    this._mapMode.tool   = null
+    this._mapMode.points = []
+    this._mapMode.cursor = null
     this._uiView.setCursor('default')
-    this._refreshObjectModeStatus()
-    this._updateMobileToolbar()
-  }
-
-  /** Removes preview line and cursor dot from the scene. */
-  _clearUrbanPreview() {
-    const scene = this._sceneView.scene
-    if (this._urbanPlacement.previewLine) {
-      scene.remove(this._urbanPlacement.previewLine)
-      this._urbanPlacement.previewLine.geometry.dispose()
-      this._urbanPlacement.previewLine.material.dispose()
-      this._urbanPlacement.previewLine = null
-    }
-    if (this._urbanPlacement.cursorDot) {
-      scene.remove(this._urbanPlacement.cursorDot)
-      this._urbanPlacement.cursorDot.geometry.dispose()
-      this._urbanPlacement.cursorDot.material.dispose()
-      this._urbanPlacement.cursorDot = null
+    this._refreshMapToolbar()
+    if (this._mapMode.active) {
+      this._uiView.setStatus('Map Mode — select a Lynch type on the left to start drawing')
     }
   }
 
   /**
-   * Confirms the current urban placement:
-   *  - Marker: places immediately (called after single click)
-   *  - Polyline/Polygon: creates the entity from accumulated points
+   * Confirms the current drawing and creates the Urban entity.
+   * Called from Enter key, Confirm button, or (for polygons) clicking near the first vertex.
    */
-  _confirmUrbanPlacement() {
-    const { type, points } = this._urbanPlacement
-    const geometry = this._geometryForType(type)
-    const lynchClass = this._lynchClassForType(type)
+  _mapConfirmDrawing() {
+    const { tool, points } = this._mapMode
+    if (!tool) return
+    const geometry  = this._geometryForType(tool)
+    const lynchClass = this._lynchClassForType(tool)
+    const renderer  = this._sceneView.renderer
 
-    this._clearUrbanPreview()
-    this._urbanPlacement.active = false
-    this._urbanPlacement.type   = null
-    this._urbanPlacement.points = []
-    this._urbanPlacement.cursor = null
-    if (window.matchMedia('(pointer: coarse)').matches) this._controls.enabled = true
-    this._uiView.setCursor('default')
-
-    const renderer = this._sceneView.renderer
-
-    if (geometry === 'marker') {
-      // Should already be handled in _onPointerDown for markers
-      if (points.length === 0) { this._updateMobileToolbar(); this._refreshObjectModeStatus(); return }
+    if (geometry === 'marker' && points.length === 1) {
       const obj = this._service.createUrbanMarker(points[0], undefined, {
         camera: this._camera, renderer, container: document.body,
       })
-      obj.lynchClass = lynchClass
       this._service.setLynchClass(obj.id, lynchClass)
-      // Do not auto-select: toolbar must return to the initial object-mode slots.
     } else if (geometry === 'polyline' && points.length >= 2) {
       const obj = this._service.createUrbanPolyline(points, undefined, renderer)
-      obj.lynchClass = lynchClass
       this._service.setLynchClass(obj.id, lynchClass)
-      // Do not auto-select: toolbar must return to the initial object-mode slots.
     } else if (geometry === 'polygon' && points.length >= 3) {
       const obj = this._service.createUrbanPolygon(points, undefined, renderer)
-      obj.lynchClass = lynchClass
       this._service.setLynchClass(obj.id, lynchClass)
-      // Do not auto-select: toolbar must return to the initial object-mode slots.
+    } else {
+      return  // not enough points
     }
 
-    this._refreshObjectModeStatus()
-    this._updateMobileToolbar()
+    // Keep the same tool active for rapid repeated placement
+    this._clearMapPreview()
+    this._mapMode.points = []
+    this._mapMode.cursor = null
+    this._refreshMapToolbar()
+    this._uiView.setStatus(`Map Mode — ${lynchClass} placed.  Draw another or select a different type.`)
   }
 
-  /** Updates the status bar during urban placement. */
-  _updateUrbanPlacementStatus() {
-    if (!this._urbanPlacement.active) return
-    const geometry = this._geometryForType(this._urbanPlacement.type)
-    const n        = this._urbanPlacement.points.length
-    const typeLabel = this._lynchClassForType(this._urbanPlacement.type)
+  /** Removes preview line and cursor dot from the Three.js scene. */
+  _clearMapPreview() {
+    const scene = this._sceneView.scene
+    if (this._mapMode.previewLine) {
+      scene.remove(this._mapMode.previewLine)
+      this._mapMode.previewLine.geometry.dispose()
+      this._mapMode.previewLine.material.dispose()
+      this._mapMode.previewLine = null
+    }
+    if (this._mapMode.cursorDot) {
+      scene.remove(this._mapMode.cursorDot)
+      this._mapMode.cursorDot.geometry.dispose()
+      this._mapMode.cursorDot.material.dispose()
+      this._mapMode.cursorDot = null
+    }
+  }
+
+  /**
+   * Picks the ground-plane (Z=0) world position under the mouse in Map Mode,
+   * using the orthographic camera for correct distortion-free picking.
+   * @param {PointerEvent|MouseEvent} e
+   * @returns {THREE.Vector3}
+   */
+  _mapPickPoint(e) {
+    const ndcX =  (e.clientX / innerWidth)  * 2 - 1
+    const ndcY = -(e.clientY / innerHeight) * 2 + 1
+    this._raycaster.setFromCamera(new THREE.Vector2(ndcX, ndcY), this._sceneView.activeCamera)
+    const pt = new THREE.Vector3()
+    this._raycaster.ray.intersectPlane(this._groundPlane, pt)
+    return new THREE.Vector3(pt.x, pt.y, 0)
+  }
+
+  /** Updates the live preview line and cursor dot during map drawing. */
+  _updateMapPreview() {
+    const { tool, points, cursor } = this._mapMode
+    if (!tool || !cursor) return
+    const geometry = this._geometryForType(tool)
+    const entry    = getLynchClassEntry(this._lynchClassForType(tool))
+    const color    = entry ? parseInt(entry.color.slice(1), 16) : 0x80cbc4
+
+    // Cursor dot
+    if (!this._mapMode.cursorDot) {
+      const g = new THREE.SphereGeometry(0.08, 8, 8)
+      const m = new THREE.MeshBasicMaterial({ color, depthTest: false })
+      this._mapMode.cursorDot = new THREE.Mesh(g, m)
+      this._mapMode.cursorDot.renderOrder = 3
+      this._sceneView.scene.add(this._mapMode.cursorDot)
+    }
+    this._mapMode.cursorDot.position.copy(cursor)
+    this._mapMode.cursorDot.material.color.setHex(color)
+
+    // Preview line (confirmed points + live cursor position)
+    if (geometry !== 'marker' && points.length > 0) {
+      const previewPts = [...points, cursor]
+      if (geometry === 'polygon' && previewPts.length >= 3) previewPts.push(previewPts[0])
+      const flat = []
+      for (const p of previewPts) flat.push(p.x, p.y, p.z)
+
+      if (!this._mapMode.previewLine) {
+        const geo = new THREE.BufferGeometry()
+        const mat = new THREE.LineBasicMaterial({ color, depthTest: false, transparent: true, opacity: 0.7 })
+        this._mapMode.previewLine = new THREE.Line(geo, mat)
+        this._mapMode.previewLine.renderOrder = 2
+        this._sceneView.scene.add(this._mapMode.previewLine)
+      }
+      this._mapMode.previewLine.geometry.setAttribute(
+        'position', new THREE.Float32BufferAttribute(new Float32Array(flat), 3),
+      )
+      this._mapMode.previewLine.geometry.attributes.position.needsUpdate = true
+      this._mapMode.previewLine.material.color.setHex(color)
+    } else if (this._mapMode.previewLine) {
+      this._sceneView.scene.remove(this._mapMode.previewLine)
+      this._mapMode.previewLine.geometry.dispose()
+      this._mapMode.previewLine.material.dispose()
+      this._mapMode.previewLine = null
+    }
+  }
+
+  /** Updates the status bar text during map drawing. */
+  _updateMapStatus() {
+    const { tool, points } = this._mapMode
+    if (!tool) return
+    const geometry  = this._geometryForType(tool)
+    const typeLabel = this._lynchClassForType(tool)
+    const n = points.length
 
     if (geometry === 'marker') {
       this._uiView.setStatusRich([
         { text: typeLabel, bold: true, color: '#80cbc4' },
-        { text: 'Click to place marker.', color: '#888' },
+        { text: 'Click to place.', color: '#888' },
         { text: 'ESC cancel', color: '#444' },
       ])
     } else if (geometry === 'polyline') {
       this._uiView.setStatusRich([
         { text: typeLabel, bold: true, color: '#80cbc4' },
-        { text: `${n} pts — Click to add point.`, color: '#888' },
-        { text: n >= 2 ? 'Enter / RMB = confirm' : '', color: '#aaa' },
+        { text: `${n} pts`, color: '#aaa' },
+        { text: 'click to add', color: '#888' },
+        { text: n >= 2 ? '  Enter / RMB = confirm' : '', color: '#aaa' },
         { text: 'ESC cancel', color: '#444' },
       ])
     } else {
       this._uiView.setStatusRich([
         { text: typeLabel, bold: true, color: '#80cbc4' },
-        { text: `${n} pts — Click to add point.`, color: '#888' },
-        { text: n >= 3 ? 'Enter = close & confirm' : '', color: '#aaa' },
+        { text: `${n} pts`, color: '#aaa' },
+        { text: 'click to add', color: '#888' },
+        { text: n >= 3 ? '  Enter = close & confirm' : '', color: '#aaa' },
         { text: 'ESC cancel', color: '#444' },
       ])
     }
   }
 
   /**
-   * Picks the ground-plane intersection point for urban placement.
-   * @returns {THREE.Vector3|null}
+   * Rebuilds the Map toolbar to reflect current state
+   * (active tool, confirm/cancel visibility).
+   * @private
    */
-  _urbanPickPoint() {
-    this._raycaster.setFromCamera(this._mouse, this._camera)
-    const pt = new THREE.Vector3()
-    if (this._raycaster.ray.intersectPlane(this._groundPlane, pt)) return pt
-    return null
-  }
+  _refreshMapToolbar() {
+    if (!this._mapMode.active) return
+    const { tool, points } = this._mapMode
+    const geometry = tool ? this._geometryForType(tool) : null
+    const canConfirm = geometry === 'polyline' ? points.length >= 2
+      : geometry === 'polygon' ? points.length >= 3
+      : false   // markers confirm immediately on click
 
-  /** Updates the preview line/polygon during urban placement pointer move. */
-  _updateUrbanPreview() {
-    const { active, type, points, cursor } = this._urbanPlacement
-    if (!active || !cursor) return
-    const geometry = this._geometryForType(type)
-    const entry    = getLynchClassEntry(this._lynchClassForType(type))
-    const color    = entry ? parseInt(entry.color.slice(1), 16) : 0x80cbc4
-
-    // Cursor dot
-    if (!this._urbanPlacement.cursorDot) {
-      const g = new THREE.SphereGeometry(0.08, 8, 8)
-      const m = new THREE.MeshBasicMaterial({ color, depthTest: false })
-      this._urbanPlacement.cursorDot = new THREE.Mesh(g, m)
-      this._urbanPlacement.cursorDot.renderOrder = 3
-      this._sceneView.scene.add(this._urbanPlacement.cursorDot)
-    }
-    this._urbanPlacement.cursorDot.position.copy(cursor)
-
-    // Preview line (confirmed points + cursor)
-    if (geometry !== 'marker' && points.length > 0) {
-      const previewPts = [...points, cursor]
-      if (geometry === 'polygon' && previewPts.length >= 3) {
-        previewPts.push(previewPts[0])   // close ring
-      }
-      const flat = []
-      for (const p of previewPts) { flat.push(p.x, p.y, p.z) }
-      const positions = new Float32Array(flat)
-
-      if (!this._urbanPlacement.previewLine) {
-        const geo = new THREE.BufferGeometry()
-        const mat = new THREE.LineBasicMaterial({ color, depthTest: false, transparent: true, opacity: 0.7 })
-        this._urbanPlacement.previewLine = new THREE.Line(geo, mat)
-        this._urbanPlacement.previewLine.renderOrder = 2
-        this._sceneView.scene.add(this._urbanPlacement.previewLine)
-      }
-      this._urbanPlacement.previewLine.geometry.setAttribute(
-        'position', new THREE.Float32BufferAttribute(positions, 3),
-      )
-      this._urbanPlacement.previewLine.geometry.attributes.position.needsUpdate = true
-      this._urbanPlacement.previewLine.material.color.setHex(color)
-    }
+    this._uiView.showMapToolbar(
+      tool,
+      (t) => this._setMapTool(t),
+      canConfirm ? () => this._mapConfirmDrawing() : null,
+      tool       ? () => this._mapCancelDrawing()  : null,
+      ()         => this._exitMapMode(),
+    )
   }
 
   /**
@@ -1822,15 +1867,14 @@ export class AppController {
     const mode     = this._scene.selectionMode
     const substate = this._scene.editSubstate
 
-    if (this._urbanPlacement.active) {
-      const geometry = this._geometryForType(this._urbanPlacement.type)
-      const canConfirm = (geometry === 'polyline' && this._urbanPlacement.points.length >= 2)
-        || (geometry === 'polygon' && this._urbanPlacement.points.length >= 3)
+    if (this._mapMode.active) {
+      // In Map Mode the left-side map toolbar handles drawing controls.
+      // Show a minimal "Exit Map" slot on mobile.
       this._uiView.setMobileToolbar([
-        ...(canConfirm ? [{ icon: ICONS.confirm, label: 'Confirm', onClick: () => this._confirmUrbanPlacement() }] : [{ spacer: true }]),
+        { icon: ICONS.back, label: 'Exit Map', onClick: () => this._exitMapMode() },
         { spacer: true },
         { spacer: true },
-        { icon: ICONS.cancel, label: 'Cancel', onClick: () => this._cancelUrbanPlacement(), danger: true },
+        { spacer: true },
       ])
       return
     }
@@ -1870,12 +1914,12 @@ export class AppController {
         return
       }
 
-      // Urban entity toolbar: Grab | Lynch | Delete | (spacer)
+      // Urban entity toolbar: Grab | Map (to edit in map mode) | Delete | (spacer)
       const _isUrban = o => o instanceof UrbanPolyline || o instanceof UrbanPolygon || o instanceof UrbanMarker
       if (hasObj && _isUrban(this._activeObj)) {
         this._uiView.setMobileToolbar([
           { icon: ICONS.grab,   label: 'Grab',   onClick: () => this._startGrab() },
-          { icon: '🗂',         label: 'Lynch',  onClick: () => this._openLynchPicker() },
+          { icon: ICONS.map,    label: 'Map',    onClick: () => this._enterMapMode() },
           { icon: ICONS.delete, label: 'Delete', onClick: () => this._deleteObject(this._scene.activeId), danger: true },
           { spacer: true },
         ])
@@ -1902,7 +1946,6 @@ export class AppController {
               () => this._addObject('measure'),
               () => this._triggerStepImport(),
               canAddFrame ? () => this._addObject('frame') : undefined,
-              { onPath: () => this._addObject('path'), onEdge: () => this._addObject('edge'), onDistrict: () => this._addObject('district'), onNode: () => this._addObject('node'), onLandmark: () => this._addObject('landmark') },
             )
           },
         },
@@ -2675,23 +2718,6 @@ export class AppController {
   // ── CoordinateFrame rotation (R key, ADR-019) ────────────────────────────
 
   /**
-   * Opens the Lynch class picker for the active Urban entity.
-   * Called from the mobile toolbar Lynch button.
-   * On desktop the N-panel picker is used directly.
-   */
-  _openLynchPicker() {
-    const obj = this._activeObj
-    if (!(obj instanceof UrbanPolyline) && !(obj instanceof UrbanPolygon) && !(obj instanceof UrbanMarker)) return
-    const geometry = obj instanceof UrbanPolyline ? 'polyline'
-      : obj instanceof UrbanPolygon ? 'polygon'
-      : 'marker'
-    // Reuse the UIView Lynch picker (which triggers onLynchClassChange callback)
-    const tempBadge  = document.createElement('span')
-    const tempBtn    = document.createElement('button')
-    this._uiView._openLynchPicker(tempBadge, tempBtn, geometry)
-  }
-
-  /**
    * Starts rotate mode for the active CoordinateFrame.
    * Only valid when the active object is a CoordinateFrame and no grab is active.
    */
@@ -3128,6 +3154,14 @@ export class AppController {
   }
 
   _onWheel(e) {
+    // ── 2D Map Mode: scroll to zoom ──────────────────────────────────────
+    if (this._mapMode.active) {
+      e.preventDefault()
+      const factor = e.deltaY > 0 ? 1.15 : 1 / 1.15
+      this._mapMode.frustumSize = Math.max(2, Math.min(500, this._mapMode.frustumSize * factor))
+      this._sceneView.setOrthoZoom(this._mapMode.frustumSize)
+      return
+    }
     if (this._rotate.active && this._ctrlHeld) {
       e.preventDefault()
       const steps = AppController.ANGLE_STEPS
@@ -3492,12 +3526,23 @@ export class AppController {
       return
     }
 
-    // ── Urban entity placement hover ─────────────────────────────────────
-    if (this._urbanPlacement.active) {
-      const pt = this._urbanPickPoint()
-      if (pt) {
-        this._urbanPlacement.cursor = pt
-        this._updateUrbanPreview()
+    // ── 2D Map Mode: pan or drawing hover ────────────────────────────────
+    if (this._mapMode.active) {
+      if (this._mapMode.isPanning && this._mapMode.panStart) {
+        const { frustumSize } = this._mapMode
+        const aspect = innerWidth / innerHeight
+        const dx = (e.clientX - this._mapMode.panStart.screenX) * (frustumSize * aspect / innerWidth)
+        const dy = (e.clientY - this._mapMode.panStart.screenY) * (frustumSize / innerHeight)
+        this._sceneView.panOrthoCamera(
+          this._mapMode.panStart.camX - dx,
+          this._mapMode.panStart.camY + dy,
+        )
+        return
+      }
+      if (this._mapMode.tool) {
+        const pt = this._mapPickPoint(e)
+        this._mapMode.cursor = pt
+        this._updateMapPreview()
       }
       return
     }
@@ -3789,41 +3834,52 @@ export class AppController {
       return
     }
 
-    // ── Urban entity placement clicks ────────────────────────────────────
-    if (this._urbanPlacement.active) {
-      if (e.button === 2) {
-        // RMB confirms polyline/polygon (if enough points), otherwise cancels
-        const geometry = this._geometryForType(this._urbanPlacement.type)
-        const n = this._urbanPlacement.points.length
-        if ((geometry === 'polyline' && n >= 2) || (geometry === 'polygon' && n >= 3)) {
-          this._confirmUrbanPlacement()
-        } else {
-          this._cancelUrbanPlacement()
+    // ── 2D Map Mode: drawing clicks and pan start ────────────────────────
+    if (this._mapMode.active) {
+      if (e.button === 1 || (e.button === 0 && !this._mapMode.tool)) {
+        // Middle button or left button with no tool → start panning
+        this._mapMode.isPanning = true
+        const cam = this._sceneView.activeCamera
+        this._mapMode.panStart = {
+          screenX: e.clientX, screenY: e.clientY,
+          camX: cam.position.x, camY: cam.position.y,
         }
+        this._uiView.setCursor('grabbing')
+        this._activeDragPointerId = e.pointerId
         return
       }
-      if (e.button === 0) {
-        const pt = this._urbanPickPoint()
-        if (!pt) return
-        const geometry = this._geometryForType(this._urbanPlacement.type)
+      if (e.button === 0 && this._mapMode.tool) {
+        const pt = this._mapPickPoint(e)
+        const geometry = this._geometryForType(this._mapMode.tool)
         if (geometry === 'marker') {
-          // Immediate place on single click
-          this._urbanPlacement.points = [pt.clone()]
-          this._confirmUrbanPlacement()
+          this._mapMode.points = [pt.clone()]
+          this._mapConfirmDrawing()
           return
         }
-        // For polygon: check if clicking near first point to close
-        if (geometry === 'polygon' && this._urbanPlacement.points.length >= 3) {
-          const first = this._urbanPlacement.points[0]
-          this._raycaster.setFromCamera(this._mouse, this._camera)
+        // For polygon: clicking near first vertex closes the shape
+        if (geometry === 'polygon' && this._mapMode.points.length >= 3) {
+          const first = this._mapMode.points[0]
           const firstScreen = this._projectToScreen(first)
-          const mouseScreen = { x: (this._mouse.x + 1) / 2 * innerWidth, y: (-this._mouse.y + 1) / 2 * innerHeight }
-          const dist = Math.hypot(mouseScreen.x - firstScreen.x, mouseScreen.y - firstScreen.y)
-          if (dist < 20) { this._confirmUrbanPlacement(); return }
+          const mx = e.clientX, my = e.clientY
+          if (Math.hypot(mx - firstScreen.x, my - firstScreen.y) < 20) {
+            this._mapConfirmDrawing()
+            return
+          }
         }
-        this._urbanPlacement.points.push(pt.clone())
-        this._updateUrbanPlacementStatus()
-        this._updateMobileToolbar()
+        this._mapMode.points.push(pt.clone())
+        this._updateMapStatus()
+        this._refreshMapToolbar()
+        return
+      }
+      if (e.button === 2 && this._mapMode.tool) {
+        // RMB confirms if enough points, otherwise cancels tool
+        const geometry = this._geometryForType(this._mapMode.tool)
+        const n = this._mapMode.points.length
+        if ((geometry === 'polyline' && n >= 2) || (geometry === 'polygon' && n >= 3)) {
+          this._mapConfirmDrawing()
+        } else {
+          this._mapCancelDrawing()
+        }
         return
       }
       return
@@ -3999,6 +4055,17 @@ export class AppController {
       clearTimeout(this._longPress.timer)
       this._longPress.timer = null
       this._longPress.pointerId = null
+    }
+
+    // ── 2D Map Mode: end panning on pointer up ────────────────────────────
+    if (this._mapMode.active && this._mapMode.isPanning) {
+      if (this._activeDragPointerId === e.pointerId) {
+        this._activeDragPointerId = null
+        this._mapMode.isPanning = false
+        this._mapMode.panStart  = null
+        this._uiView.setCursor(this._mapMode.tool ? 'crosshair' : 'default')
+      }
+      return
     }
 
     // ── Measure point confirmation (hold-to-snap, release-to-confirm) ─────
@@ -4196,14 +4263,21 @@ export class AppController {
       return
     }
 
-    // ── Urban entity placement keys ─────────────────────────────────────
-    if (this._urbanPlacement.active) {
-      if (e.key === 'Escape') { this._cancelUrbanPlacement(); return }
-      if (e.key === 'Enter') {
-        const geometry = this._geometryForType(this._urbanPlacement.type)
-        const n = this._urbanPlacement.points.length
+    // ── 2D Map Mode keys ────────────────────────────────────────────────────
+    if (this._mapMode.active) {
+      if (e.key === 'Escape') {
+        if (this._mapMode.tool) {
+          this._mapCancelDrawing()   // cancel drawing, stay in map mode
+        } else {
+          this._exitMapMode()        // exit map mode entirely
+        }
+        return
+      }
+      if (e.key === 'Enter' && this._mapMode.tool) {
+        const geometry = this._geometryForType(this._mapMode.tool)
+        const n = this._mapMode.points.length
         if ((geometry === 'polyline' && n >= 2) || (geometry === 'polygon' && n >= 3)) {
-          this._confirmUrbanPlacement()
+          this._mapConfirmDrawing()
         }
         return
       }
@@ -4342,7 +4416,6 @@ export class AppController {
           () => this._addObject('measure'),
           () => this._triggerStepImport(),
           canAddFrame ? () => this._addObject('frame') : undefined,
-          { onPath: () => this._addObject('path'), onEdge: () => this._addObject('edge'), onDistrict: () => this._addObject('district'), onNode: () => this._addObject('node'), onLandmark: () => this._addObject('landmark') },
         )
         return
       }

--- a/src/view/SceneView.js
+++ b/src/view/SceneView.js
@@ -21,6 +21,9 @@ export class SceneView {
     this.camera.position.set(6, -4, 3)    // front (+X), right (-Y), above (+Z)
     this.camera.lookAt(0, 0, 0)
 
+    this._orthoCamera = null
+    this._useOrtho    = false
+
     this.controls = new OrbitControls(this.camera, this.renderer.domElement)
     this.controls.enableDamping = false
     // Left button is reserved for object/face operations; right button orbits the camera
@@ -58,6 +61,13 @@ export class SceneView {
     this.camera.aspect = innerWidth / innerHeight
     this.camera.updateProjectionMatrix()
     this.renderer.setSize(innerWidth, innerHeight)
+    if (this._orthoCamera) {
+      const aspect = innerWidth / innerHeight
+      const h = this._orthoCamera.top - this._orthoCamera.bottom
+      this._orthoCamera.left   = -h * aspect / 2
+      this._orthoCamera.right  =  h * aspect / 2
+      this._orthoCamera.updateProjectionMatrix()
+    }
   }
 
   /**
@@ -85,9 +95,74 @@ export class SceneView {
     this.camera.updateProjectionMatrix()
   }
 
+  /**
+   * Switches between the perspective camera and an orthographic top-down camera.
+   * When enabling, the ortho camera is centred over the current OrbitControls target.
+   * @param {boolean} enable
+   * @param {number} [frustumSize=50] - visible world-units height in ortho view
+   */
+  useOrthoCamera(enable, frustumSize = 50) {
+    if (enable) {
+      const aspect = innerWidth / innerHeight
+      if (!this._orthoCamera) {
+        this._orthoCamera = new THREE.OrthographicCamera(
+          -frustumSize * aspect / 2,  frustumSize * aspect / 2,
+           frustumSize / 2,           -frustumSize / 2,
+          -1000, 1000,
+        )
+      } else {
+        this._orthoCamera.left   = -frustumSize * aspect / 2
+        this._orthoCamera.right  =  frustumSize * aspect / 2
+        this._orthoCamera.top    =  frustumSize / 2
+        this._orthoCamera.bottom = -frustumSize / 2
+      }
+      // Centre ortho camera over the perspective camera's focus point (XY plane)
+      const t = this.controls.target
+      this._orthoCamera.position.set(t.x, t.y, 100)
+      this._orthoCamera.up.set(0, 1, 0)
+      this._orthoCamera.lookAt(t.x, t.y, 0)
+      this._orthoCamera.updateProjectionMatrix()
+      this._useOrtho = true
+      this.controls.enabled = false
+    } else {
+      this._useOrtho = false
+      this.controls.enabled = true
+    }
+  }
+
+  /**
+   * Adjusts the orthographic frustum height (zoom level) while keeping the camera centred.
+   * @param {number} frustumSize
+   */
+  setOrthoZoom(frustumSize) {
+    if (!this._orthoCamera) return
+    const aspect = innerWidth / innerHeight
+    this._orthoCamera.left   = -frustumSize * aspect / 2
+    this._orthoCamera.right  =  frustumSize * aspect / 2
+    this._orthoCamera.top    =  frustumSize / 2
+    this._orthoCamera.bottom = -frustumSize / 2
+    this._orthoCamera.updateProjectionMatrix()
+  }
+
+  /**
+   * Translates the orthographic camera in XY (world-space pan).
+   * @param {number} x
+   * @param {number} y
+   */
+  panOrthoCamera(x, y) {
+    if (!this._orthoCamera) return
+    this._orthoCamera.position.set(x, y, 100)
+    this._orthoCamera.lookAt(x, y, 0)
+  }
+
+  /** The camera currently being used for rendering. */
+  get activeCamera() {
+    return (this._useOrtho && this._orthoCamera) ? this._orthoCamera : this.camera
+  }
+
   /** Updates controls and renders the scene (call from the animation loop) */
   render() {
-    this.controls.update()
-    this.renderer.render(this.scene, this.camera)
+    if (!this._useOrtho) this.controls.update()
+    this.renderer.render(this.scene, this.activeCamera)
   }
 }

--- a/src/view/UIView.js
+++ b/src/view/UIView.js
@@ -26,6 +26,7 @@ export const ICONS = {
   measure:  `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="21" x2="21" y2="3"/><line x1="3" y1="13" x2="7" y2="13"/><line x1="7" y1="9" x2="11" y2="9"/><line x1="11" y1="5" x2="15" y2="5"/></svg>`,
   frame:    `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="2.5" fill="currentColor" stroke="none"/><line x1="12" y1="12" x2="19" y2="12" stroke="#e05252"/><line x1="12" y1="12" x2="8.5" y2="8.5" stroke="#52e052"/><line x1="12" y1="12" x2="12" y2="5" stroke="#5252e0"/></svg>`,
   grab:     `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 11V6a2 2 0 0 0-4 0v5"/><path d="M14 10V4a2 2 0 0 0-4 0v6"/><path d="M10 10.5V6a2 2 0 0 0-4 0v8"/><path d="M6 14a4 4 0 0 0 2.83 3.83L10 18h4l1.17-.17A4 4 0 0 0 18 14v-2H6v2z"/></svg>`,
+  map:      `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6"/><line x1="8" y1="2" x2="8" y2="18"/><line x1="16" y1="6" x2="16" y2="22"/></svg>`,
 }
 
 export class UIView {
@@ -167,6 +168,32 @@ export class UIView {
     this._headerEl.appendChild(this._redoBtn)
 
     this._headerEl.appendChild(this._modeSelectorEl)
+
+    // ── Map Mode button ───────────────────────────────────────────────────
+    this._mapModeBtn = document.createElement('button')
+    Object.assign(this._mapModeBtn.style, {
+      padding: '4px 8px',
+      background: 'transparent',
+      border: '1px solid #3a3a3a',
+      borderRadius: '5px',
+      color: '#aaa',
+      cursor: 'pointer',
+      fontSize: '12px',
+      fontFamily: 'system-ui, -apple-system, sans-serif',
+      lineHeight: '1',
+      flexShrink: '0',
+      display: 'flex',
+      alignItems: 'center',
+      gap: '5px',
+    })
+    this._mapModeBtn.title = 'Open 2D Map Mode for urban modeling'
+    this._mapModeBtn.innerHTML = `${ICONS.map}<span>Map</span>`
+    this._headerEl.appendChild(this._mapModeBtn)
+    /** @type {Function|null} */
+    this._onMapModeClick = null
+    this._mapModeBtn.addEventListener('click', () => {
+      if (this._onMapModeClick) this._onMapModeClick()
+    })
 
     // ── Header status (centered within header bar via flex) ───────────────
     this._headerStatusEl = document.createElement('div')
@@ -617,6 +644,9 @@ export class UIView {
    *  cb(lynchClass: string|null)  — null means "clear classification" */
   onLynchClassChange(callback) { this._onLynchClassChangeCb = callback }
 
+  /** Registers callback for the Map Mode button click */
+  onMapModeClick(callback) { this._onMapModeClick = callback }
+
   /** Registers callback for mode changes */
   onModeChange(callback) {
     this._modeChangeCallback = callback
@@ -782,9 +812,8 @@ export class UIView {
    * @param {() => void} [onMeasure]
    * @param {() => void} [onImportStep]
    * @param {() => void} [onFrame]
-   * @param {{ onPath?: () => void, onEdge?: () => void, onDistrict?: () => void, onNode?: () => void, onLandmark?: () => void }} [urban]
    */
-  showAddMenu(x, y, onBox, onSketch, onMeasure, onImportStep, onFrame, urban) {
+  showAddMenu(x, y, onBox, onSketch, onMeasure, onImportStep, onFrame) {
     this.hideAddMenu()
     const menu = document.createElement('div')
     Object.assign(menu.style, {
@@ -848,54 +877,6 @@ export class UIView {
     ]
     items.forEach(({ label, hint, cb }) => menu.appendChild(makeItem(label, hint, cb)))
 
-    // ── Urban submenu ─────────────────────────────────────────────────────────
-    if (urban) {
-      const sep = document.createElement('div')
-      Object.assign(sep.style, { height: '1px', background: '#3a3a3a', margin: '2px 0' })
-      menu.appendChild(sep)
-
-      // Urban submenu header
-      const urbanHeader = makeItem('Urban ▶', '', null)
-      Object.assign(urbanHeader.style, { color: '#80cbc4' })
-      menu.appendChild(urbanHeader)
-
-      // Sub-items container (shown/hidden on click)
-      const subContainer = document.createElement('div')
-      subContainer.style.display = 'none'
-      Object.assign(subContainer.style, { background: '#232323' })
-
-      const URBAN_ITEMS = [
-        { label: '⟿ Urban Path',     color: '#4A90D9', cb: urban.onPath },
-        { label: '⟿ Urban Edge',     color: '#E74C3C', cb: urban.onEdge },
-        { label: '⬡ Urban District', color: '#27AE60', cb: urban.onDistrict },
-        { label: '⬤ Urban Node',     color: '#F39C12', cb: urban.onNode },
-        { label: '⬤ Urban Landmark', color: '#9B59B6', cb: urban.onLandmark },
-      ]
-      URBAN_ITEMS.forEach(({ label, color, cb }) => {
-        if (!cb) return
-        const subItem = document.createElement('div')
-        Object.assign(subItem.style, {
-          padding: '6px 12px 6px 22px',
-          color,
-          cursor: 'pointer',
-          fontSize: '12px',
-          fontFamily: 'sans-serif',
-        })
-        subItem.textContent = label
-        subItem.addEventListener('mouseenter', () => { subItem.style.background = '#3a3a3a' })
-        subItem.addEventListener('mouseleave', () => { subItem.style.background = 'transparent' })
-        subItem.addEventListener('click', () => { this.hideAddMenu(); cb() })
-        subContainer.appendChild(subItem)
-      })
-
-      urbanHeader.addEventListener('click', () => {
-        const shown = subContainer.style.display !== 'none'
-        subContainer.style.display = shown ? 'none' : 'block'
-      })
-
-      menu.appendChild(subContainer)
-    }
-
     document.body.appendChild(menu)
     this._addMenuEl = menu
 
@@ -916,6 +897,155 @@ export class UIView {
       document.removeEventListener('click', this._addMenuCloseHandler)
       this._addMenuCloseHandler = null
     }
+  }
+
+  // ── 2D Map Mode toolbar ──────────────────────────────────────────────────
+
+  /**
+   * Shows the 2D Map Mode toolbar on the left side of the screen.
+   * Lynch-type buttons let the user pick what to draw; Confirm/Cancel appear
+   * only when a drawing is in progress.
+   *
+   * @param {string|null} activeTool  - currently selected tool ('path'|'edge'|'district'|'node'|'landmark'|null)
+   * @param {(type: string) => void} onToolSelect  - called when user clicks a type button
+   * @param {(() => void)|null} onConfirm  - called when Confirm clicked (null = hidden)
+   * @param {() => void} onCancel   - called when Cancel clicked
+   * @param {() => void} onExit     - called when Exit Map clicked
+   */
+  showMapToolbar(activeTool, onToolSelect, onConfirm, onCancel, onExit) {
+    this.hideMapToolbar()
+
+    const toolbar = document.createElement('div')
+    toolbar.id = '_mapToolbar'
+    Object.assign(toolbar.style, {
+      position: 'fixed',
+      top: '50%',
+      left: '8px',
+      transform: 'translateY(-50%)',
+      background: '#1e1e2e',
+      border: '1px solid #3a3a4a',
+      borderRadius: '8px',
+      padding: '6px',
+      zIndex: '150',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '4px',
+      boxShadow: '0 4px 16px rgba(0,0,0,0.6)',
+      userSelect: 'none',
+      minWidth: '44px',
+    })
+
+    const TOOL_ITEMS = [
+      { type: 'path',     label: '⟿',  title: 'Path (Linear)',     color: '#4A90D9' },
+      { type: 'edge',     label: '⟿',  title: 'Edge (Boundary)',   color: '#E74C3C' },
+      { type: 'district', label: '⬡',  title: 'District (Area)',   color: '#27AE60' },
+      { type: 'node',     label: '⬤',  title: 'Node (Junction)',   color: '#F39C12' },
+      { type: 'landmark', label: '⬤',  title: 'Landmark (Point)',  color: '#9B59B6' },
+    ]
+
+    const sep = () => {
+      const d = document.createElement('div')
+      Object.assign(d.style, { height: '1px', background: '#3a3a4a', margin: '2px 0' })
+      return d
+    }
+
+    // Tool buttons
+    TOOL_ITEMS.forEach(({ type, label, title, color }) => {
+      const btn = document.createElement('button')
+      const isActive = activeTool === type
+      Object.assign(btn.style, {
+        width: '36px', height: '36px',
+        background: isActive ? color + '33' : 'transparent',
+        border: isActive ? `1.5px solid ${color}` : '1.5px solid transparent',
+        borderRadius: '6px',
+        color,
+        cursor: 'pointer',
+        fontSize: '16px',
+        lineHeight: '1',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        transition: 'background 0.1s',
+      })
+      btn.title = title
+      btn.textContent = label
+      btn.addEventListener('mouseenter', () => {
+        if (activeTool !== type) btn.style.background = color + '22'
+      })
+      btn.addEventListener('mouseleave', () => {
+        if (activeTool !== type) btn.style.background = 'transparent'
+      })
+      btn.addEventListener('click', () => onToolSelect(type))
+      toolbar.appendChild(btn)
+    })
+
+    // Confirm / Cancel (drawing in progress)
+    if (onConfirm !== null || onCancel) {
+      toolbar.appendChild(sep())
+
+      if (onConfirm) {
+        const confirmBtn = document.createElement('button')
+        Object.assign(confirmBtn.style, {
+          width: '36px', height: '36px',
+          background: '#1a3a1a',
+          border: '1.5px solid #4caf50',
+          borderRadius: '6px',
+          color: '#4caf50',
+          cursor: 'pointer',
+          fontSize: '16px',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        })
+        confirmBtn.title = 'Confirm (Enter)'
+        confirmBtn.innerHTML = ICONS.confirm
+        confirmBtn.addEventListener('click', () => onConfirm())
+        toolbar.appendChild(confirmBtn)
+      }
+
+      if (onCancel) {
+        const cancelBtn = document.createElement('button')
+        Object.assign(cancelBtn.style, {
+          width: '36px', height: '36px',
+          background: '#3a1a1a',
+          border: '1.5px solid #e74c3c',
+          borderRadius: '6px',
+          color: '#e74c3c',
+          cursor: 'pointer',
+          fontSize: '16px',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        })
+        cancelBtn.title = 'Cancel drawing (Escape)'
+        cancelBtn.innerHTML = ICONS.cancel
+        cancelBtn.addEventListener('click', () => onCancel())
+        toolbar.appendChild(cancelBtn)
+      }
+    }
+
+    // Exit button
+    toolbar.appendChild(sep())
+    const exitBtn = document.createElement('button')
+    Object.assign(exitBtn.style, {
+      width: '36px', height: '36px',
+      background: 'transparent',
+      border: '1.5px solid #555',
+      borderRadius: '6px',
+      color: '#aaa',
+      cursor: 'pointer',
+      fontSize: '10px',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      lineHeight: '1',
+    })
+    exitBtn.title = 'Exit Map Mode'
+    exitBtn.innerHTML = ICONS.back
+    exitBtn.addEventListener('click', () => onExit())
+    toolbar.appendChild(exitBtn)
+
+    document.body.appendChild(toolbar)
+    this._mapToolbarEl = toolbar
+  }
+
+  /** Removes the Map Mode toolbar. */
+  hideMapToolbar() {
+    const existing = document.getElementById('_mapToolbar')
+    if (existing) existing.remove()
+    this._mapToolbarEl = null
   }
 
   /**


### PR DESCRIPTION
- SceneView: add OrthographicCamera, useOrthoCamera(), setOrthoZoom(),
  panOrthoCamera(), activeCamera getter; render() uses activeCamera
- UIView: remove Urban submenu from Add menu; add Map button to header,
  showMapToolbar() / hideMapToolbar() with Lynch-type buttons + confirm/cancel/exit;
  register onMapModeClick() callback
- AppController: replace _urbanPlacement state + methods with _mapMode;
  _enterMapMode() / _exitMapMode() switch ortho camera;
  _setMapTool() / _mapConfirmDrawing() / _mapCancelDrawing() drawing lifecycle;
  _refreshMapToolbar() rebuilds toolbar on every state change;
  pan via left/middle drag, zoom via scroll wheel;
  map-mode branches in _onPointerMove, _onPointerDown, _onPointerUp, _onKeyDown, _onWheel
- docs: STATE_TRANSITIONS.md adds Map Mode FSM; SCREEN_DESIGN.md rewrites S-14/15/16

https://claude.ai/code/session_0182TaQMzvaKxR8SEhfkvZ8q