### PR TITLE
fix: Zone confirm button, Boundary/Anchor animations, Route particle visibility

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -1285,30 +1285,40 @@ export class AppController {
     // Read the user-supplied name (or fall back to the auto-generated default)
     const name = this._uiView.getMapPendingName() ?? pendingName ?? placeType
 
-    if (geometry === 'point' && pendingPoints.length >= 1) {
-      const obj = this._service.createAnnotatedPoint(pendingPoints[0], name, {
-        camera: this._camera, renderer, container: document.body,
-      })
-      this._service.setPlaceType(obj.id, placeType)
-    } else if (geometry === 'line' && pendingPoints.length >= 2) {
-      const obj = this._service.createAnnotatedLine(pendingPoints, name, renderer)
-      this._service.setPlaceType(obj.id, placeType)
-    } else if (geometry === 'region' && pendingPoints.length >= 3) {
-      const obj = this._service.createAnnotatedRegion(pendingPoints, name, renderer)
-      this._service.setPlaceType(obj.id, placeType)
-    } else {
-      return  // geometry validation failed — should not reach here
+    // Create entity — state reset always happens in finally, even if creation throws
+    let created = false
+    try {
+      if (geometry === 'point' && pendingPoints.length >= 1) {
+        const obj = this._service.createAnnotatedPoint(pendingPoints[0], name, {
+          camera: this._camera, renderer, container: document.body,
+        })
+        this._service.setPlaceType(obj.id, placeType)
+        created = true
+      } else if (geometry === 'line' && pendingPoints.length >= 2) {
+        const obj = this._service.createAnnotatedLine(pendingPoints, name, renderer)
+        this._service.setPlaceType(obj.id, placeType)
+        created = true
+      } else if (geometry === 'region' && pendingPoints.length >= 3) {
+        const obj = this._service.createAnnotatedRegion(pendingPoints, name, renderer)
+        this._service.setPlaceType(obj.id, placeType)
+        created = true
+      }
+    } catch (err) {
+      console.error('[MapMode] entity creation failed:', err)
+    } finally {
+      // Always exit pending state — confirm button must disappear regardless of success
+      this._clearMapPreview()
+      this._mapMode.drawState     = 'drawing'  // ready for another gesture
+      this._mapMode.points        = []
+      this._mapMode.pendingPoints = null
+      this._mapMode.pendingName   = null
+      this._mapMode.cursor        = null
+      this._refreshMapToolbar()
     }
 
-    // Tool resets to idle after confirm — no chain drawing (ADR-031 §5)
-    this._clearMapPreview()
-    this._mapMode.drawState     = 'drawing'  // ready for another gesture
-    this._mapMode.points        = []
-    this._mapMode.pendingPoints = null
-    this._mapMode.pendingName   = null
-    this._mapMode.cursor        = null
-    this._refreshMapToolbar()
-    this._uiView.setStatus(`Map Mode — ${placeType} placed. Draw another or select a different type.`)
+    if (created) {
+      this._uiView.setStatus(`Map Mode — ${placeType} placed. Draw another or select a different type.`)
+    }
   }
 
   /** Removes preview line, cursor dot, and snap ring from the Three.js scene. */

--- a/src/view/AnnotatedLineView.js
+++ b/src/view/AnnotatedLineView.js
@@ -24,15 +24,18 @@ import { LineGeometry }  from 'three/addons/lines/LineGeometry.js'
 import { LineMaterial }  from 'three/addons/lines/LineMaterial.js'
 import { getPlaceTypeEntry } from '../domain/PlaceTypeRegistry.js'
 
-const DEFAULT_COLOR    = 0x888888   // unclassified grey
-const SELECTED_WIDTH   = 4
-const UNSELECTED_WIDTH = 2
-const PARTICLE_COUNT   = 4          // flowing dots per Route line
-const PARTICLE_RADIUS  = 0.045
-const PARTICLE_SPEED   = 0.22       // fraction of total line length per second
-const DRAWING_OPACITY  = 0.70       // while rubber-band preview (drawing state)
-const PENDING_OPACITY  = 0.90       // while awaiting confirm (pending state)
-const CONFIRMED_OPACITY = 1.00      // after entity is committed
+const DEFAULT_COLOR      = 0x888888   // unclassified grey
+const SELECTED_WIDTH     = 4
+const UNSELECTED_WIDTH   = 3
+const PARTICLE_COUNT     = 6          // flowing dots per Route line
+const PARTICLE_RADIUS    = 0.12       // world-unit radius; visible at default frustumSize=50
+const PARTICLE_SPEED     = 0.22       // fraction of total line length per second
+const DRAWING_OPACITY    = 0.70       // while rubber-band preview (drawing state)
+const PENDING_OPACITY    = 0.90       // while awaiting confirm (pending state)
+const CONFIRMED_OPACITY  = 1.00       // after entity is committed
+const BOUNDARY_DASH_SIZE = 0.60       // confirmed Boundary dash length (world units)
+const BOUNDARY_GAP_SIZE  = 0.30       // confirmed Boundary gap length (world units)
+const BOUNDARY_DASH_SPD  = 0.30       // march speed: world units per second
 
 export class AnnotatedLineView {
   /**
@@ -56,10 +59,7 @@ export class AnnotatedLineView {
       transparent: true,
       opacity:     CONFIRMED_OPACITY,
     })
-    this._lineMat.resolution.set(
-      renderer?.domElement?.width  ?? window.innerWidth,
-      renderer?.domElement?.height ?? window.innerHeight,
-    )
+    this._lineMat.resolution.set(window.innerWidth, window.innerHeight)
     this._line = new Line2(this._lineGeo, this._lineMat)
     this._line.renderOrder = 2
     scene.add(this._line)
@@ -204,29 +204,36 @@ export class AnnotatedLineView {
    * @param {number} t  elapsed seconds (performance.now() / 1000)
    */
   tick(t) {
-    if (!this._line.visible || this._placeType !== 'Route') return
-    if (this._segments.length === 0 || this._totalLen === 0) return
+    if (!this._line.visible) return
 
-    for (const mesh of this._particles) {
-      // Each particle travels the full polyline length continuously.
-      const frac = ((mesh._tOffset + t * PARTICLE_SPEED) % 1 + 1) % 1
-      const targetDist = frac * this._totalLen
+    if (this._placeType === 'Route') {
+      if (this._segments.length === 0 || this._totalLen === 0) return
 
-      let cumLen = 0
-      let placed = false
-      for (const seg of this._segments) {
-        if (cumLen + seg.len >= targetDist) {
-          const segFrac = seg.len > 0 ? (targetDist - cumLen) / seg.len : 0
-          mesh.position.lerpVectors(seg.a, seg.b, segFrac)
-          placed = true
-          break
+      for (const mesh of this._particles) {
+        // Each particle travels the full polyline length continuously.
+        const frac = ((mesh._tOffset + t * PARTICLE_SPEED) % 1 + 1) % 1
+        const targetDist = frac * this._totalLen
+
+        let cumLen = 0
+        let placed = false
+        for (const seg of this._segments) {
+          if (cumLen + seg.len >= targetDist) {
+            const segFrac = seg.len > 0 ? (targetDist - cumLen) / seg.len : 0
+            mesh.position.lerpVectors(seg.a, seg.b, segFrac)
+            placed = true
+            break
+          }
+          cumLen += seg.len
         }
-        cumLen += seg.len
+        if (!placed) {
+          // Floating-point edge: snap to last segment endpoint
+          mesh.position.copy(this._segments[this._segments.length - 1].b)
+        }
       }
-      if (!placed) {
-        // Floating-point edge: snap to last segment endpoint
-        mesh.position.copy(this._segments[this._segments.length - 1].b)
-      }
+    } else if (this._placeType === 'Boundary') {
+      // Marching-ants: animate dashOffset for a slow "boundary tape" effect.
+      const cycle = BOUNDARY_DASH_SIZE + BOUNDARY_GAP_SIZE
+      this._lineMat.dashOffset = -((t * BOUNDARY_DASH_SPD) % cycle)
     }
   }
 
@@ -260,6 +267,17 @@ export class AnnotatedLineView {
     this._dotMat.color.setHex(hex)
     this._partMat.color.setHex(hex)
     this.boxHelper.material?.color.setHex(hex)
+    // Boundary: confirmed style uses slow-marching dashes (marching-ants animation)
+    if (placeType === 'Boundary') {
+      this._lineMat.dashed   = true
+      this._lineMat.dashSize = BOUNDARY_DASH_SIZE
+      this._lineMat.gapSize  = BOUNDARY_GAP_SIZE
+    } else {
+      this._lineMat.dashed   = false
+      this._lineMat.dashSize = 1000
+      this._lineMat.gapSize  = 0
+    }
+    this._lineMat.needsUpdate = true
     // Rebuild particles now that the place type is known (fixes Route particle bug:
     // particles were never created when setPlaceType was called after construction).
     this._rebuildParticles(this._points)

--- a/src/view/AnnotatedPointView.js
+++ b/src/view/AnnotatedPointView.js
@@ -21,11 +21,11 @@
 import * as THREE from 'three'
 import { getPlaceTypeEntry } from '../domain/PlaceTypeRegistry.js'
 
-const DEFAULT_COLOR    = 0x888888
-const MARKER_RADIUS    = 0.25
-const MARKER_HEIGHT    = 0.04
-const CROSSHAIR_LEN    = 0.18   // half-length of each arm (ADR-031 §8)
-const CROSSHAIR_OPACITY = 0.55  // constant opacity (ADR-031 §8)
+const DEFAULT_COLOR     = 0x888888
+const MARKER_RADIUS     = 0.25
+const MARKER_HEIGHT     = 0.04
+const CROSSHAIR_LEN     = 0.45   // half-length; extends beyond MARKER_RADIUS so arms are visible outside the dot
+const CROSSHAIR_OPACITY = 0.90   // high opacity for contrast against colored marker
 
 export class AnnotatedPointView {
   /**
@@ -100,8 +100,9 @@ export class AnnotatedPointView {
     ])
     const crosshairGeo = new THREE.BufferGeometry()
     crosshairGeo.setAttribute('position', new THREE.Float32BufferAttribute(crosshairPositions, 3))
+    // White crosshair so arms contrast against the colored marker disc beneath
     this._crosshairMat = new THREE.LineBasicMaterial({
-      color:       this._colorForType(placeType),
+      color:       0xffffff,
       depthTest:   false,
       transparent: true,
       opacity:     CROSSHAIR_OPACITY,
@@ -264,7 +265,7 @@ export class AnnotatedPointView {
     this._mat.color.setHex(hex)
     this._ringMat.color.setHex(hex)
     this._sonarMat.color.setHex(hex)
-    this._crosshairMat.color.setHex(hex)
+    // Crosshair stays white for contrast — do not tint with place-type color
     this.boxHelper.material?.color.setHex(hex)
     const hexStr = hex.toString(16).padStart(6, '0')
     this._label.style.borderLeft = `3px solid #${hexStr}`

--- a/src/view/AnnotatedRegionView.js
+++ b/src/view/AnnotatedRegionView.js
@@ -56,10 +56,7 @@ export class AnnotatedRegionView {
       transparent: true,
       opacity:     CONFIRMED_OPACITY,
     })
-    this._lineMat.resolution.set(
-      renderer?.domElement?.width  ?? window.innerWidth,
-      renderer?.domElement?.height ?? window.innerHeight,
-    )
+    this._lineMat.resolution.set(window.innerWidth, window.innerHeight)
     this._line = new Line2(this._lineGeo, this._lineMat)
     this._line.renderOrder = 2
     scene.add(this._line)
@@ -247,6 +244,8 @@ export class AnnotatedRegionView {
     this.boxHelper.material?.color.setHex(hex)
     // Reset fill opacity to default when place type changes
     this._fillMat.opacity = FILL_OPACITY
+    // rimRing is only active for Zone; sync visibility with the new type
+    this._rimRing.visible = this._fillMesh.visible && placeType === 'Zone'
   }
 
   /**


### PR DESCRIPTION
Zone confirmation:
- _mapConfirmDrawing() now wraps entity creation in try-catch-finally to
  guarantee the pending state is always exited (confirm button always
  disappears) even when an unexpected error occurs during creation

Boundary animation:
- Confirmed Boundary line switches to dashed mode in setPlaceType()
- tick() animates dashOffset at 0.30 wu/s ("marching-ants" boundary tape)
- Constants: BOUNDARY_DASH_SIZE=0.60, BOUNDARY_GAP_SIZE=0.30

Anchor animation (crosshair visibility):
- CROSSHAIR_LEN 0.18 → 0.45: arms now extend beyond MARKER_RADIUS (0.25)
  so the outer 0.20 wu portion is clearly visible outside the disc
- Crosshair color changed to white (0xffffff) so inner arms also contrast
  against the colored marker; not overwritten by setPlaceType()
- CROSSHAIR_OPACITY 0.55 → 0.90 for better contrast

Route particles / line:
- PARTICLE_RADIUS 0.045 → 0.12: visible at default frustumSize=50
- PARTICLE_COUNT 4 → 6: denser coverage along the polyline
- UNSELECTED_WIDTH 2 → 3 px: slightly thicker line
- LineMaterial.resolution uses window.innerWidth/Height (CSS px) instead
  of renderer.domElement.width/height (physical px); fixes half-thickness
  on retina displays

Zone rimRing:
- setPlaceType() now syncs _rimRing.visible with the new type so the
  pulsing rim appears correctly when a region is assigned 'Zone'
- AnnotatedRegionView.LineMaterial resolution also fixed to CSS px

https://claude.ai/code/session_01C6L72oaC9eN4VFf4UUW3m6