### PR TITLE
Improve Map drawing UX: chain lines, zone rect-drag, element animations

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -227,6 +227,12 @@ export class AppController {
       panStart:    null,   // { screenX, screenY, camX, camY }
       /** Current orthographic frustum height (world units) */
       frustumSize: 50,
+      /**
+       * Zone drag-to-rectangle state: set on pointerdown when zone tool is active
+       * and no polygon vertices exist yet.  Cleared on pointerup.
+       * @type {{ pt: THREE.Vector3, screenX: number, screenY: number }|null}
+       */
+      zoneDragStart: null,
     }
 
     // ── Sketch drawing state (Edit Mode · 2D) ──────────────────────────────
@@ -1185,9 +1191,10 @@ export class AppController {
   /** Cancels the current drawing without creating an entity. */
   _mapCancelDrawing() {
     this._clearMapPreview()
-    this._mapMode.tool   = null
-    this._mapMode.points = []
-    this._mapMode.cursor = null
+    this._mapMode.tool          = null
+    this._mapMode.points        = []
+    this._mapMode.cursor        = null
+    this._mapMode.zoneDragStart = null
     this._uiView.setCursor('default')
     this._refreshMapToolbar()
     if (this._mapMode.active) {
@@ -1221,12 +1228,24 @@ export class AppController {
       return  // not enough points
     }
 
-    // Keep the same tool active for rapid repeated placement
+    // Keep the same tool active for rapid repeated placement.
+    // For lines: carry the last endpoint forward so the next segment starts there
+    // automatically (chain drawing — no need to re-click the same point).
+    // For regions/points: reset to empty for fresh placement.
+    const lastPt = points[points.length - 1]
     this._clearMapPreview()
-    this._mapMode.points = []
+    this._mapMode.points = geometry === 'line' ? [lastPt.clone()] : []
     this._mapMode.cursor = null
     this._refreshMapToolbar()
-    this._uiView.setStatus(`Map Mode — ${placeType} placed.  Draw another or select a different type.`)
+    if (geometry === 'line') {
+      this._uiView.setStatusRich([
+        { text: placeType, bold: true, color: '#80cbc4' },
+        { text: 'placed — click to extend from endpoint', color: '#888' },
+        { text: '  ESC = new line', color: '#444' },
+      ])
+    } else {
+      this._uiView.setStatus(`Map Mode — ${placeType} placed.  Draw another or select a different type.`)
+    }
   }
 
   /** Removes preview line and cursor dot from the Three.js scene. */
@@ -1303,7 +1322,7 @@ export class AppController {
 
   /** Updates the live preview line and cursor dot during map drawing. */
   _updateMapPreview() {
-    const { tool, points, cursor } = this._mapMode
+    const { tool, points, cursor, zoneDragStart } = this._mapMode
     if (!tool || !cursor) return
     const geometry = this._geometryForType(tool)
     const entry    = getPlaceTypeEntry(this._placeTypeForType(tool))
@@ -1320,10 +1339,26 @@ export class AppController {
     this._mapMode.cursorDot.position.copy(cursor)
     this._mapMode.cursorDot.material.color.setHex(color)
 
-    // Preview line (confirmed points + live cursor position)
-    if (geometry !== 'point' && points.length > 0) {
-      const previewPts = [...points, cursor]
+    // Determine the preview point sequence to render
+    let previewPts = null
+    if (geometry === 'region' && zoneDragStart) {
+      // Zone drag-to-rectangle: show live rectangle from anchor to cursor
+      const p1 = zoneDragStart.pt
+      const p2 = cursor
+      previewPts = [
+        new THREE.Vector3(p1.x, p1.y, 0),
+        new THREE.Vector3(p2.x, p1.y, 0),
+        new THREE.Vector3(p2.x, p2.y, 0),
+        new THREE.Vector3(p1.x, p2.y, 0),
+        new THREE.Vector3(p1.x, p1.y, 0),  // close ring
+      ]
+    } else if (geometry !== 'point' && points.length > 0) {
+      // Normal polygon / polyline preview: confirmed points + live cursor
+      previewPts = [...points, cursor]
       if (geometry === 'region' && previewPts.length >= 3) previewPts.push(previewPts[0])
+    }
+
+    if (previewPts) {
       const flat = []
       for (const p of previewPts) flat.push(p.x, p.y, p.z)
 
@@ -4117,16 +4152,36 @@ export class AppController {
           this._mapConfirmDrawing()
           return
         }
-        // For region: clicking near first vertex closes the shape
-        if (geometry === 'region' && this._mapMode.points.length >= 3) {
-          const first = this._mapMode.points[0]
-          const firstScreen = this._projectToScreen(first, this._sceneView.activeCamera)
-          const mx = e.clientX, my = e.clientY
-          if (Math.hypot(mx - firstScreen.x, my - firstScreen.y) < 20) {
-            this._mapConfirmDrawing()
-            return
+        if (geometry === 'region') {
+          // Clicking near the first polygon vertex closes and confirms the shape
+          if (this._mapMode.points.length >= 3) {
+            const first = this._mapMode.points[0]
+            const firstScreen = this._projectToScreen(first, this._sceneView.activeCamera)
+            if (Math.hypot(e.clientX - firstScreen.x, e.clientY - firstScreen.y) < 20) {
+              this._mapConfirmDrawing()
+              return
+            }
           }
+          if (this._mapMode.points.length === 0) {
+            // No polygon vertices yet — start drag-to-rectangle (like sketch).
+            // pointerup will confirm as rectangle if dragged, or add as first
+            // polygon vertex if the pointer barely moved (just a tap/click).
+            this._mapMode.zoneDragStart = { pt: pt.clone(), screenX: e.clientX, screenY: e.clientY }
+            this._activeDragPointerId = e.pointerId
+            this._uiView.setStatusRich([
+              { text: 'Zone', bold: true, color: '#80cbc4' },
+              { text: 'drag to draw rectangle', color: '#888' },
+              { text: '  ESC cancel', color: '#444' },
+            ])
+          } else {
+            // Polygon mode (already have vertices): add next vertex
+            this._mapMode.points.push(pt.clone())
+            this._updateMapStatus()
+            this._refreshMapToolbar()
+          }
+          return
         }
+        // Line tool: push next vertex
         this._mapMode.points.push(pt.clone())
         this._updateMapStatus()
         this._refreshMapToolbar()
@@ -4325,6 +4380,32 @@ export class AppController {
         this._mapMode.isPanning = false
         this._mapMode.panStart  = null
         this._uiView.setCursor(this._mapMode.tool ? 'crosshair' : 'default')
+      }
+      return
+    }
+
+    // ── 2D Map Mode: zone drag-to-rectangle confirmation ──────────────────
+    if (this._mapMode.active && this._mapMode.zoneDragStart &&
+        this._activeDragPointerId === e.pointerId) {
+      const { pt: startPt, screenX: sx, screenY: sy } = this._mapMode.zoneDragStart
+      this._mapMode.zoneDragStart = null
+      this._activeDragPointerId   = null
+      const isDrag = Math.hypot(e.clientX - sx, e.clientY - sy) > 5
+      if (isDrag && this._mapMode.cursor) {
+        // Dragged enough → confirm as axis-aligned rectangle zone
+        const p1 = startPt, p2 = this._mapMode.cursor
+        this._mapMode.points = [
+          new THREE.Vector3(p1.x, p1.y, 0),
+          new THREE.Vector3(p2.x, p1.y, 0),
+          new THREE.Vector3(p2.x, p2.y, 0),
+          new THREE.Vector3(p1.x, p2.y, 0),
+        ]
+        this._mapConfirmDrawing()
+      } else {
+        // Barely moved → treat as click: start polygon vertex collection
+        this._mapMode.points.push(startPt)
+        this._updateMapStatus()
+        this._refreshMapToolbar()
       }
       return
     }
@@ -4738,11 +4819,14 @@ export class AppController {
       requestAnimationFrame(loop)
       this._sceneView.render()
       if (this._gizmoView) this._gizmoView.update()
-      // Keep MeasureLine HTML labels positioned over the correct screen pixel
-      // and CoordinateFrame axes at a constant screen size.
+      // Keep MeasureLine / AnnotatedPoint HTML labels positioned over the correct screen pixel,
+      // drive per-element animations, and keep CoordinateFrame axes at constant screen size.
+      const t = performance.now() * 0.001  // elapsed seconds for animation clock
       for (const obj of this._scene.objects.values()) {
         if (obj instanceof MeasureLine)     obj.meshView.updateLabelPosition()
-        if (obj instanceof AnnotatedPoint)  obj.meshView.updateLabelPosition()
+        if (obj instanceof AnnotatedPoint)  { obj.meshView.updateLabelPosition(); obj.meshView.tick(t) }
+        if (obj instanceof AnnotatedLine)   obj.meshView.tick(t)
+        if (obj instanceof AnnotatedRegion) obj.meshView.tick(t)
         if (obj instanceof CoordinateFrame) obj.meshView.updateScale(this._camera, this._sceneView.renderer)
       }
       // Sync CoordinateFrame world poses every frame (ADR-020).

--- a/src/view/AnnotatedLineView.js
+++ b/src/view/AnnotatedLineView.js
@@ -6,6 +6,10 @@
  *  - Vertex dot markers (small spheres) at each vertex
  *  - A BoxHelper for selection highlight
  *
+ * Animations (called via tick(t) each frame):
+ *  - Route:    4 small particles flow along the polyline (traffic / data-flow feel)
+ *  - Boundary: none — static solid line conveys "barrier / wall" semantics
+ *
  * Exposes the same minimal no-op interface as MeasureLineView / ImportedMeshView
  * so AppController's setMode() and mode-agnostic calls are safe.
  *
@@ -23,6 +27,9 @@ import { getPlaceTypeEntry } from '../domain/PlaceTypeRegistry.js'
 const DEFAULT_COLOR   = 0x888888   // unclassified grey
 const SELECTED_WIDTH  = 4
 const UNSELECTED_WIDTH = 2
+const PARTICLE_COUNT  = 4          // flowing dots per Route line
+const PARTICLE_RADIUS = 0.045
+const PARTICLE_SPEED  = 0.22       // fraction of total line length per second
 
 export class AnnotatedLineView {
   /**
@@ -34,6 +41,7 @@ export class AnnotatedLineView {
   constructor(scene, points, placeType, renderer) {
     this._scene    = scene
     this._renderer = renderer
+    this._placeType = placeType
 
     // ── Line2 geometry ─────────────────────────────────────────────────────
     this._lineGeo = new LineGeometry()
@@ -62,6 +70,24 @@ export class AnnotatedLineView {
     /** @type {THREE.Mesh[]} */
     this._dots = []
 
+    // ── Route flowing particles ────────────────────────────────────────────
+    // Shared geometry / material reused across all particles for this line.
+    this._partGeo = new THREE.SphereGeometry(PARTICLE_RADIUS, 6, 6)
+    this._partMat = new THREE.MeshBasicMaterial({
+      color:       this._colorForType(placeType),
+      depthTest:   false,
+      transparent: true,
+      opacity:     0.85,
+    })
+    /** @type {THREE.Mesh[]} */
+    this._particles = []
+    /**
+     * Pre-computed segment data for the current polyline.
+     * @type {Array<{ a: THREE.Vector3, b: THREE.Vector3, len: number }>}
+     */
+    this._segments  = []
+    this._totalLen  = 0
+
     // ── BoxHelper ──────────────────────────────────────────────────────────
     this._helperObj = new THREE.Object3D()
     scene.add(this._helperObj)
@@ -86,7 +112,10 @@ export class AnnotatedLineView {
     }
     this._dots = []
 
-    if (!points || points.length < 2) return
+    if (!points || points.length < 2) {
+      this._rebuildParticles([])
+      return
+    }
 
     // Flat position array for LineGeometry
     const flat = []
@@ -104,6 +133,37 @@ export class AnnotatedLineView {
     }
 
     this._updateBoxHelper(points)
+    this._rebuildParticles(points)
+  }
+
+  /**
+   * Recomputes segment data and rebuilds particle meshes for Route animation.
+   * @param {THREE.Vector3[]} points
+   */
+  _rebuildParticles(points) {
+    // Remove existing particles from scene
+    for (const p of this._particles) this._scene.remove(p)
+    this._particles = []
+    this._segments  = []
+    this._totalLen  = 0
+
+    if (this._placeType !== 'Route' || !points || points.length < 2) return
+
+    // Pre-compute segments
+    for (let i = 0; i < points.length - 1; i++) {
+      const len = points[i].distanceTo(points[i + 1])
+      this._segments.push({ a: points[i].clone(), b: points[i + 1].clone(), len })
+      this._totalLen += len
+    }
+
+    // Create particles with evenly staggered start offsets
+    for (let i = 0; i < PARTICLE_COUNT; i++) {
+      const mesh = new THREE.Mesh(this._partGeo, this._partMat)
+      mesh.renderOrder = 4
+      mesh._tOffset = i / PARTICLE_COUNT  // stagger around the loop
+      this._scene.add(mesh)
+      this._particles.push(mesh)
+    }
   }
 
   /**
@@ -130,6 +190,39 @@ export class AnnotatedLineView {
     return entry ? parseInt(entry.color.slice(1), 16) : DEFAULT_COLOR
   }
 
+  // ── Per-frame animation ────────────────────────────────────────────────────
+
+  /**
+   * Drives Route particle animation.  Called every frame from AppController.
+   * @param {number} t  elapsed seconds (performance.now() / 1000)
+   */
+  tick(t) {
+    if (!this._line.visible || this._placeType !== 'Route') return
+    if (this._segments.length === 0 || this._totalLen === 0) return
+
+    for (const mesh of this._particles) {
+      // Each particle travels the full polyline length continuously.
+      const frac = ((mesh._tOffset + t * PARTICLE_SPEED) % 1 + 1) % 1
+      const targetDist = frac * this._totalLen
+
+      let cumLen = 0
+      let placed = false
+      for (const seg of this._segments) {
+        if (cumLen + seg.len >= targetDist) {
+          const segFrac = seg.len > 0 ? (targetDist - cumLen) / seg.len : 0
+          mesh.position.lerpVectors(seg.a, seg.b, segFrac)
+          placed = true
+          break
+        }
+        cumLen += seg.len
+      }
+      if (!placed) {
+        // Floating-point edge: snap to last segment endpoint
+        mesh.position.copy(this._segments[this._segments.length - 1].b)
+      }
+    }
+  }
+
   // ── Move support ───────────────────────────────────────────────────────────
 
   /**
@@ -154,9 +247,11 @@ export class AnnotatedLineView {
    * @param {string|null} placeType
    */
   setPlaceType(placeType) {
+    this._placeType = placeType
     const hex = this._colorForType(placeType)
     this._lineMat.color.setHex(hex)
     this._dotMat.color.setHex(hex)
+    this._partMat.color.setHex(hex)
     this.boxHelper.material?.color.setHex(hex)
   }
 
@@ -164,7 +259,8 @@ export class AnnotatedLineView {
 
   setVisible(visible) {
     this._line.visible = visible
-    for (const d of this._dots) d.visible = visible
+    for (const d of this._dots)     d.visible = visible
+    for (const p of this._particles) p.visible = visible
     if (!visible) this.boxHelper.visible = false
   }
 
@@ -200,11 +296,16 @@ export class AnnotatedLineView {
     scene.remove(this._line)
     scene.remove(this._helperObj)
     scene.remove(this.boxHelper)
-    for (const d of this._dots) scene.remove(d)
+    for (const d of this._dots)     scene.remove(d)
+    for (const p of this._particles) scene.remove(p)
     this._lineGeo.dispose()
     this._lineMat.dispose()
     this._dotGeo.dispose()
     this._dotMat.dispose()
-    this._dots = []
+    this._partGeo.dispose()
+    this._partMat.dispose()
+    this._dots      = []
+    this._particles = []
+    this._segments  = []
   }
 }

--- a/src/view/AnnotatedPointView.js
+++ b/src/view/AnnotatedPointView.js
@@ -6,6 +6,10 @@
  *  - An HTML label showing the point name, positioned above the mesh
  *  - A BoxHelper for selection highlight
  *
+ * Animations (called via tick(t) each frame):
+ *  - Hub:    sonar-ping ring expands and fades every 2 s (beacon / junction feel)
+ *  - Anchor: outline ring breathes slowly at 4 s period (calm, fixed reference feel)
+ *
  * Exposes the same minimal no-op interface as MeasureLineView / ImportedMeshView
  * so AppController's setMode() and mode-agnostic calls are safe.
  *
@@ -35,6 +39,7 @@ export class AnnotatedPointView {
     this._scene    = scene
     this._camera   = camera
     this._renderer = renderer
+    this._placeType = placeType
 
     // ── Circle marker mesh ─────────────────────────────────────────────────
     this._geo = new THREE.CylinderGeometry(MARKER_RADIUS, MARKER_RADIUS, MARKER_HEIGHT, 16)
@@ -63,6 +68,22 @@ export class AnnotatedPointView {
     this._ring.position.copy(point)
     this._ring.renderOrder = 3
     scene.add(this._ring)
+
+    // ── Sonar-ping ring (Hub animation) ───────────────────────────────────
+    // Expands from the marker outward and fades, giving a "broadcasting node" feel.
+    // For non-Hub types the ring stays invisible (opacity: 0).
+    this._sonarGeo = new THREE.RingGeometry(MARKER_RADIUS * 0.85, MARKER_RADIUS, 16)
+    this._sonarMat = new THREE.MeshBasicMaterial({
+      color:       this._colorForType(placeType),
+      depthTest:   false,
+      transparent: true,
+      opacity:     0,
+      side:        THREE.DoubleSide,
+    })
+    this._sonarRing = new THREE.Mesh(this._sonarGeo, this._sonarMat)
+    this._sonarRing.position.copy(point)
+    this._sonarRing.renderOrder = 4
+    scene.add(this._sonarRing)
 
     // ── BoxHelper ──────────────────────────────────────────────────────────
     this.boxHelper = new THREE.BoxHelper(this._mesh, 0xffffff)
@@ -103,6 +124,7 @@ export class AnnotatedPointView {
     this._point.copy(point)
     this._mesh.position.copy(point)
     this._ring.position.copy(point)
+    this._sonarRing.position.copy(point)
     if (this.boxHelper.visible) this.boxHelper.update()
   }
 
@@ -110,6 +132,32 @@ export class AnnotatedPointView {
   _colorForType(placeType) {
     const entry = getPlaceTypeEntry(placeType)
     return entry ? parseInt(entry.color.slice(1), 16) : DEFAULT_COLOR
+  }
+
+  // ── Per-frame animation ────────────────────────────────────────────────────
+
+  /**
+   * Drives place-type-specific animations.  Called every frame from AppController.
+   * @param {number} t  elapsed seconds (performance.now() / 1000)
+   */
+  tick(t) {
+    if (!this._mesh.visible) return
+    if (this._placeType === 'Hub') {
+      // Sonar ping: ring expands 1× → 4× and fades over a 2 s cycle.
+      // Creates a "broadcasting junction node" feel — game-like beacon.
+      const phase = (t % 2.0) / 2.0             // 0 → 1 every 2 s
+      this._sonarRing.scale.setScalar(1 + phase * 3)
+      this._sonarMat.opacity = (1 - phase) * 0.65
+      // Outline ring: steady
+      this._ringMat.opacity = 0.6
+    } else if (this._placeType === 'Anchor') {
+      // Slow breathing on the outline ring (4 s period) — calm, fixed-reference feel.
+      const breath = (Math.sin(t * Math.PI * 0.5) + 1) * 0.5  // 0 → 1, 4 s period
+      this._ringMat.opacity = 0.25 + breath * 0.55
+      this._sonarMat.opacity = 0
+    } else {
+      this._sonarMat.opacity = 0
+    }
   }
 
   // ── Label update (call once per frame while visible) ───────────────────────
@@ -158,12 +206,16 @@ export class AnnotatedPointView {
    * @param {string}      name  entity name (label text may reflect place type label)
    */
   setPlaceType(placeType, name) {
+    this._placeType = placeType
     const hex = this._colorForType(placeType)
     this._mat.color.setHex(hex)
     this._ringMat.color.setHex(hex)
+    this._sonarMat.color.setHex(hex)
     this.boxHelper.material?.color.setHex(hex)
     const hexStr = hex.toString(16).padStart(6, '0')
     this._label.style.borderLeft = `3px solid #${hexStr}`
+    // Reset sonar scale so the ping animation restarts cleanly from the new type
+    this._sonarRing.scale.setScalar(1)
     if (name) {
       this._name = name
       this._label.textContent = name
@@ -179,8 +231,9 @@ export class AnnotatedPointView {
   // ── Visual state ───────────────────────────────────────────────────────────
 
   setVisible(visible) {
-    this._mesh.visible  = visible
-    this._ring.visible  = visible
+    this._mesh.visible      = visible
+    this._ring.visible      = visible
+    this._sonarRing.visible = visible
     this._label.style.display = visible ? 'block' : 'none'
     if (!visible) this.boxHelper.visible = false
   }
@@ -215,11 +268,14 @@ export class AnnotatedPointView {
   dispose(scene) {
     scene.remove(this._mesh)
     scene.remove(this._ring)
+    scene.remove(this._sonarRing)
     scene.remove(this.boxHelper)
     this._geo.dispose()
     this._mat.dispose()
     this._ringGeo.dispose()
     this._ringMat.dispose()
+    this._sonarGeo.dispose()
+    this._sonarMat.dispose()
     this._label.remove()
   }
 }

--- a/src/view/AnnotatedRegionView.js
+++ b/src/view/AnnotatedRegionView.js
@@ -7,6 +7,9 @@
  *  - Vertex dot markers (small spheres) at each vertex
  *  - A BoxHelper for selection highlight
  *
+ * Animations (called via tick(t) each frame):
+ *  - Zone: fill opacity breathes gently on a 4 s cycle (alive, "owned territory" feel)
+ *
  * Exposes the same minimal no-op interface as MeasureLineView / ImportedMeshView.
  *
  * Note: no `cuboid` property — AnnotatedRegion is excluded from raycasting.
@@ -21,6 +24,8 @@ import { getPlaceTypeEntry } from '../domain/PlaceTypeRegistry.js'
 
 const DEFAULT_COLOR    = 0x888888
 const FILL_OPACITY     = 0.18
+const FILL_OPACITY_MIN = 0.10  // breathing animation lower bound
+const FILL_OPACITY_MAX = 0.28  // breathing animation upper bound
 const SELECTED_WIDTH   = 4
 const UNSELECTED_WIDTH = 2
 
@@ -34,6 +39,7 @@ export class AnnotatedRegionView {
   constructor(scene, points, placeType, renderer) {
     this._scene    = scene
     this._renderer = renderer
+    this._placeType = placeType
 
     // ── Line2 (closed ring) ────────────────────────────────────────────────
     this._lineGeo = new LineGeometry()
@@ -152,6 +158,19 @@ export class AnnotatedRegionView {
     return entry ? parseInt(entry.color.slice(1), 16) : DEFAULT_COLOR
   }
 
+  // ── Per-frame animation ────────────────────────────────────────────────────
+
+  /**
+   * Drives Zone fill breathing animation.  Called every frame from AppController.
+   * @param {number} t  elapsed seconds (performance.now() / 1000)
+   */
+  tick(t) {
+    if (!this._fillMesh.visible || this._placeType !== 'Zone') return
+    // Gentle sine-wave breath: opacity oscillates between MIN and MAX on a 4 s period.
+    const breath = (Math.sin(t * Math.PI * 0.5) + 1) * 0.5  // 0 → 1, 4 s period
+    this._fillMat.opacity = FILL_OPACITY_MIN + breath * (FILL_OPACITY_MAX - FILL_OPACITY_MIN)
+  }
+
   // ── Move support ───────────────────────────────────────────────────────────
 
   /**
@@ -175,11 +194,14 @@ export class AnnotatedRegionView {
    * @param {string|null} placeType
    */
   setPlaceType(placeType) {
+    this._placeType = placeType
     const hex = this._colorForType(placeType)
     this._lineMat.color.setHex(hex)
     this._fillMat.color.setHex(hex)
     this._dotMat.color.setHex(hex)
     this.boxHelper.material?.color.setHex(hex)
+    // Reset fill opacity to default when place type changes
+    this._fillMat.opacity = FILL_OPACITY
   }
 
   // ── Visual state ───────────────────────────────────────────────────────────


### PR DESCRIPTION
LINE DRAWING (chain mode)
- After confirming a Route/Boundary, the last endpoint is carried forward as
  the start of the next segment.  No need to re-click the same point twice.
- Status bar now reads "click to extend from endpoint  ESC = new line".

ZONE DRAWING (sketch-style drag)
- When no polygon vertices exist yet, pointerdown begins a drag-to-rectangle
  interaction identical to the sketch phase: drag from corner to corner,
  release to confirm a 4-point axis-aligned Zone instantly.
- A pointer movement < 5 px is treated as a plain click, adding the first
  polygon vertex and falling back to the existing click-by-click polygon mode.

GAME-LIKE ELEMENT ANIMATIONS (per-frame via tick(t))
- Hub    AnnotatedPointView: sonar-ping ring expands 1× → 4× and fades over
  a 2 s cycle — "broadcasting node / junction" beacon feel.
- Anchor AnnotatedPointView: outline ring breathes slowly on a 4 s sine wave
  — calm, "fixed reference" feel distinct from Hub.
- Route  AnnotatedLineView:  4 small particles flow along the polyline at
  PARTICLE_SPEED, staggered evenly — traffic / data-flow feel.
- Zone   AnnotatedRegionView: fill opacity breathes between 0.10 and 0.28 on
  a 4 s sine wave — alive "owned territory" feel.
- Boundary: intentionally static — conveys solid barrier semantics.

AppController.start() drives all animations via tick(t) in the RAF loop.

https://claude.ai/code/session_011KHJy5v7NXraGGEez6zTom