### PR TITLE
fix: Zone generation — replace null geometry with BufferGeometry in AnnotatedRegionView

### DIFF
--- a/docs/CODE_CONTRACTS.md
+++ b/docs/CODE_CONTRACTS.md
@@ -126,3 +126,4 @@ Detail: `docs/code_contracts/memory_management.md`
 | _clearScene Emit Order | Emit `objectRemoved` for each object BEFORE replacing `this._model` |
 | SceneSerializer Entity Coverage | Every domain entity must be explicitly handled (or commented) in `serializeScene()` |
 | ImportedMesh Serialization | Base64 buffers; restore `cuboid.position` from `offset` BEFORE calling `initCorners()` |
+| THREE.Mesh Requires Valid Geometry | Never pass `null` to `new THREE.Mesh(null, mat)` — use `new THREE.BufferGeometry()` as placeholder; `updateMorphTargets()` throws on null geometry |

--- a/docs/code_contracts/memory_management.md
+++ b/docs/code_contracts/memory_management.md
@@ -41,6 +41,12 @@ _clearScene() {
 - **Principle**: Silently skipping an entity type in `serializeScene()` causes that type to disappear on the next load with no error. This is a silent data-loss bug — the save succeeds, the load succeeds, but objects are gone.
 - **Concrete Rule**: Every domain entity class added to `SceneModel` (e.g. `Solid`, `Profile`, `MeasureLine`, `CoordinateFrame`, `ImportedMesh`) must be explicitly handled in `serializeScene()` — either serialized with a matching `_deserializeEntities` branch, or skipped with a comment explaining why. Verify that new entity types are covered in SceneSerializer in the same commit they are added to the domain layer.
 
+## THREE.Mesh Requires Valid Geometry — Never Pass null
+
+- **Principle**: `THREE.Mesh(null, material)` throws `TypeError: Cannot read properties of null (reading 'morphAttributes')` in Three.js r172 because the constructor calls `updateMorphTargets()` which accesses `this.geometry.morphAttributes` unconditionally.
+- **Concrete Rule**: Never pass `null` as the geometry argument to `new THREE.Mesh(...)`. When the real geometry will be set later (e.g. in `_setPoints()`), use `new THREE.BufferGeometry()` as a valid empty placeholder. Store the placeholder in the same instance field that tracks the geometry (e.g. `this._fillGeo`) so that `_setPoints` can dispose it correctly with `if (this._fillGeo) { this._fillGeo.dispose() }` before assigning the real geometry.
+- **Root bug**: `AnnotatedRegionView` used `new THREE.Mesh(null, mat)` for both `_fillMesh` and `_rimRing`, causing `createAnnotatedRegion()` to throw on every call, silently swallowed by the try-catch in `_mapConfirmDrawing()`, so Zone was never created.
+
 ## ImportedMesh Serialization: Base64 Typed Arrays + Position Offset
 
 - **Principle**: Raw Float32/Uint32 buffers cannot be stored directly in JSON. Base64 encoding is used so geometry survives round-trip through the BFF DB without loss.

--- a/src/view/AnnotatedRegionView.js
+++ b/src/view/AnnotatedRegionView.js
@@ -62,7 +62,10 @@ export class AnnotatedRegionView {
     scene.add(this._line)
 
     // ── Fill mesh ──────────────────────────────────────────────────────────
-    this._fillGeo = null
+    // Use an empty BufferGeometry as placeholder — THREE.Mesh(null, ...) throws
+    // in r172 because updateMorphTargets() accesses geometry.morphAttributes.
+    // _setPoints() replaces this with a ShapeGeometry and disposes the placeholder.
+    this._fillGeo = new THREE.BufferGeometry()
     this._fillMat = new THREE.MeshBasicMaterial({
       color:       this._colorForType(placeType),
       transparent: true,
@@ -87,7 +90,8 @@ export class AnnotatedRegionView {
     // Pulses outward from the polygon boundary: scale 1.0×→1.08×, opacity 0.40→0
     // on a 3 s cycle.  The ring geometry is rebuilt in _setPoints() to match the
     // actual polygon bounding radius.
-    this._rimGeo  = null
+    // Empty BufferGeometry placeholder — same reason as _fillGeo above.
+    this._rimGeo  = new THREE.BufferGeometry()
     this._rimMat  = new THREE.MeshBasicMaterial({
       color:       this._colorForType(placeType),
       depthTest:   false,
@@ -95,7 +99,7 @@ export class AnnotatedRegionView {
       opacity:     0,
       side:        THREE.DoubleSide,
     })
-    this._rimRing = new THREE.Mesh(null, this._rimMat)
+    this._rimRing = new THREE.Mesh(this._rimGeo, this._rimMat)
     this._rimRing.renderOrder = 1
     scene.add(this._rimRing)
 
@@ -160,10 +164,13 @@ export class AnnotatedRegionView {
     if (boundRadius > 0) {
       // Thin rim at the polygon boundary; inner radius slightly inside boundary
       this._rimGeo  = new THREE.RingGeometry(boundRadius * 0.92, boundRadius, 32)
-      this._rimRing.geometry = this._rimGeo
       this._rimRing.position.set(centroid.x, centroid.y, 0)
       this._rimRing.scale.setScalar(1)
+    } else {
+      // Degenerate polygon (all points identical) — keep a valid empty geometry
+      this._rimGeo = new THREE.BufferGeometry()
     }
+    this._rimRing.geometry = this._rimGeo
 
     this._updateBoxHelper(points)
   }


### PR DESCRIPTION
THREE.Mesh(null, material) throws TypeError in r172 because the constructor
calls updateMorphTargets() which accesses this.geometry.morphAttributes
unconditionally. null.morphAttributes crashes every call to createAnnotatedRegion(),
silently swallowed by the try-catch added in the previous session, so Zone was
never created.

Fix: initialise _fillGeo and _rimGeo with new THREE.BufferGeometry() instead
of null. _setPoints() already disposes and replaces both fields when real
geometry is available. Also added else branch in _setPoints to keep _rimRing
pointing at a valid (empty) geometry when boundRadius is zero.

CODE_CONTRACTS updated: "THREE.Mesh Requires Valid Geometry" rule added to
Section 4 (Memory Management) and detail file.

https://claude.ai/code/session_01RyZBoQkLf2jKAuz36BQfZy