### PR TITLE
fix(map): fix 3D label position, add annotation selection, fix import

### DIFF
--- a/docs/CODE_CONTRACTS.md
+++ b/docs/CODE_CONTRACTS.md
@@ -65,6 +65,7 @@ Detail: `docs/code_contracts/architecture.md`
 | Urban Placement Confirm No Auto-Select | `_confirmUrbanPlacement()` must NOT call `_switchActiveObject()` after creating the entity; previous selection is preserved and toolbar returns to initial object-mode slots |
 | Rect Selection Null Cuboid Guard | `_finalizeRectSelection()` must use `obj.meshView.cuboid?.visible` (optional chaining); Urban entities and CoordinateFrame return `null` for `.cuboid` and would throw TypeError without the guard |
 | CoordinateFrame.localOffset vs Geometry.corners | `CoordinateFrame` exposes `localOffset` (LocalVector3[]); geometry exposes `corners` (WorldVector3[]). `.corners` does NOT exist on `CoordinateFrame`. Use `_grabHandlesOf(obj)` for grab/move; use `_worldPoseCache` for world position. (PHILOSOPHY #21 Phase 3) |
+| HTML Overlay Active Camera | Views projecting 3D→screen for HTML labels must use `SceneView.activeCamera`, not `AppController._camera` (perspective-only); pass `this._sceneView.activeCamera` at each animation-loop call site |
 
 ---
 
@@ -125,6 +126,7 @@ Detail: `docs/code_contracts/memory_management.md`
 | Object Lifecycle Symmetry | Every `scene.add()` must have matching `scene.remove()` + `.dispose()` in `dispose()` |
 | _clearScene Emit Order | Emit `objectRemoved` for each object BEFORE replacing `this._model` |
 | SceneSerializer Entity Coverage | Every domain entity must be explicitly handled (or commented) in `serializeScene()` |
+| SceneImporter KNOWN_TYPES Coverage | `KNOWN_TYPES` in `SceneImporter` must include every type in `serializeScene()` + `_deserializeEntities`; add in same commit as domain entity |
 | ImportedMesh Serialization | Base64 buffers; restore `cuboid.position` from `offset` BEFORE calling `initCorners()` |
 | THREE.Mesh Requires Valid Geometry | Never pass `null` to `new THREE.Mesh(null, mat)` — use `new THREE.BufferGeometry()` as placeholder; `updateMorphTargets()` throws on null geometry |
 | Zone Rim Ring Must Use Polygon Geometry | Use `ShapeGeometry` + polygon hole for the rim ring; `RingGeometry` always produces a circle regardless of Zone shape |

--- a/docs/code_contracts/architecture.md
+++ b/docs/code_contracts/architecture.md
@@ -287,3 +287,9 @@ if (e.target !== renderer.domElement) return
 this._updateMouse(e)   // ← must be here, not further down
 // ... rotate / grab / urban placement handlers follow
 ```
+
+## HTML Overlay Views Must Use the Active Camera for Screen Projection
+
+- **Principle**: `AppController.get _camera()` always returns the perspective camera (`SceneView.camera`). When Map mode activates the orthographic camera (`SceneView.activeCamera`), the renderer uses the ortho camera but views storing the old perspective camera reference will compute wrong screen positions.
+- **Concrete Rule**: Any view that projects 3D positions to screen coordinates for HTML overlay positioning (e.g. `AnnotatedPointView.updateLabelPosition()`) must use the ACTIVE camera, not a stale stored reference. Call sites in the animation loop must pass `this._sceneView.activeCamera` explicitly: `obj.meshView.updateLabelPosition(this._sceneView.activeCamera)`. The same applies to `MeasureLineView` if it is ever used alongside Map mode's orthographic camera.
+- **Root bug**: `AnnotatedPointView` stored `this._camera` (perspective camera) at construction time. In Map mode the ortho camera was used for rendering, but labels were projected with the perspective camera → labels appeared at wrong screen positions relative to the rendered 3D markers.

--- a/docs/code_contracts/memory_management.md
+++ b/docs/code_contracts/memory_management.md
@@ -41,6 +41,12 @@ _clearScene() {
 - **Principle**: Silently skipping an entity type in `serializeScene()` causes that type to disappear on the next load with no error. This is a silent data-loss bug — the save succeeds, the load succeeds, but objects are gone.
 - **Concrete Rule**: Every domain entity class added to `SceneModel` (e.g. `Solid`, `Profile`, `MeasureLine`, `CoordinateFrame`, `ImportedMesh`) must be explicitly handled in `serializeScene()` — either serialized with a matching `_deserializeEntities` branch, or skipped with a comment explaining why. Verify that new entity types are covered in SceneSerializer in the same commit they are added to the domain layer.
 
+## SceneImporter KNOWN_TYPES Must Mirror Every Serializable Entity Type
+
+- **Principle**: `SceneImporter.parseImportJson()` silently drops any object whose `type` field is not in `KNOWN_TYPES`. If a new entity type is added to the serializer but not to `KNOWN_TYPES`, exported files containing that type will silently lose those objects on import.
+- **Concrete Rule**: Whenever a new domain entity type is added to `SceneSerializer` (export) and `SceneService._deserializeEntities` (import), add its type string to the `KNOWN_TYPES` set in `SceneImporter.parseImportJson()` in the same commit. The three sets must stay in sync: `serializeScene()` branches, `_deserializeEntities` branches, and `KNOWN_TYPES`.
+- **Root bug**: `AnnotatedLine`, `AnnotatedRegion`, `AnnotatedPoint` were added to the serializer and deserializer but never added to `KNOWN_TYPES`, causing them to be silently filtered out on every import.
+
 ## THREE.Mesh Requires Valid Geometry — Never Pass null
 
 - **Principle**: `THREE.Mesh(null, material)` throws `TypeError: Cannot read properties of null (reading 'morphAttributes')` in Three.js r172 because the constructor calls `updateMorphTargets()` which accesses `this.geometry.morphAttributes` unconditionally.

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -2170,6 +2170,45 @@ export class AppController {
     return obj ? { hit: hits[0], obj } : null
   }
 
+  /**
+   * Hits any visible annotation entity (AnnotatedLine/Region/Point) using a
+   * bounding-box raycast.  Called as a fallback when _hitAnyObject() misses
+   * (annotation entities have no cuboid and are excluded from that test).
+   * @returns {{ obj: object }|null}
+   */
+  _hitAnyAnnotation() {
+    this._raycaster.setFromCamera(this._mouse, this._camera)
+    const ray = this._raycaster.ray
+    const pt  = new THREE.Vector3()
+
+    let nearestDist = Infinity
+    let nearestObj  = null
+
+    for (const obj of this._scene.objects.values()) {
+      if (!(obj instanceof AnnotatedLine) && !(obj instanceof AnnotatedRegion) && !(obj instanceof AnnotatedPoint)) continue
+      if (!obj.meshView?.visible) continue  // skip soft-deleted
+
+      const corners = obj.corners
+      if (!corners.length) continue
+
+      const box = new THREE.Box3()
+      for (const c of corners) box.expandByPoint(c)
+      // Expand by pick tolerance; for single-point entities this is the full hit area.
+      box.expandByScalar(0.3)
+
+      const hitPt = ray.intersectBox(box, pt)
+      if (hitPt) {
+        const dist = ray.origin.distanceTo(hitPt)
+        if (dist < nearestDist) {
+          nearestDist = dist
+          nearestObj  = obj
+        }
+      }
+    }
+
+    return nearestObj ? { obj: nearestObj } : null
+  }
+
   /** Hits only the active object's mesh */
   _hitActiveSolid() {
     if (!this._activeObj) return null
@@ -4128,7 +4167,7 @@ export class AppController {
         }
         this._updateNPanel()
       } else {
-        this._uiView.setCursor(this._hitAnyObject() ? 'pointer' : 'default')
+        this._uiView.setCursor((this._hitAnyObject() || this._hitAnyAnnotation()) ? 'pointer' : 'default')
       }
       return
     }
@@ -4478,7 +4517,9 @@ export class AppController {
     }
 
     if (this._scene.selectionMode === 'object') {
-      const result = this._hitAnyObject()
+      // Primary cuboid hit; fall back to annotation entity bounding-box hit.
+      let result = this._hitAnyObject()
+      if (!result) result = this._hitAnyAnnotation()
       if (result) {
         const { hit, obj } = result
         if (!this._selectedIds.has(obj.id)) {
@@ -4500,8 +4541,10 @@ export class AppController {
           }
         }
 
-        // MeasureLine and CoordinateFrame cannot be dragged
-        if (obj instanceof MeasureLine || obj instanceof CoordinateFrame) {
+        // MeasureLine, CoordinateFrame, and annotation entities cannot be pointer-dragged
+        // (use G key to move them after selecting).
+        if (obj instanceof MeasureLine || obj instanceof CoordinateFrame ||
+            obj instanceof AnnotatedLine || obj instanceof AnnotatedRegion || obj instanceof AnnotatedPoint) {
           return
         }
 
@@ -5110,7 +5153,7 @@ export class AppController {
       const t = performance.now() * 0.001  // elapsed seconds for animation clock
       for (const obj of this._scene.objects.values()) {
         if (obj instanceof MeasureLine)     obj.meshView.updateLabelPosition()
-        if (obj instanceof AnnotatedPoint)  { obj.meshView.updateLabelPosition(); obj.meshView.tick(t) }
+        if (obj instanceof AnnotatedPoint)  { obj.meshView.updateLabelPosition(this._sceneView.activeCamera); obj.meshView.tick(t) }
         if (obj instanceof AnnotatedLine)   obj.meshView.tick(t)
         if (obj instanceof AnnotatedRegion) obj.meshView.tick(t)
         if (obj instanceof CoordinateFrame) obj.meshView.updateScale(this._camera, this._sceneView.renderer)

--- a/src/service/SceneImporter.js
+++ b/src/service/SceneImporter.js
@@ -49,7 +49,10 @@ export function parseImportJson(jsonText) {
   }
 
   // Light per-entry type check (no deep validation — invalid entries are skipped on import)
-  const KNOWN_TYPES = new Set(['Solid', 'Profile', 'MeasureLine', 'CoordinateFrame', 'ImportedMesh'])
+  const KNOWN_TYPES = new Set([
+    'Solid', 'Profile', 'MeasureLine', 'CoordinateFrame', 'ImportedMesh',
+    'AnnotatedLine', 'AnnotatedRegion', 'AnnotatedPoint',
+  ])
   const objects = root.objects.filter(o => {
     if (!o || typeof o !== 'object') return false
     if (!KNOWN_TYPES.has(o.type))    return false

--- a/src/view/AnnotatedLineView.js
+++ b/src/view/AnnotatedLineView.js
@@ -311,6 +311,9 @@ export class AnnotatedLineView {
     if (sel) this.boxHelper.update()
   }
 
+  /** True when the line is shown in the scene (false when soft-deleted). */
+  get visible() { return this._line.visible }
+
   // ── Edit-mode no-ops ───────────────────────────────────────────────────────
 
   setFaceHighlight()      {}

--- a/src/view/AnnotatedPointView.js
+++ b/src/view/AnnotatedPointView.js
@@ -219,10 +219,15 @@ export class AnnotatedPointView {
   /**
    * Projects anchor position to screen and updates label position.
    * Must be called from the animation loop (AppController._animate) while visible.
+   * @param {import('three').Camera} [camera]  Active camera to use for projection.
+   *   When Map mode uses an orthographic camera, pass that camera here so the
+   *   label tracks the rendered position correctly.  Falls back to the stored
+   *   perspective camera if omitted.
    */
-  updateLabelPosition() {
+  updateLabelPosition(camera) {
+    const cam = camera ?? this._camera
     if (!this._mesh.visible) return
-    const ndc    = this._point.clone().project(this._camera)
+    const ndc    = this._point.clone().project(cam)
     const canvas = this._renderer.domElement
     const rect   = canvas.getBoundingClientRect()
     const sx = (ndc.x  + 1) / 2 * rect.width  + rect.left
@@ -234,6 +239,9 @@ export class AnnotatedPointView {
     this._label.style.left    = `${Math.round(sx + MARKER_RADIUS * 20 + 4)}px`
     this._label.style.top     = `${Math.round(sy - 10)}px`
   }
+
+  /** True when the marker is shown in the scene (false when soft-deleted). */
+  get visible() { return this._mesh.visible }
 
   // ── Move support ───────────────────────────────────────────────────────────
 

--- a/src/view/AnnotatedRegionView.js
+++ b/src/view/AnnotatedRegionView.js
@@ -292,6 +292,9 @@ export class AnnotatedRegionView {
     if (sel) this.boxHelper.update()
   }
 
+  /** True when the region is shown in the scene (false when soft-deleted). */
+  get visible() { return this._line.visible }
+
   // ── Edit-mode no-ops ───────────────────────────────────────────────────────
 
   setFaceHighlight()      {}


### PR DESCRIPTION
Three bugs fixed:

1. Label position mismatch in 3D/Map mode
   - AnnotatedPointView.updateLabelPosition() stored the perspective camera at
     construction time. In Map mode SceneView switches to an orthographic camera
     for rendering, so labels were projected with the wrong camera → labels
     appeared at wrong screen positions relative to the 3D markers.
   - Fix: accept optional `camera` param in updateLabelPosition(); animation loop
     now passes `this._sceneView.activeCamera` so the correct camera is always used.

2. Annotation entities not selectable in 3D object mode
   - _hitAnyObject() explicitly excluded AnnotatedLine/Region/Point (no cuboid).
   - Added _hitAnyAnnotation() using bounding-box raycasting with 0.3-unit pick
     tolerance, tried as fallback when _hitAnyObject() returns null.
   - Annotation entities return early before pointer-drag setup (like MeasureLine);
     use G key to move them after selecting.
   - Hover cursor now also reflects annotation entities.

3. Annotation entities silently dropped on JSON import
   - SceneImporter.parseImportJson() filtered objects by KNOWN_TYPES which did not
     include AnnotatedLine, AnnotatedRegion, AnnotatedPoint → import silently lost
     all map annotations.
   - Fix: add all three annotation types to KNOWN_TYPES.

Also: add visible getters to annotation views for the hit-test filter.

CODE_CONTRACTS: new rules for KNOWN_TYPES coverage and HTML overlay active camera.

https://claude.ai/code/session_01BAsXNXA5AHd2YFVoq5RwUD