### PR TITLE
Fix mobile map drawing: confirm button, tool types, grid snap, endpoint snap

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -212,7 +212,7 @@ export class AppController {
     this._mapMode = {
       /** Whether map mode is currently active */
       active: false,
-      /** Active drawing tool: 'path'|'edge'|'district'|'node'|'landmark'|null */
+      /** Active drawing tool: 'route'|'boundary'|'zone'|'hub'|'anchor'|null */
       tool:   null,
       /** @type {THREE.Vector3[]} confirmed vertex positions (Z=0 plane) */
       points: [],
@@ -1170,7 +1170,7 @@ export class AppController {
 
   /**
    * Sets the active map drawing tool.
-   * @param {string} type  'route'|'boundary'|'zone'|'hub'|'anchor'
+   * @param {string} type  PlaceType name lowercase: 'route'|'boundary'|'zone'|'hub'|'anchor'
    */
   _setMapTool(type) {
     this._mapCancelDrawing()   // clear any in-progress drawing
@@ -1249,6 +1249,7 @@ export class AppController {
   /**
    * Picks the ground-plane (Z=0) world position under the mouse in Map Mode,
    * using the orthographic camera for correct distortion-free picking.
+   * Applies grid snapping (1-unit grid) then endpoint snapping to existing vertices.
    * @param {PointerEvent|MouseEvent} e
    * @returns {THREE.Vector3}
    */
@@ -1258,7 +1259,46 @@ export class AppController {
     this._raycaster.setFromCamera(new THREE.Vector2(ndcX, ndcY), this._sceneView.activeCamera)
     const pt = new THREE.Vector3()
     this._raycaster.ray.intersectPlane(this._groundPlane, pt)
-    return new THREE.Vector3(pt.x, pt.y, 0)
+    pt.z = 0
+
+    // Grid snap: round to nearest grid unit (matches GridHelper 20×20 / 20 divisions = 1 unit)
+    const GRID = 1.0
+    pt.x = Math.round(pt.x / GRID) * GRID
+    pt.y = Math.round(pt.y / GRID) * GRID
+
+    // Endpoint snap: override grid snap when cursor is within 24 px of an existing vertex
+    return this._mapSnapToEndpoint(pt, e.clientX, e.clientY)
+  }
+
+  /**
+   * Snaps a grid-snapped world point to a nearby annotated entity vertex.
+   * Uses the orthographic camera to measure screen-space distance.
+   * Endpoint snap has higher priority than grid snap.
+   * @param {THREE.Vector3} gridPt  grid-snapped world position
+   * @param {number} screenX  pointer clientX
+   * @param {number} screenY  pointer clientY
+   * @param {number} [snapPx=24]  snap radius in CSS pixels
+   * @returns {THREE.Vector3}
+   */
+  _mapSnapToEndpoint(gridPt, screenX, screenY, snapPx = 24) {
+    const cam = this._sceneView.activeCamera
+    let bestDist = snapPx
+    let bestPt   = null
+
+    for (const obj of this._scene.objects.values()) {
+      const verts = (obj instanceof AnnotatedLine || obj instanceof AnnotatedRegion || obj instanceof AnnotatedPoint)
+        ? obj.vertices.map(v => v.position)
+        : null
+      if (!verts) continue
+
+      for (const vert of verts) {
+        const sv = this._projectToScreen(vert, cam)
+        const d  = Math.hypot(screenX - sv.x, screenY - sv.y)
+        if (d < bestDist) { bestDist = d; bestPt = vert.clone() }
+      }
+    }
+
+    return bestPt ?? gridPt
   }
 
   /** Updates the live preview line and cursor dot during map drawing. */
@@ -1281,9 +1321,9 @@ export class AppController {
     this._mapMode.cursorDot.material.color.setHex(color)
 
     // Preview line (confirmed points + live cursor position)
-    if (geometry !== 'marker' && points.length > 0) {
+    if (geometry !== 'point' && points.length > 0) {
       const previewPts = [...points, cursor]
-      if (geometry === 'polygon' && previewPts.length >= 3) previewPts.push(previewPts[0])
+      if (geometry === 'region' && previewPts.length >= 3) previewPts.push(previewPts[0])
       const flat = []
       for (const p of previewPts) flat.push(p.x, p.y, p.z)
 
@@ -1349,9 +1389,9 @@ export class AppController {
     if (!this._mapMode.active) return
     const { tool, points } = this._mapMode
     const geometry = tool ? this._geometryForType(tool) : null
-    const canConfirm = geometry === 'polyline' ? points.length >= 2
-      : geometry === 'polygon' ? points.length >= 3
-      : false   // markers confirm immediately on click
+    const canConfirm = geometry === 'line' ? points.length >= 2
+      : geometry === 'region' ? points.length >= 3
+      : false   // points confirm immediately on click
 
     this._uiView.showMapToolbar(
       tool,
@@ -1887,8 +1927,8 @@ export class AppController {
   }
 
   // ─── Utilities ─────────────────────────────────────────────────────────────
-  _projectToScreen(position) {
-    const v = position.clone().project(this._camera)
+  _projectToScreen(position, camera = this._camera) {
+    const v = position.clone().project(camera)
     return {
       x: (v.x + 1) / 2 * innerWidth,
       y: (-v.y + 1) / 2 * innerHeight,
@@ -4072,15 +4112,15 @@ export class AppController {
       if (e.button === 0 && this._mapMode.tool) {
         const pt = this._mapPickPoint(e)
         const geometry = this._geometryForType(this._mapMode.tool)
-        if (geometry === 'marker') {
+        if (geometry === 'point') {
           this._mapMode.points = [pt.clone()]
           this._mapConfirmDrawing()
           return
         }
-        // For polygon: clicking near first vertex closes the shape
-        if (geometry === 'polygon' && this._mapMode.points.length >= 3) {
+        // For region: clicking near first vertex closes the shape
+        if (geometry === 'region' && this._mapMode.points.length >= 3) {
           const first = this._mapMode.points[0]
-          const firstScreen = this._projectToScreen(first)
+          const firstScreen = this._projectToScreen(first, this._sceneView.activeCamera)
           const mx = e.clientX, my = e.clientY
           if (Math.hypot(mx - firstScreen.x, my - firstScreen.y) < 20) {
             this._mapConfirmDrawing()
@@ -4096,7 +4136,7 @@ export class AppController {
         // RMB confirms if enough points, otherwise cancels tool
         const geometry = this._geometryForType(this._mapMode.tool)
         const n = this._mapMode.points.length
-        if ((geometry === 'polyline' && n >= 2) || (geometry === 'polygon' && n >= 3)) {
+        if ((geometry === 'line' && n >= 2) || (geometry === 'region' && n >= 3)) {
           this._mapConfirmDrawing()
         } else {
           this._mapCancelDrawing()
@@ -4497,7 +4537,7 @@ export class AppController {
       if (e.key === 'Enter' && this._mapMode.tool) {
         const geometry = this._geometryForType(this._mapMode.tool)
         const n = this._mapMode.points.length
-        if ((geometry === 'polyline' && n >= 2) || (geometry === 'polygon' && n >= 3)) {
+        if ((geometry === 'line' && n >= 2) || (geometry === 'region' && n >= 3)) {
           this._mapConfirmDrawing()
         }
         return

--- a/src/view/UIView.js
+++ b/src/view/UIView.js
@@ -936,11 +936,11 @@ export class UIView {
     })
 
     const TOOL_ITEMS = [
-      { type: 'path',     label: '⟿',  title: 'Path (Linear)',     color: '#4A90D9' },
-      { type: 'edge',     label: '⟿',  title: 'Edge (Boundary)',   color: '#E74C3C' },
-      { type: 'district', label: '⬡',  title: 'District (Area)',   color: '#27AE60' },
-      { type: 'node',     label: '⬤',  title: 'Node (Junction)',   color: '#F39C12' },
-      { type: 'landmark', label: '⬤',  title: 'Landmark (Point)',  color: '#9B59B6' },
+      { type: 'route',    label: '⟿',  title: 'Route (経路)',       color: '#4A90D9' },
+      { type: 'boundary', label: '⟿',  title: 'Boundary (境界)',    color: '#E74C3C' },
+      { type: 'zone',     label: '⬡',  title: 'Zone (ゾーン)',      color: '#27AE60' },
+      { type: 'hub',      label: '⬤',  title: 'Hub (ハブ)',         color: '#F39C12' },
+      { type: 'anchor',   label: '⬤',  title: 'Anchor (アンカー)',  color: '#9B59B6' },
     ]
 
     const sep = () => {


### PR DESCRIPTION
Root cause of most bugs: UIView map toolbar TOOL_ITEMS still used pre-ADR-029
names (path/edge/district/node/landmark) while _geometryForType() checked for
the new names (zone/hub/anchor). This caused district/node/landmark tools to
all return 'line' geometry, making zones create lines and point tools never
auto-confirm.

Fixes:
- UIView: update TOOL_ITEMS type values to current PlaceType names
  (route/boundary/zone/hub/anchor), matching PlaceTypeRegistry
- _refreshMapToolbar: fix canConfirm check 'polyline'→'line', 'polygon'→'region'
  (geometry values returned by _geometryForType were never 'polyline'/'polygon')
- Keyboard Enter handler: same 'polyline'→'line', 'polygon'→'region' fix
- RMB confirm handler: same fix
- _onPointerDown: fix 'marker'→'point' for point-tool auto-confirm;
  fix 'polygon'→'region' for region close-by-click check
- _updateMapPreview: fix 'marker'→'point' to suppress line preview for Hub/Anchor;
  fix 'polygon'→'region' for closing-segment preview
- _projectToScreen: accept optional camera parameter (default this._camera)
  so map-mode callers can pass the active orthographic camera
- _onPointerDown region closing: use activeCamera for correct screen projection
- _mapPickPoint: add 1-unit grid snapping (lines align to grid automatically)
- Add _mapSnapToEndpoint: snaps to existing annotated entity vertices within
  24 CSS pixels, using the ortho camera; endpoint snap overrides grid snap,
  making consecutive line connection accurate

https://claude.ai/code/session_01KsZ6E4kP59sUVgnv4T64gw