### PR TITLE
fix(mobile): fix black screen caused by TransformControls API mismatch

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -1848,13 +1848,15 @@ export class AppController {
     this._tc = new TransformControls(this._sceneView.camera, this._sceneView.renderer.domElement)
     this._tc.setMode('translate')
     this._tc.setSpace('world')
-    this._tc.visible = false
-    this._sceneView.scene.add(this._tc)
+    // In Three.js r152+ TransformControls extends Controls (not Object3D).
+    // The visible scene graph lives in tc.getHelper() (= tc._root, an Object3D).
+    // Must add getHelper() to the scene, not tc itself.
+    this._sceneView.scene.add(this._tc.getHelper())
 
     // Render the gizmo on top of CoordinateFrame axes (renderOrder 1) so it
     // is never hidden behind the origin frame that appears on selection.
-    this._tc.traverse(child => {
-      if (child !== this._tc) child.renderOrder = 2
+    this._tc.getHelper().traverse(child => {
+      child.renderOrder = 2
     })
 
     // Disable OrbitControls while dragging; re-enable on release
@@ -1915,14 +1917,12 @@ export class AppController {
     this._tcProxy.position.copy(centroid)
     this._tcProxy.updateMatrixWorld()
     this._tc.attach(this._tcProxy)
-    this._tc.visible = true
   }
 
   /** Detaches and hides the TC gizmo. Safe to call when TC is already detached. */
   _detachMobileTransform() {
     if (!this._tc) return
     this._tc.detach()
-    this._tc.visible = false
   }
 
   /**
@@ -1936,7 +1936,7 @@ export class AppController {
       ? (this._service.worldPoseOf(obj.id)?.position?.clone() ?? new THREE.Vector3())
       : getCentroid(obj.corners)
     this._tcProxy.position.copy(centroid)
-    this._tc.updateMatrixWorld()
+    this._tc.getHelper().updateMatrixWorld()
   }
 
   /**


### PR DESCRIPTION
In Three.js r152+, TransformControls extends Controls (EventDispatcher),
not Object3D. The visible scene graph lives in tc.getHelper() (= tc._root).

Three bugs from the API mismatch:

1. tc.traverse() did not exist — TypeError crashed the AppController
   constructor, preventing start() from being called → black screen on load.

2. scene.add(tc) silently failed with a console error because tc is not
   Object3D (checked via isObject3D). The gizmo was never in the scene.

3. tc.updateMatrixWorld() did not exist — would have thrown on undo/redo.

Fixes:
- scene.add(tc.getHelper()) to add the actual Object3D root to the scene
- tc.getHelper().traverse() for renderOrder assignment
- tc.getHelper().updateMatrixWorld() in _syncMobileTransformProxy
- Remove tc.visible = true/false no-ops (attach/detach handle _root.visible)

https://claude.ai/code/session_01Hh48e9Uitqs8RXYUULJ1rZ