### PR TITLE
docs: add SpatialLink roadmap and reorganize ROADMAP.md

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,137 +1,118 @@
 # Roadmap
 
-## Design Direction (2026-03-20, updated 2026-04-05)
+## Design Direction (2026-03-20, updated 2026-04-09)
 
 This project is a **solid-body modeling application**. Each shape is a deformable solid defined by a LocalGeometry graph (vertices / edges / faces). Complex scenes are built by placing and deforming multiple solid objects alongside coordinate frames and measurement annotations. See `docs/adr/` for detailed design decisions.
 
 ---
 
-## Wasm Geometry Engine (ADR-027)
+## Spatial Annotation System (ADR-029)
 
-Three-layer architecture for non-blocking, near-zero-copy geometry computation.
-Rust → WebAssembly → Web Worker → Main thread (Three.js).
+Generic 2D annotation entities for city, building, and part-level scales:
+`AnnotatedLine` (linear), `AnnotatedRegion` (areal), `AnnotatedPoint` (point),
+classified by place type: Route / Boundary / Zone / Hub / Anchor.
 
-### Phase 1 — Infrastructure ✅ *2026-04-05*
+Domain layer (entities, registry, service, serializer) is complete.
+The phases below cover the rendering and UI layers.
 
-| Task | Details | ADR |
-|------|---------|-----|
-| Rust crate `wasm-engine/` | `build_cuboid_geometry()` + pointer getters + `wasm_memory()`; mirrors `CuboidModel.js` face/normal logic exactly | ADR-027 |
-| Web Worker bridge `geometry.worker.js` | Loads Wasm via `initWasm(wasmUrl)`, reads output via pointer (zero-copy view), slices once, transfers ArrayBuffer to main thread | ADR-027 |
-| `GeometryEngine.js` facade | Promise API (`computeCuboid(corners)`); `?worker` Vite import; graceful fallback to `CuboidModel.buildGeometry()` on init failure | ADR-027 |
-| Build pipeline | `pnpm build:wasm` (wasm-pack → `src/engine/wasm/`); `pnpm build` runs it first; `pnpm test:wasm` (cargo test); CI updated | ADR-027 |
-| `src/engine/wasm/` committed | Generated WASM binary and JS bindings committed — JS-only developers need no Rust toolchain | ADR-027 |
-
-### Phase 2 — Wire into rendering pipeline ✅ *2026-04-05*
+### Phase 1 — Rendering layer ★ prerequisite for all UI
 
 | Task | Details | ADR |
 |------|---------|-----|
-| `MeshView` async geometry path | `rebuildGeometry()` → `await geometryEngine.computeCuboid(corners)` via Wasm worker; sync `updateGeometry()` retained for real-time interactive operations | ADR-027 |
-| Batched computation (multi-object scenes) | `SceneService.batchRebuildSolids(solids)` runs all `rebuildGeometry()` calls via `Promise.all()`; called from `loadScene()` and `importFromJson()` after all entities are created | ADR-027 |
-| Progress indicator | `batchRebuildStart/Progress/End` events emitted when solid count > 3; `AppController` subscribes and shows/updates/hides `showImportProgress()` overlay | ADR-027 |
+| `AnnotatedLineView` | Three.js `Line2` (fat line) with configurable stroke color; BoxHelper for selection | ADR-029 |
+| `AnnotatedRegionView` | Three.js `Line2` closed ring + translucent fill `Mesh` (ShapeGeometry); BoxHelper | ADR-029 |
+| `AnnotatedPointView` | Three.js `Sprite` or `Mesh` (flat circle / diamond); label HTML overlay | ADR-029 |
+| Wire views into `SceneService.create*` | Replace `meshView = null` with constructed view; add `scene.add` / `dispose` | ADR-029 |
+| `AppController` instanceof guards | Grab (G key) allowed; Edit Mode blocked (no sub-element editing yet); Stack blocked | ADR-029 |
 
-### Phase 3 — Expand Rust compute surface ✅ *2026-04-05*
+### Phase 2 — Classification UI (N-panel + Outliner)
 
 | Task | Details | ADR |
 |------|---------|-----|
-| `build_extruded_profile(profile, height)` | Arbitrary n-gon prism geometry in Rust (2*n f32 profile verts + height); fan-triangulated caps + side quads; centroid-based outward-normal test handles CW/CCW input. `GeometryEngine.computeExtrudedProfile()` + `MeshView.rebuildExtrudedProfile()` wired; AppController fires async Wasm rebuild after sync `updateGeometry()` on extrude confirm | ADR-027 |
-| `build_instance_matrices(transforms[])` | Batch TRS → column-major 4×4 matrices in Rust (n×10 f32 → n×16 f32); matches `THREE.Matrix4.compose()` layout exactly; JS fallback via Three.js `Matrix4.compose()`; `GeometryEngine.computeInstanceMatrices()` ready for `THREE.InstancedMesh` usage | ADR-027 |
+| Outliner type icons | `⟿` for AnnotatedLine, `⬡` for AnnotatedRegion, `⬤` for AnnotatedPoint | ADR-029 |
+| Outliner place-type badge | Coloured badge next to name when `placeType` is set | ADR-029 |
+| N-panel "Place Type" section | Badge + Set/Change button + clear button; shown for all three entity types | ADR-029 |
+| Place-type picker overlay | Grouped list filtered by geometry type (`getPlaceTypesByGeometry`); search input | ADR-029 |
+| `SetPlaceTypeCommand` wired to controller | `AppController` subscribes `objectPlaceTypeChanged`; forwards to OutlinerView | ADR-029 |
 
-**Remaining (Phase 3 future)**
+### Phase 3 — Creation UX
 
