### PR TITLE
fix(mobile): make TransformControls gizmo visible above CoordinateFrame

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -1194,6 +1194,9 @@ export class AppController {
     this._mapMode.cursor        = null
     this._mapMode.mobileDragStart = null
     this._mapMode.isPanning     = false
+    // TC was created with the perspective camera; the ortho camera used in Map
+    // Mode would cause wrong gizmo scale and broken raycast — hide it.
+    this._detachMobileTransform()
     this._sceneView.useOrthoCamera(true, this._mapMode.frustumSize)
     this._uiView.setCursor('default')
     this._uiView.setStatus('Map Mode — select a type on the left to start drawing')
@@ -1210,6 +1213,8 @@ export class AppController {
     this._uiView.hideMapToolbar()
     this._uiView.setCursor('default')
     this._refreshObjectModeStatus()
+    // Restore TC gizmo now that the perspective camera is active again.
+    if (this._activeObj && this._objSelected) this._attachMobileTransform(this._activeObj)
     this._updateMobileToolbar()
   }
 
@@ -1845,6 +1850,12 @@ export class AppController {
     this._tc.setSpace('world')
     this._tc.visible = false
     this._sceneView.scene.add(this._tc)
+
+    // Render the gizmo on top of CoordinateFrame axes (renderOrder 1) so it
+    // is never hidden behind the origin frame that appears on selection.
+    this._tc.traverse(child => {
+      if (child !== this._tc) child.renderOrder = 2
+    })
 
     // Disable OrbitControls while dragging; re-enable on release
     this._tc.addEventListener('dragging-changed', (e) => {
@@ -3062,6 +3073,10 @@ export class AppController {
         this._setChildFramesVisible(this._scene.activeId, sel)
       }
     }
+    // Sync the TC gizmo with the new selection state so every code path
+    // (not just _switchActiveObject) keeps the gizmo visible/hidden correctly.
+    if (sel && this._activeObj) this._attachMobileTransform(this._activeObj)
+    else this._detachMobileTransform()
     this._refreshObjectModeStatus()
     this._updateMobileToolbar()
   }


### PR DESCRIPTION
Three bugs prevented the TC gizmo from showing on mobile:

1. renderOrder conflict — CoordinateFrame axes use renderOrder=1 (X-ray)
   while TC gizmo children default to renderOrder=0, so the frame arrows
   were rendered on top and visually hid the gizmo. Fixed by traversing
   TC children after scene.add() and setting renderOrder=2.

2. _setObjectSelected(true) did not attach TC — the tap path that calls
   _setObjectSelected(true) instead of _switchActiveObject (when the
   tapped solid is already activeId but _objSelected=false) never called
   _attachMobileTransform. Added attach/detach sync at the end of
   _setObjectSelected so every code path is covered.

3. Map Mode (ortho camera) kept TC attached — TC was created with the
   perspective camera; entering Map Mode switched to ortho without
   detaching TC, causing wrong gizmo scale and broken raycasting.
   Added _detachMobileTransform() in _enterMapMode and re-attach in
   _exitMapMode.

https://claude.ai/code/session_01A73yjDmVpiu71mtxinriEH