### PR TITLE
fix(Zone): replace circular RingGeometry rim ring with polygon ShapeGeometry

### DIFF
--- a/docs/CODE_CONTRACTS.md
+++ b/docs/CODE_CONTRACTS.md
@@ -127,3 +127,4 @@ Detail: `docs/code_contracts/memory_management.md`
 | SceneSerializer Entity Coverage | Every domain entity must be explicitly handled (or commented) in `serializeScene()` |
 | ImportedMesh Serialization | Base64 buffers; restore `cuboid.position` from `offset` BEFORE calling `initCorners()` |
 | THREE.Mesh Requires Valid Geometry | Never pass `null` to `new THREE.Mesh(null, mat)` — use `new THREE.BufferGeometry()` as placeholder; `updateMorphTargets()` throws on null geometry |
+| Zone Rim Ring Must Use Polygon Geometry | Use `ShapeGeometry` + polygon hole for the rim ring; `RingGeometry` always produces a circle regardless of Zone shape |

--- a/docs/code_contracts/memory_management.md
+++ b/docs/code_contracts/memory_management.md
@@ -47,6 +47,11 @@ _clearScene() {
 - **Concrete Rule**: Never pass `null` as the geometry argument to `new THREE.Mesh(...)`. When the real geometry will be set later (e.g. in `_setPoints()`), use `new THREE.BufferGeometry()` as a valid empty placeholder. Store the placeholder in the same instance field that tracks the geometry (e.g. `this._fillGeo`) so that `_setPoints` can dispose it correctly with `if (this._fillGeo) { this._fillGeo.dispose() }` before assigning the real geometry.
 - **Root bug**: `AnnotatedRegionView` used `new THREE.Mesh(null, mat)` for both `_fillMesh` and `_rimRing`, causing `createAnnotatedRegion()` to throw on every call, silently swallowed by the try-catch in `_mapConfirmDrawing()`, so Zone was never created.
 
+## Zone Rim Ring Must Use Polygon ShapeGeometry, Not RingGeometry
+
+- **Principle**: `THREE.RingGeometry` always produces a circular ring regardless of the polygon's actual shape. When this is used for an animation that is meant to "pulse outward from the boundary", rectangular or irregular Zones get a visually mismatched circular pulse.
+- **Concrete Rule**: In `AnnotatedRegionView._setPoints()`, build the rim ring as a `THREE.ShapeGeometry` with a polygonal hole: outer boundary = polygon vertices in local space (centroid at origin); inner boundary = vertices scaled 92% toward centroid. Position `_rimRing` at the centroid in world space. `scale.setScalar()` in `tick()` then expands the ring outward along the real polygon shape.
+
 ## ImportedMesh Serialization: Base64 Typed Arrays + Position Offset
 
 - **Principle**: Raw Float32/Uint32 buffers cannot be stored directly in JSON. Base64 encoding is used so geometry survives round-trip through the BFF DB without loss.

--- a/src/view/AnnotatedRegionView.js
+++ b/src/view/AnnotatedRegionView.js
@@ -6,7 +6,7 @@
  *  - A translucent fill mesh (ShapeGeometry on Z=0 XY plane)
  *  - Vertex dot markers (small spheres) at each vertex
  *  - A BoxHelper for selection highlight
- *  - A rim ring (RingGeometry) that pulses outward from the boundary (Zone only)
+ *  - A rim ring (polygon-shaped ShapeGeometry) that pulses outward from the boundary (Zone only)
  *
  * Animations (called via tick(t) each frame):
  *  - Zone: fill opacity breathes on a 4 s cycle (alive, "owned territory" feel)
@@ -88,8 +88,9 @@ export class AnnotatedRegionView {
 
     // ── Rim ring (Zone animation — ADR-031 §8) ─────────────────────────────
     // Pulses outward from the polygon boundary: scale 1.0×→1.08×, opacity 0.40→0
-    // on a 3 s cycle.  The ring geometry is rebuilt in _setPoints() to match the
-    // actual polygon bounding radius.
+    // on a 3 s cycle.  The ring geometry is rebuilt in _setPoints() as a
+    // polygon-shaped ShapeGeometry (with hole) so the ring tracks the actual
+    // Zone shape rather than an approximating circle.
     // Empty BufferGeometry placeholder — same reason as _fillGeo above.
     this._rimGeo  = new THREE.BufferGeometry()
     this._rimMat  = new THREE.MeshBasicMaterial({
@@ -154,22 +155,30 @@ export class AnnotatedRegionView {
       this._dots.push(dot)
     }
 
-    // Rim ring: compute centroid and max bounding radius
+    // Rim ring: polygon-shaped ring that matches the Zone outline.
+    // Build in local space with centroid at origin so scale.setScalar() expands
+    // the ring along the actual polygon shape (not a circle).
     const centroid = new THREE.Vector3()
     for (const p of points) centroid.add(p)
     centroid.divideScalar(points.length)
-    const boundRadius = Math.max(...points.map(p => p.distanceTo(centroid)))
 
     if (this._rimGeo) { this._rimGeo.dispose(); this._rimGeo = null }
-    if (boundRadius > 0) {
-      // Thin rim at the polygon boundary; inner radius slightly inside boundary
-      this._rimGeo  = new THREE.RingGeometry(boundRadius * 0.92, boundRadius, 32)
-      this._rimRing.position.set(centroid.x, centroid.y, 0)
-      this._rimRing.scale.setScalar(1)
-    } else {
-      // Degenerate polygon (all points identical) — keep a valid empty geometry
-      this._rimGeo = new THREE.BufferGeometry()
-    }
+
+    // Outer boundary = polygon vertices; inner boundary = vertices shrunk 92% toward
+    // centroid to form a thin ring matching the Zone shape.
+    const relPts = points.map(p => new THREE.Vector2(p.x - centroid.x, p.y - centroid.y))
+    const outerShape = new THREE.Shape()
+    outerShape.moveTo(relPts[0].x, relPts[0].y)
+    for (let i = 1; i < relPts.length; i++) outerShape.lineTo(relPts[i].x, relPts[i].y)
+    outerShape.closePath()
+    const innerHole = new THREE.Path()
+    innerHole.moveTo(relPts[0].x * 0.92, relPts[0].y * 0.92)
+    for (let i = 1; i < relPts.length; i++) innerHole.lineTo(relPts[i].x * 0.92, relPts[i].y * 0.92)
+    innerHole.closePath()
+    outerShape.holes.push(innerHole)
+    this._rimGeo = new THREE.ShapeGeometry(outerShape)
+    this._rimRing.position.set(centroid.x, centroid.y, 0)
+    this._rimRing.scale.setScalar(1)
     this._rimRing.geometry = this._rimGeo
 
     this._updateBoxHelper(points)


### PR DESCRIPTION
The rim ring animation for Zone used THREE.RingGeometry, which always
produces a circular ring regardless of the Zone's actual polygon shape.
Rectangular or irregular Zones got a visually mismatched circular pulse.

Replace with THREE.ShapeGeometry built from the polygon vertices in local
space (centroid at origin) with an inner hole at 92% scale. The mesh is
positioned at the centroid so scale.setScalar() in tick() correctly expands
the ring outward along the real Zone outline.

Also add CODE_CONTRACTS rule: "Zone Rim Ring Must Use Polygon Geometry".

https://claude.ai/code/session_01WrLdB1TynhpZGBbMtuxdtw