-| Candidate Task | Description | ADR |
-|---------------|-------------|-----|
-| `run_monte_carlo(params)` | Simulation engine for urban analysis (UrbanPolygon / ADR-026) | ADR-027 |
-| `build_boolean_union(a, b)` | CSG union — could replace server-side BFF round-trip for simple ops | ADR-027, ADR-017 |
-
-### Phase 4 — True zero-copy (SharedArrayBuffer) — partial ✅ *2026-04-05*
-
-> COOP/COEP headers are now set on GitHub Pages via a service worker.
-> The `posView.slice()` step is analysed and deferred — see ADR-027 §Phase 4 Architectural Analysis.
-
-| Task | Status | Details |
-|------|--------|---------|
-| Enable COOP/COEP headers | ✅ *2026-04-05* | `public/coi-serviceworker.js` intercepts every fetch on GitHub Pages and injects `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: require-corp`; `index.html` registers the SW and reloads once on first activation; Vite dev server already sets these headers natively |
-| Shared Wasm Memory | ⏸ Deferred | Requires `RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals"` (nightly Rust as of 2026-04); architectural constraint documented in ADR-027 |
-| Remove the one remaining copy | ⏸ Deferred | Blocked by shared Wasm memory above; single-buffered Rust statics require one copy to guarantee Three.js data ownership (ADR-027 §Phase 4 Architectural Analysis) |
+| Task | Details | ADR |
+|------|---------|-----|
+| "Annotate" submenu in Add menu (Shift+A) | Entries: Route, Boundary, Zone, Hub, Anchor (geometry type inferred from selection) | ADR-029 |
+| `AnnotatedLine` placement mode | Click to place vertices; Enter/RMB to confirm; Escape to cancel | ADR-029 |
+| `AnnotatedRegion` placement mode | Click to place ring vertices; auto-close on first vertex or Enter | ADR-029 |
+| `AnnotatedPoint` placement mode | Single click to place; immediate confirm | ADR-029 |
+| Mobile toolbar for annotation placement | Fixed-slot layout during placement; Cancel in last slot | ADR-024, ADR-029 |
 
 ---
 
-## BFF + Microservices Migration (ADR-015)
+## SpatialLink (ADR-030)
 
-The architecture evolves incrementally from a browser-only SPA toward a thin-client frontend
-backed by a BFF and dedicated microservices.
+Typed semantic edges between annotated elements — makes spatial relationships
+machine-readable in the scene graph. Design defined in ADR-029 §Out of scope;
+full specification in ADR-030.
 
-**Phase B ends with a UX validation checkpoint.**
-Phases C and D are intentionally left open — the direction will be decided based on learnings
-from that checkpoint (pivot if needed).
-
-```
-Browser (View + Controller)
-        │ REST / WebSocket
-        ▼
-BFF (Node.js) — auth, aggregation, routing
-   ├── Scene Service   — scene CRUD + DB
-   ├── User Service    — auth / profile
-   └── Geometry Service — graph eval, STEP import, export
-```
-
-### Phase A — BFF skeleton + Scene persistence ✅ *2026-03-21*
+### Phase 1 — Domain layer
 
 | Task | Details | ADR |
 |------|---------|-----|
-| Scaffold BFF (Node.js / Express or Fastify) | JWT gateway, REST routing stub | ADR-015 |
-| Scene save / load REST endpoints | `POST /scenes`, `GET /scenes/:id` | ADR-015 |
-| Scene Service + DB schema | Store scene JSON (objects + transform graph) | ADR-015, ADR-016 |
-| TransformGraph persistence | Adjacency list: `TransformNode[]` + `TransformEdge[]`; ROS frame + quaternions | ADR-016 |
-| `SceneService` → HTTP client | Replace in-memory CRUD with BFF REST calls | ADR-015 |
-| Existing frontend behaviour unchanged | Client-complete fallback while BFF is wired up | ADR-015 |
-| **`VITE_BFF_URL` env var** | GitHub Pages cannot run server-side code. BFF must be deployed separately (Railway / Render / Fly.io etc.). `BffClient` baseUrl should default to `import.meta.env.VITE_BFF_URL \|\| '/api'` so the production frontend points to the hosted BFF while the dev Vite proxy still works. | ADR-015 |
+| `SpatialLink` domain entity | `id`, `sourceId`, `targetId`, `linkType` (`references` / `connects` / `contains` / `adjacent`); no geometry | ADR-030 |
+| `SceneService.createSpatialLink()` / `deleteSpatialLink()` | Emits `spatialLinkAdded` / `spatialLinkRemoved`; stored in `SceneModel` | ADR-030 |
+| `CreateSpatialLinkCommand` / `DeleteSpatialLinkCommand` | Undo/redo support; factory naming convention | ADR-030, ADR-022 |
+| `SceneSerializer` + `SceneExporter` + `SceneImporter` | `"links": [...]` top-level array; scene version bump to 1.2; backward-compatible load | ADR-030 |
 
-### Phase B — Geometry Service + WebSocket + Node Editor prototype ★ UX checkpoint ✅ *2026-03-21*
+### Phase 2 — Scene graph integration
 
 | Task | Details | ADR |
 |------|---------|-----|
-| Extract Geometry Service | `server/src/geometry/` — OperationGraph (DAG), nodeTypes, evaluator, meshEncoder | ADR-017 |
-| WebSocket session (BFF ↔ Frontend) | `ws` on `/api/ws`; SessionManager; operation-based messages | ADR-017 |
-| Delta-sync protocol on reconnect | `session.resume` → `graph.snapshot` full-state (delta-patch deferred to Phase C) | ADR-017 |
-| Node Editor UI prototype | `NodeEditorView` — SVG DAG panel, draggable nodes, param editor, STEP trigger | ADR-017 |
-| STEP import prototype | `POST /api/import/step` (multer); `import.step` WS message; `occt-import-js` lazy-load | ADR-017 |
-| TransformGraph → DAG | OperationGraph extends TransformGraph with cycle detection (DFS), topo-sort | ADR-017 |
-| BffClient WebSocket | `WsChannel` class; `openWs()`/`closeWs()`; `SceneService.openGeometryChannel()` | ADR-017 |
-| **★ UX validation checkpoint** | Evaluate: latency feel, Node Editor usability, STEP import UX. Decide pivot direction for Phase C+. | — |
+| `getSceneGraph()` extension | Include SpatialLinks as `relation: 'spatial'` edges with `linkType` field | ADR-030, ADR-028 |
+| `SceneService.getLinksOf(entityId)` | Query helper: return all links where `sourceId` or `targetId` matches | ADR-030 |
 
-### Phase C — STEP reference geometry + Solid coexistence ✅ *2026-03-22*
-
-**Goal**: Import STEP files and display them in the scene as reference geometry while continuing
-to model with Solid objects in the same scene.
-`ImportedMesh` is a thin-client entity — it only displays server-evaluated geometry (read-only).
-Solid objects remain thick-client (local editing).
-
-> **Prerequisite**: Phase B UX checkpoint cleared. Phase B WebSocket + Geometry Service continues.
+### Phase 3 — Rendering
 
 | Task | Details | ADR |
 |------|---------|-----|
-| `ImportedMeshView` | Display arbitrary triangle mesh (positions/normals/indices) via Three.js BufferGeometry. Manages BoxHelper and visibility only; no edit mesh. | — |
-| `ImportedMesh` domain entity | Holds `id`, `name`, `meshView: ImportedMeshView`. Methods: `rename()`, `move()`. Distinguished from Solid/Profile via `instanceof ImportedMesh`. | — |
-| `SceneService.createImportedMesh()` | Create ImportedMesh + ImportedMeshView and register in SceneModel. Emits `objectAdded`. | — |
-| `SceneService._applyGeometryUpdate()` | If objectId not in SceneModel → auto-create via `createImportedMesh()`. For ImportedMesh → call `meshView.updateGeometryBuffers()`. | — |
-| `OutlinerView` type icons | Added `type` argument to `addObject(id, name, type)`. `'imported'` → `⬡` in grey (distinct from Solid blue). Edit button disabled. | — |
-| `AppController` ImportedMesh guards | Edit Mode transition blocked with toast. Grab (G key) and pointer drag allowed. Ctrl+drag rotation and pivot selection blocked. | — |
-| `SceneView.fitCameraToSphere()` | Repositions camera and expands `camera.far` after geometry load. Triggered by `geometryApplied` event. | — |
-| Unit conversion dialog | `NodeEditorView._showUnitDialog()` — 6 scale presets (mm→m, etc.) applied server-side before streaming. | — |
-| occt-import-js API fix | Geometry extracted at mesh level (`mesh.attributes.position.array`), not face level. | — |
+| `SpatialLinkView` | Three.js dashed line/arrow between source and target world centroids; updates per animation frame | ADR-030 |
+| Color-coded by `linkType` | `references`=amber, `connects`=cyan, `contains`=violet, `adjacent`=slate | ADR-030 |
+| Polymorphic interface completeness | No-op stubs for all AppController-called MeshView methods (PHILOSOPHY #17) | ADR-030 |
 
-**Out of scope (deferred to Phase D)**:
-- STEP geometry scene persistence (SceneSerializer extension / embedding geometry in scene.data)
-- Node Editor DAG topology editing (add/remove nodes and edges)
-- Delta-sync protocol (currently full-graph snapshot only)
-- Multi-instance BFF / Redis session sharing
+### Phase 4 — Creation UI
 
-### Phase D — Post-C (direction TBD after Phase C checkpoint)
+| Task | Details | ADR |
+|------|---------|-----|
+| Two-phase `L`-key link creation | Select source → `L` key → click target → linkType picker overlay → confirm | ADR-030 |
+| N-panel "Spatial Links" section | List all links for selected entity with delete button per link | ADR-030 |
+| Outliner badge for linked entities | Small icon when entity participates in ≥ 1 SpatialLink | ADR-030 |
+| `AppController` guards | Block Grab / Edit / Stack / Dup for `SpatialLink`; `showToast()` on blocked ops | ADR-030 |
+
+---
+
+## Wasm Geometry Engine — remaining work (ADR-027)
+
+Phases 1–4 are implemented (2026-04-05). See ADR-027 for full design and implementation details.
+
+**Remaining Phase 3 candidates**
+
+| Candidate Task | Description | ADR |
+|---------------|-------------|-----|
+| `run_monte_carlo(params)` | Simulation engine for urban / spatial analysis | ADR-027 |
+| `build_boolean_union(a, b)` | CSG union — could replace server-side BFF round-trip for simple ops | ADR-027, ADR-017 |
+
+**Phase 4 deferred**
+
+| Task | Status | Details |
+|------|--------|---------|
+| Shared Wasm Memory | ⏸ Deferred | Requires `RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals"` (nightly Rust); architectural analysis in ADR-027 |
+| Remove the one remaining copy | ⏸ Deferred | Blocked by shared Wasm memory above |
+
+---
+
+## BFF Phase D (ADR-015)
+
+Phases A, B, C implemented (2026-03-21 to 2026-03-22). See ADR-015 and ADR-017 for details.
 
 > **Priority to be determined after Phase C completion.**
-
-Candidate tasks:
 
 | Candidate Task | Original Phase | ADR |
 |---------------|----------------|-----|
@@ -144,111 +125,6 @@ Candidate tasks:
 | Remove all domain computation from frontend | D | ADR-015 |
 | Frontend unit tests — View / Controller only | D | ADR-015 |
 | Independent Geometry Service scaling | D | ADR-015 |
-
----
-
----
-
-## Lynch Urban Elements — 2D Map Classification (ADR-026)
-
-New 2D entity types for city-scale urban morphology based on Kevin Lynch's
-*The Image of the City* (1960).  Domain layer (entities, registry, service,
-serializer) is complete.  The phases below cover the rendering and UI layers.
-
-### Phase 1 — Rendering layer ★ prerequisite for all UI
-
-| Task | Details | ADR |
-|------|---------|-----|
-| `UrbanPolylineView` | Three.js `Line2` (fat line) with configurable stroke color; BoxHelper for selection | ADR-026 |
-| `UrbanPolygonView` | Three.js `Line2` closed ring + translucent fill `Mesh` (ShapeGeometry); BoxHelper | ADR-026 |
-| `UrbanMarkerView` | Three.js `Sprite` or `Mesh` (flat circle / diamond); label HTML overlay | ADR-026 |
-| Wire views into `SceneService.create*` | Replace `meshView = null` with constructed view; add scene.add / dispose | ADR-026 |
-| `AppController` instanceof guards | Grab (G key) allowed; Edit Mode blocked (no sub-element editing yet); Stack blocked | ADR-026 |
-
-### Phase 2 — Classification UI (N-panel + Outliner)
-
-| Task | Details | ADR |
-|------|---------|-----|
-| Outliner type icons | `⟿` for UrbanPolyline, `⬡` for UrbanPolygon, `⬤` for UrbanMarker | ADR-026 |
-| Outliner Lynch class badge | Coloured badge (Lynch color) next to name when `lynchClass` is set | ADR-026 |
-| N-panel "Lynch Class" section | Badge + Set/Change button + clear button; shown for all three Urban entity types | ADR-026 |
-| Lynch class picker overlay | Grouped list filtered by geometry type (`getLynchClassesByGeometry`); search input | ADR-026 |
-| `SetLynchClassCommand` wired to controller | `AppController` subscribes `objectLynchClassChanged`; forwards to OutlinerView | ADR-026 |
-
-### Phase 3 — Creation UX
-
-| Task | Details | ADR |
-|------|---------|-----|
-| "Urban" submenu in Add menu (Shift+A) | Entries: Urban Path, Urban Edge, Urban District, Urban Node, Urban Landmark | ADR-026 |
-| UrbanPolyline placement mode | Click to place vertices; Enter/RMB to confirm; Escape to cancel | ADR-026 |
-| UrbanPolygon placement mode | Click to place ring vertices; auto-close on first vertex or Enter | ADR-026 |
-| UrbanMarker placement mode | Single click to place; immediate confirm | ADR-026 |
-| Mobile toolbar for Urban placement | Fixed-slot layout during placement; Cancel in last slot | ADR-024, ADR-026 |
-
----
-
-## Coordinate Space Type Safety
-
-**Goal**: eliminate the class of bugs where `LocalVector3` is silently used where
-`WorldVector3` is required (or vice versa) by making the distinction enforceable at
-compile time. Root cause documented in PHILOSOPHY #21.
-
-**Root cause of the nested-frame bug (2026-04-07)**:
-`CoordinateFrame.corners` returns `[this.translation]` — a parent-relative local offset.
-Geometry `corners` return world-space positions. Both are `Vector3[]`. The spatial
-computation layer treated them uniformly, producing wrong world positions for nested frames
-and connection lines anchored at world origin.
-
-### Phase 1 — Hotfix ✅ *2026-04-07*
-
-| Task | Details |
-|------|---------|
-| `instanceof` branch in `_updateWorldPoses()` | For `CoordinateFrame` parents: read world position from `_worldPoseCache`; for geometry: compute centroid from `corners` as before |
-| `instanceof` branch in `createCoordinateFrame()` | Same branching for initial world position on frame creation |
-| CODE_CONTRACTS rule | "CoordinateFrame.corners Is Local Space" added to `architecture.md` and index |
-| PHILOSOPHY principle | #21 "Coordinate Spaces Are Statically Distinguished" added |
-
-### Phase 2 — Branded type annotations (JSDoc) ✅ *2026-04-07*
-
-**Approach**: JSDoc intersection types create compile-time brands with zero runtime overhead.
-`tsc --checkJs` enforces them without a TypeScript migration.
-
-| Task | Details |
-|------|---------|
-| Add branded type aliases ✅ | `src/types/spatial.js` — exports `@typedef WorldVector3` and `LocalVector3` as branded `THREE.Vector3` intersections |
-| Annotate `corners` return types ✅ | `/** @returns {WorldVector3[]} */` on Solid, ImportedMesh, Profile; `/** @returns {LocalVector3[]} */` on CoordinateFrame |
-| Annotate `_worldPoseCache` values ✅ | `{ position: WorldVector3, quaternion: THREE.Quaternion }` |
-| Annotate `_updateWorldPoses()` locals ✅ | `parentWorldPos: WorldVector3`, `worldPos: WorldVector3` |
-| Annotate `createCoordinateFrame()` locals ✅ | `initialWorldPos: WorldVector3` |
-| Wire `tsc --checkJs` into CI ✅ | `tsconfig.json` (`checkJs: true`, `noImplicitAny: false`, `strictFunctionTypes: true`, `noEmit: true`); `pnpm typecheck` script; CI step after install, before build |
-| Bonus: fix Urban entity Vertex bug ✅ | `UrbanPolyline/Polygon/Marker.fromPoints()` passed only `id` to `new Vertex()`, leaving `position` undefined — caught by tsc; fixed to `new Vertex(id, p.clone())` |
-| Scope note | `src/types/` and `src/domain/` are the checked include set. View/service files transitively pulled in carry `// @ts-nocheck` until full annotation is done in Phase 3. `strict: true` deferred to Phase 3. |
-
-**Expected outcome**: any future code that passes `frame.corners[0]` (LocalVector3) where
-a WorldVector3 is expected produces a type error at `pnpm typecheck` — caught before merge.
-`pnpm typecheck` is now a required CI gate on every push to main/master.
-
-### Phase 3 — Structural separation ✅ *2026-04-07*
-
-**Chosen option**: Rename `CoordinateFrame.corners` → `localOffset`.
-
-Phase 2 enforces coordinate-space safety via the type checker (brands), but `CoordinateFrame.corners`
-still existed as a property — the API shape allowed confusion even if the type checker warned.
-Phase 3 eliminates the confusion at the **API level**: accessing `.corners` on a CoordinateFrame
-now returns `undefined`. No branch, no annotation, no code review can save incorrect code —
-the property simply does not exist.
-
-This aligns with PHILOSOPHY #2 ("Type Is the Capability Contract") and the full intent of
-PHILOSOPHY #21 ("The type system must enforce this — **not documentation, not naming conventions,
-not code review**").
-
-| Task | Details |
-|------|---------|
-| Rename `CoordinateFrame.get corners()` → `get localOffset()` | Property name encodes semantics; accessing `.corners` on a frame returns `undefined` |
-| Add `_grabHandlesOf(obj)` helper in AppController | Single `instanceof` branch; all grab/move/cancel/undo paths use it |
-| Fix nested-frame N-panel bug | `onFramePositionChange` used `parent.corners` as world pos for CF parents — now uses `worldPoseOf()` |
-| Update `MoveCommand.js` | Add `CoordinateFrame` import + `localOffset` branch |
-| Update `spatial.js` | `LocalVector3` comment refers to `localOffset`, not `corners` |
 
 ---
 
@@ -271,7 +147,7 @@ Mobile UX design decisions are formally documented in:
 - **ADR-023** — Mobile Input Model (touch gesture model, device detection, OrbitControls strategy, confirmation lifecycle)
 - **ADR-024** — Mobile Toolbar Architecture (fixed-slot layout, spacer pattern, mode-specific layouts)
 
-Mobile UX Phases 1 and 2 were completed 2026-03-28. Remaining items are grouped by phase.
+Phases 1 and 2 completed 2026-03-28.
 
 ### Phase 3 — Advanced touch controls
 
@@ -310,59 +186,24 @@ Bugs are also tracked on GitHub Issues #69–#73.
 
 ---
 
-## Completed
+## Completed phases
 
-| Item | Date |
-|------|------|
-| Wasm Geometry Engine Phase 4 — COOP/COEP via `public/coi-serviceworker.js`; `index.html` SW registration with one-shot reload; `typeof SharedArrayBuffer !== 'undefined'` now true on GitHub Pages; shared Wasm memory deferred (requires nightly Rust); architectural analysis documented in ADR-027 (ADR-027) | 2026-04-05 |
-| Wasm Geometry Engine Phase 3 — `build_extruded_profile()` (arbitrary n-gon prism); `build_instance_matrices()` (batch TRS→4x4); `GeometryEngine.computeExtrudedProfile()` + `computeInstanceMatrices()`; `MeshView.rebuildExtrudedProfile()`; AppController async Wasm rebuild on extrude confirm (ADR-027) | 2026-04-05 |
-| Wasm Geometry Engine Phase 2 — `MeshView.rebuildGeometry()` async Wasm path; `SceneService.batchRebuildSolids()` parallel rebuild via `Promise.all()`; progress overlay for batches > 3 objects; `importFromJson()` made async; sync `updateGeometry()` retained for interactive ops (ADR-027) | 2026-04-05 |
-| Wasm Geometry Engine — three-layer architecture (Rust/Wasm + Web Worker + GeometryEngine.js facade); zero-copy data path; `pnpm build:wasm` pipeline; wasm-pack output committed; CI updated; JS-only devs need no Rust toolchain (ADR-027) | 2026-04-05 |
-| IFC semantic classification — `IFCClassRegistry`, `SetIfcClassCommand`; N-panel IFC class picker (dropdown) for Solid and ImportedMesh; `Ctrl+Z` undoable; `SceneSerializer` and `SceneExporter` include `ifcClass` field (ADR-025) | 2026-04-01 |
-| Documentation — `docs/SCREEN_DESIGN.md`, `docs/LAYOUT_DESIGN.md`, `docs/EVENTS.md` created (Japanese → English); Mermaid `block-beta` diagrams; `CLAUDE.md` change-impact matrix added | 2026-04-01 |
-| Documentation — `docs/PHILOSOPHY.md` created: 20 design principles distilled from MENTAL_MODEL, PROCESS_NOTES, and ADRs; doc-structure refactored (MENTAL_MODEL → CODE_CONTRACTS + DEVELOPMENT + PHILOSOPHY) | 2026-04-01 |
-| Bugfix — Mobile header overflow: Export/Import buttons replaced by `_moreMenuBtn` (⋯) dropdown on mobile; `_headerStatusEl` uses `visibility:hidden` to remain a flex spacer | 2026-04-01 |
-| Scene JSON import — `SceneImporter.js` (pure: parse/validate JSON v1.0 and v1.1); `SceneService.importFromJson()` reconstructs all entity types; merge mode remaps IDs; `UIView` gains Import header button + `showImportModal()`; `Ctrl+I` shortcut | 2026-04-01 |
-| Scene JSON export — `SceneExporter.js` (pure computation); downloads structured JSON snapshot; geometry Base64-encoded for ImportedMesh; `UIView` gains Export header button; `Ctrl+E` shortcut | 2026-03-31 |
-| Swagger UI — `swagger-ui-express` v5; OpenAPI 3.0 spec for all BFF endpoints mounted at `GET /api/docs`; JWT BearerAuth security scheme and dev-token flow documented | 2026-03-29 |
-| Mobile UX documentation — ADR-023 (Mobile Input Model: touch gesture model, device detection, OrbitControls strategy, confirmation lifecycle); ADR-024 (Mobile Toolbar Architecture: fixed-slot layout, spacer pattern, mode-specific layouts); MENTAL_MODEL.md split into 6.9k index + 4 detail files | 2026-03-29 |
-| OrbitControls bugfix — OrbitControls now disabled during 2D extrude height-drag and face-extrude auto-start on touch (coarse pointer) devices; `_onPointerDown` gained `2d-extrude` early-return; face-extrude auto-start guard corrected from `innerWidth < 768` to `matchMedia` | 2026-03-29 |
-| Mobile UX Phase 2 — Measure tool quick-access (promoted to top of Add menu: Measure → Box → Sketch → Frame → Import STEP); Frame Rotate button for CoordinateFrame (5-slot Object mode toolbar: Rotate\|Grab\|Delete\|Add Frame\|spacer; `ICONS.rotate`, `ICONS.grab`, `ICONS.frame` added); long-press context menu (400ms popup with Grab/Duplicate/Delete/Rename; `UIView.showContextMenu`/`hideContextMenu`/`showRenameDialog`) | 2026-03-28 |
-| Mobile UX Phase 1 — Undo/Redo header buttons (`_undoBtn`/`_redoBtn`, `setUndoRedoEnabled`); Duplicate button in Object mode toolbar (5-slot: Add\|Dup\|Edit\|Delete\|Stack); first-run onboarding overlay (`showOnboardingIfNeeded`, `localStorage.ee_onboarded`); touch gesture model: single-finger drag = orbit, long-press ≥ 400 ms on selected object = Grab (`_longPress` state) | 2026-03-28 |
-| Undo/Redo Phase 4 — `RenameCommand`, `FrameRotateCommand`; `MoveCommand` extended to all entity types (CoordinateFrame, MeasureLine, ImportedMesh); `SceneService.invalidateWorldPose`; `FrameMoveCommand` covered by updated `MoveCommand` (ADR-022) | 2026-03-27 |
-| Undo/Redo Phase 3 — `AddSolidCommand` + `DeleteCommand` (soft-delete: detach without dispose, bounded by MAX=50); `_deleteObject` no longer calls `deleteObject` (dispose); `_addObject` pushes undo record (ADR-022) | 2026-03-27 |
-| Undo/Redo Phase 2 — `FaceExtrudeCommand` (corner-snapshot via MoveCommand), `ExtrudeSketchCommand` (Profile↔Solid swap); `SceneService.detachObject`/`reattachObject`; `extrudeProfile` now emits events (ADR-022) | 2026-03-27 |
-| Undo/Redo Phase 1 — `CommandStack` + `MoveCommand` (Grab); `Ctrl+Z`/`Ctrl+Y`/`Ctrl+Shift+Z`; stack cleared on scene load (ADR-022) | 2026-03-27 |
-| Entity taxonomy redesign — `Cuboid`→`Solid`, `Sketch`→`Profile`; LocalGeometry unified interface for MeasureLine/Profile; `CoordinateFrame._worldPos` → `SceneService._worldPoseCache`; Euler convention → ROS RPY (ADR-020, ADR-021) | 2026-03-26 |
-| Save/Load Scene UI — header buttons, `enableSaveLoad()`, `_saveScene()`/`_loadScene()` dialogs; `_clearScene()` now emits `objectRemoved`; SceneSerializer handles CoordinateFrame + MeasureLine | 2026-03-26 |
-| CoordinateFrame N panel UX — R-key updates N panel in realtime; Location/Rotation labels clarified (World vs Local, RPY); Origin frame shows actual world position; two bug fixes | 2026-03-25 |
-| CoordinateFrame Phase B — nested frame hierarchy (frame→frame), R-key rotation (X/Y/Z axis + numeric input), `CoordinateFrameView.updateRotation()`, topological-sort animation loop, Outliner multi-level indentation, recursive cascade delete (ADR-019) | 2026-03-23 |
-| CoordinateFrame Phase A — attach named SE(3) frames to geometry objects; auto Origin frame on Solid creation; Outliner indentation; parent-gated visibility (X-ray when selected) (ADR-018) | 2026-03-23 |
-| Move support for ImportedMesh and MeasureLine — synthetic AABB corners + `move()` for ImportedMesh; `corners`/`move()` for MeasureLine; `updateGeometry()`/`updateBoxHelper()` on both views | 2026-03-23 |
-| STEP import end-to-end — occt-import-js API fix (geometry at mesh level); camera far-clip / fitCameraToSphere; `_finalizeRectSelection` ImportedMesh guard; unit conversion dialog | 2026-03-23 |
-| Server startup fix — `PRAGMA journal_mode = WAL` moved out of `db.batch()` into standalone `db.execute()` | 2026-03-23 |
-| Measure guide + snap display fix — MeasureLineView no-op interface completeness; `_measure.snapMeshView` for snap display fallback when active object is MeasureLine | 2026-03-23 |
-| Mobile Stack snap fix + footer keybinding update | 2026-03-23 |
-| Mobile toolbar 4-slot unification — `{ spacer: true }` placeholder; all modes padded to 4 slots | 2026-03-22 |
-| MeasureLine — 1D measure tool: M key / Shift+A → Measure; V/E/F snap during placement; amber dashed line + HTML distance label; Outliner icon | 2026-03-22 |
-| BFF Phase C — ImportedMesh thin-client entity, ImportedMeshView, SceneService.createImportedMesh(), _applyGeometryUpdate() routing, OutlinerView type icon, AppController guards | 2026-03-22 |
-| BFF Phase B — Geometry Service (DAG evaluator), WebSocket session (ADR-017), Node Editor UI prototype, STEP import (REST + WS), BffClient WsChannel | 2026-03-21 |
-| BFF Phase A — Express BFF scaffold, SQLite scene persistence, TransformGraph storage (ADR-016), BffClient, SceneSerializer, Vite proxy, pnpm workspace | 2026-03-21 |
-| Mobile touch support — Pointer Events API, `_activeDragPointerId`, mobile toolbar, canvas target guard, touch hover sync, face-extrude confirm on `pointerup` | 2026-03-21 |
-| Architecture design — BFF + microservices strategy, transform graph (SE(3) tree, ROS frames, quaternions) | 2026-03-21 (ADR-015, ADR-016) |
-| DDD Phase 6 — Sub-element selection (1/2/3 keys); Grab snap expanded to all geometry (ADR-014) | 2026-03-20 |
-| DDD Phase 5-3 — Edge/Face graph objects; unified selection model; dimension field removed (ADR-012) | 2026-03-20 |
-| DDD Phase 5-2 — Event-driven status bar; _refreshObjectModeStatus() | 2026-03-20 |
-| DDD Phase 5-1 — Vertex layer in graph model (ADR-012) | 2026-03-20 |
-| DDD Phase 4 — Domain events (EventEmitter); SceneService observable (ADR-013) | 2026-03-20 |
-| DDD Phase 3 — SceneService ApplicationService layer (ADR-011) | 2026-03-20 |
-| DDD Phase 2 — Domain entity behaviour methods (ADR-010) | 2026-03-20 |
-| DDD Phase 1 — Typed domain entities Cuboid / Sketch (ADR-009) | 2026-03-20 |
-| Method B: Sketch → Extrude (ADR-002) + Edit Mode 2D/3D dispatch (ADR-004) | 2026-03-20 |
-| Custom BufferGeometry cuboid + Face Extrude | 2026-03-17 |
-| MVC refactor (Model / View / Controller separation) | 2026-03-17 |
-| Blender-style Grab controls (G/X/Y/Z, numeric input) | 2026-03-18 |
-| ROS world frame (+X forward, +Y left, +Z up) | 2026-03-19 |
-| Blender-style UI (header bar, N panel, bottom info bar) | 2026-03-19 |
-| Colored status display (`setStatusRich`) | 2026-03-19 |
-| Cuboid-based architecture design + ADRs (ADR-007) | 2026-03-20 |
+Full implementation history in `docs/SESSION_LOG.md`. Detailed design rationale in the respective ADRs.
+
+| Feature | Completion | ADR / Notes |
+|---------|------------|-------------|
+| Spatial Annotation System refactor (UrbanPolyline→AnnotatedLine etc.) | 2026-04-08 | ADR-029 |
+| Coordinate Space Type Safety (Phases 1–3: instanceof hotfix → JSDoc brands → API separation) | 2026-04-07 | PHILOSOPHY #21, CODE_CONTRACTS |
+| Wasm Geometry Engine (Phases 1–4: Rust/Wasm + Worker + COOP/COEP) | 2026-04-05 | ADR-027 |
+| IFC Semantic Classification | 2026-04-01 | ADR-025 |
+| Undo / Redo (Phases 1–4: Command pattern, all entity types) | 2026-03-27 | ADR-022 |
+| Mobile UX (Phases 1–2: toolbar, gestures, long-press, onboarding) | 2026-03-28 | ADR-023, ADR-024 |
+| BFF + Microservices (Phases A–C: BFF, WebSocket, STEP import, ImportedMesh) | 2026-03-21 to 2026-03-22 | ADR-015, ADR-017 |
+| Entity taxonomy redesign (Cuboid→Solid, Sketch→Profile) | 2026-03-26 | ADR-020, ADR-021 |
+| CoordinateFrame (Phase A: attach + auto-origin; Phase B: nested hierarchy + rotation) | 2026-03-23 | ADR-018, ADR-019 |
+| Anchored Annotations & Scene Graph API | 2026-04-06 | ADR-028 |
+| Save / Load Scene UI + SceneSerializer | 2026-03-26 | ADR-015 |
+| MeasureLine (1D annotation with snap) | 2026-03-22 | ADR-021 |
+| Scene JSON export + import (Ctrl+E / Ctrl+I) | 2026-03-31 to 2026-04-01 | ADR-015 |
+| DDD Phases 1–6 (domain entities, events, graph model, sub-element selection) | 2026-03-20 | ADR-009–ADR-014 |
+| MVC refactor, ROS world frame, Blender-style UI and controls | 2026-03-17 to 2026-03-19 | ADR-002–ADR-008 |

--- a/docs/adr/ADR-015-bff-microservices-architecture.md
+++ b/docs/adr/ADR-015-bff-microservices-architecture.md
@@ -2,8 +2,16 @@
 
 - **Status**: Accepted
 - **Date**: 2026-03-20
-- **Implemented (Phase A)**: 2026-03-21
 - **References**: ADR-011, ADR-012, ADR-013
+
+## Implementation Status
+
+| Phase | Summary | Date |
+|-------|---------|------|
+| **Phase A** | Express BFF skeleton; SQLite scene persistence; `TransformGraph` storage; `BffClient`; `SceneSerializer`; Vite proxy; pnpm workspace | ✅ 2026-03-21 |
+| **Phase B** | Geometry Service (DAG evaluator); WebSocket session (ADR-017); Node Editor UI prototype; STEP import (REST + WS); `BffClient.WsChannel` | ✅ 2026-03-21 |
+| **Phase C** | `ImportedMesh` thin-client entity + `ImportedMeshView`; `SceneService.createImportedMesh()` + `_applyGeometryUpdate()`; Outliner type icon; AppController guards; `fitCameraToSphere()`; unit conversion dialog | ✅ 2026-03-22 |
+| **Phase D** | Direction TBD after Phase C checkpoint — see ROADMAP §BFF Phase D | Pending |
 
 ---
 

--- a/docs/adr/ADR-027-wasm-geometry-engine.md
+++ b/docs/adr/ADR-027-wasm-geometry-engine.md
@@ -7,6 +7,16 @@
 | **Deciders** | yuubae215 |
 | **Related** | ADR-007 (Cuboid geometry), ADR-012 (Graph-based geometry), ADR-017 (WebSocket geometry service) |
 
+## Implementation Status
+
+| Phase | Summary | Date |
+|-------|---------|------|
+| **Phase 1** — Infrastructure | Rust crate `wasm-engine/` with `build_cuboid_geometry()`; `geometry.worker.js` bridge (zero-copy pointer read, ArrayBuffer transfer); `GeometryEngine.js` facade (Promise API, graceful JS fallback); `pnpm build:wasm` pipeline; generated Wasm committed | ✅ 2026-04-05 |
+| **Phase 2** — Rendering pipeline | `MeshView.rebuildGeometry()` async Wasm path; `SceneService.batchRebuildSolids()` parallel rebuild via `Promise.all()`; progress overlay for batches > 3 objects; `importFromJson()` made async; sync `updateGeometry()` retained for interactive ops | ✅ 2026-04-05 |
+| **Phase 3** — Expanded compute | `build_extruded_profile()` (arbitrary n-gon prism); `build_instance_matrices()` (batch TRS → 4×4); `GeometryEngine.computeExtrudedProfile()` + `computeInstanceMatrices()`; `MeshView.rebuildExtrudedProfile()`; AppController async Wasm rebuild on extrude confirm | ✅ 2026-04-05 |
+| **Phase 4** — COOP/COEP | `public/coi-serviceworker.js` injects isolation headers on GitHub Pages; `index.html` registers SW with one-shot reload; `SharedArrayBuffer` now available on GitHub Pages | ✅ 2026-04-05 |
+| **Phase 4** — Shared Wasm Memory | Requires nightly Rust (`+atomics,+bulk-memory`); architectural constraint documented in §Future Work | ⏸ Deferred |
+
 ---
 
 ## Context

--- a/docs/adr/ADR-030-spatial-link.md
+++ b/docs/adr/ADR-030-spatial-link.md
@@ -1,0 +1,213 @@
+# ADR-030 — SpatialLink: Typed Semantic Edges Between Annotated Elements
+
+| Field | Value |
+|-------|-------|
+| **Status** | Proposed |
+| **Date** | 2026-04-09 |
+| **References** | ADR-029, ADR-028, ADR-013, ADR-020, ADR-022 |
+
+---
+
+## Context
+
+ADR-029 defines three annotation entity types (`AnnotatedLine`, `AnnotatedRegion`,
+`AnnotatedPoint`) and their place-type classifications (Route, Boundary, Zone, Hub, Anchor).
+While each entity carries semantic meaning via its `placeType`, the *relationships* between
+entities — spatial proximity, topological containment, datum derivation — remain implicit.
+They are visible to the user's eye but invisible to the system.
+
+ADR-028's `getSceneGraph()` already supports typed edges:
+
+- `'frame'` — CoordinateFrame parent-child chains
+- `'anchor'` — MeasureLine endpoint anchor references
+
+The architecture is ready to accept a third relation type: `'spatial'`.
+
+ADR-029 explicitly defers `SpatialLink` (see §Out of scope) and defines its minimal shape:
+
+```js
+{
+  id:       'link_001',
+  sourceId: 'annot_point_A',
+  targetId: 'annot_point_B',
+  linkType: 'references',
+}
+```
+
+This ADR designs and implements that entity.
+
+### Relationship to CoordinateFrame
+
+`aligns` is deliberately excluded from the `linkType` vocabulary (see ADR-029).
+When two things align — a datum hole and a jig pin — they establish a new coordinate
+basis: the alignment *is* a `CoordinateFrame`. The mathematical relationship is expressed
+by placing a frame at the datum location. The semantic relationship between the two
+annotated points is `references` — "A derives its positional datum from B" — which is a
+meaning-carrying relationship, not a geometric transform.
+
+---
+
+## Decision
+
+### 1. Domain entity
+
+`SpatialLink` is a first-class domain entity in `src/domain/SpatialLink.js`.
+
+```js
+class SpatialLink {
+  constructor(id, sourceId, targetId, linkType) {
+    this.id       = id
+    this.sourceId = sourceId   // ID of any scene entity
+    this.targetId = targetId   // ID of any scene entity
+    this.linkType = linkType   // see §2
+  }
+}
+```
+
+`SpatialLink` is stored in `SceneModel` alongside other entities. It is NOT a geometry
+entity — it has no `meshView`, no `corners`, no `move()`. `AppController` must guard
+Grab / Edit / Stack / Duplicate for `SpatialLink` the same way it does for `MeasureLine`.
+
+### 2. linkType vocabulary
+
+| linkType | Directed? | Meaning |
+|----------|-----------|---------|
+| `references` | yes | Source derives its positional datum from target (tolerance chain) |
+| `connects` | no | A route logically connects source to target |
+| `contains` | yes | Region source spatially contains entity target |
+| `adjacent` | no | Source and target share a boundary or are spatially neighbouring |
+
+`aligns` is not included — it is a CoordinateFrame concept (see Context above).
+
+### 3. SceneService API
+
+```js
+// Create
+createSpatialLink(sourceId, targetId, linkType)
+  // → emits spatialLinkAdded({ link: SpatialLink })
+
+// Delete
+deleteSpatialLink(linkId)
+  // → emits spatialLinkRemoved({ linkId })
+
+// Query
+getLinksOf(entityId)
+  // → SpatialLink[] — all links where sourceId or targetId === entityId
+```
+
+### 4. Command layer
+
+| Command factory | Undo action |
+|-----------------|-------------|
+| `createSpatialLinkCommand(link)` | `deleteSpatialLink(link.id)` |
+| `deleteSpatialLinkCommand(link)` | recreate with same `id`, `sourceId`, `targetId`, `linkType` |
+
+Both commands follow the `createXCommand` factory naming convention (CODE_CONTRACTS §Architecture).
+
+### 5. Scene graph integration
+
+`getSceneGraph()` includes SpatialLink edges as `relation: 'spatial'`:
+
+```js
+{
+  nodes: [{ id, name, type, parentId }],
+  edges: [
+    { from: 'annot_point_A', to: 'annot_point_B', relation: 'spatial', linkType: 'references' },
+    // … existing 'frame' and 'anchor' entries
+  ]
+}
+```
+
+### 6. Serialization
+
+`SceneSerializer` includes SpatialLinks as a top-level `"links"` array (version bump to `1.2`):
+
+```jsonc
+{
+  "version": "1.2",
+  "objects": [...],
+  "links": [
+    {
+      "type": "SpatialLink",
+      "id": "link_001",
+      "sourceId": "annot_point_A",
+      "targetId": "annot_point_B",
+      "linkType": "references"
+    }
+  ]
+}
+```
+
+`SceneImporter` restores links after all entity IDs are mapped (same deferred pattern as
+CoordinateFrame `parentId` resolution). Absence of `"links"` is treated as `[]` — backward
+compatible with v1.0 / v1.1 scenes.
+
+### 7. Rendering (Phase 3)
+
+`SpatialLinkView` renders a dashed line or directed arrow between the world centroids of
+source and target entities. It updates each animation frame via the `_updateWorldPoses()`
+loop. Color is coded by `linkType`:
+
+| linkType | Color |
+|----------|-------|
+| `references` | amber `#F59E0B` |
+| `connects` | cyan `#06B6D4` |
+| `contains` | violet `#8B5CF6` |
+| `adjacent` | slate `#64748B` |
+
+`SpatialLinkView` must implement a complete no-op interface for every `MeshView` method
+called through polymorphic references in `AppController` (PHILOSOPHY #17 — Polymorphic
+Interfaces Must Be Complete).
+
+### 8. Creation UI (Phase 4)
+
+Two-phase selection flow:
+
+1. Select source entity → press `L` key (or Add menu → "Spatial Link")
+2. Status bar prompts "Click target entity"
+3. Click target → link-type picker overlay appears (four buttons)
+4. Confirm → `CreateSpatialLinkCommand` pushed to undo stack
+
+N-panel shows a "Spatial Links" section for the selected entity listing all links where
+it is source or target, with a delete button per link. Outliner displays a small badge
+icon when an entity participates in one or more SpatialLinks.
+
+---
+
+## Consequences
+
+### Benefits
+
+- Spatial relationships are machine-readable — `getSceneGraph()` can detect semantically
+  isolated clusters, datum chains, and containment hierarchies
+- `getLinksOf(entityId)` enables future analytics (how many things reference this datum?)
+- Serialization preserves relationships; reopening a scene restores them exactly
+
+### Constraints
+
+- `SpatialLink` has no geometry — cannot be grabbed, extruded, edited, or stacked
+- `AppController` must add `instanceof SpatialLink` guards (same pattern as MeasureLine)
+- `SpatialLinkView` must satisfy PHILOSOPHY #17 (polymorphic interface completeness)
+- Deleting a source or target entity does NOT auto-delete the link — the link becomes
+  "dangling". `getLinksOf()` callers should filter links where the referenced entity no
+  longer exists. A future enhancement could show a "broken link" indicator.
+
+### Out of scope
+
+- **Constraint solving**: `SpatialLink` is semantic, not geometric. Making `references`
+  drive world-position updates (like CoordinateFrame parenting) requires a separate
+  constraint-solver ADR.
+- **Directed graph visualization** (force layout, Sankey diagram) — deferred to a future UX ADR.
+- **Multi-hop path queries** (shortest path between two entities) — deferred.
+
+---
+
+## References
+
+- ADR-029 — Spatial Annotation System (defines entity types; defers SpatialLink)
+- ADR-028 — Anchored Annotations & Scene Graph API (`getSceneGraph()` structure)
+- ADR-013 — Domain Events
+- ADR-020 — Domain Entity Taxonomy
+- ADR-022 — Undo / Redo via Command Pattern
+- PHILOSOPHY #17 — Polymorphic Interfaces Must Be Complete
+- PHILOSOPHY #2 — Type Is the Capability Contract

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,6 +41,7 @@ This directory records the project's design decisions.
 | [ADR-027](ADR-027-wasm-geometry-engine.md) | **Wasm Geometry Engine — Three-Layer Architecture with Zero-Copy Data Path** | Accepted | 2026-04-05 | ADR-007, ADR-012, ADR-017 |
 | [ADR-028](ADR-028-anchored-annotations-scene-graph.md) | **Anchored Annotations & Scene Graph API** | Accepted | 2026-04-06 | ADR-012, ADR-016, ADR-018, ADR-019, ADR-021 |
 | [ADR-029](ADR-029-spatial-annotation-system.md) | **Spatial Annotation System — AnnotatedLine/Region/Point with Place Types** | Accepted | 2026-04-08 | ADR-020, ADR-021, ADR-022, ADR-025, ADR-013, ADR-028 |
+| [ADR-030](ADR-030-spatial-link.md) | **SpatialLink — Typed Semantic Edges Between Annotated Elements** | Proposed | 2026-04-09 | ADR-029, ADR-028, ADR-013, ADR-020, ADR-022 |
 
 ## How to Add a New ADR
 


### PR DESCRIPTION
- Add ADR-030: SpatialLink — typed semantic edges between annotated
  elements (references / connects / contains / adjacent); phases 1–4
  covering domain layer, scene graph integration, rendering, creation UI
- Reorganize ROADMAP.md: remove completed inline phase tables (Wasm 1–4,
  BFF A–C, Coordinate Space Type Safety); replace with single-row summary
  pointing to ADRs; condense Completed list to a compact table
- Update Lynch Urban Elements section → Spatial Annotation System with
  ADR-029 entity names (AnnotatedLine/Region/Point, Place Types)
- Add Implementation Status table to ADR-027 (Wasm phases 1–4)
- Add Implementation Status table to ADR-015 (BFF phases A–D)
- Add ADR-030 to docs/adr/README.md index

https://claude.ai/code/session_015S5UE782XiLgn8AbGfQ1tq