### PR TITLE
fix(mobile): fix TC gizmo attachment to CoordinateFrame on touch devices

### DIFF
--- a/docs/CODE_CONTRACTS.md
+++ b/docs/CODE_CONTRACTS.md
@@ -66,6 +66,7 @@ Detail: `docs/code_contracts/architecture.md`
 | Rect Selection Null Cuboid Guard | `_finalizeRectSelection()` must use `obj.meshView.cuboid?.visible` (optional chaining); Urban entities and CoordinateFrame return `null` for `.cuboid` and would throw TypeError without the guard |
 | CoordinateFrame.localOffset vs Geometry.corners | `CoordinateFrame` exposes `localOffset` (LocalVector3[]); geometry exposes `corners` (WorldVector3[]). `.corners` does NOT exist on `CoordinateFrame`. Use `_grabHandlesOf(obj)` for grab/move; use `_worldPoseCache` for world position. (PHILOSOPHY #21 Phase 3) |
 | HTML Overlay Active Camera | Views projecting 3D→screen for HTML labels must use `SceneView.activeCamera`, not `AppController._camera` (perspective-only); pass `this._sceneView.activeCamera` at each animation-loop call site |
+| TC Gizmo Force-Update After Proxy Repositioning | Call `_tc.getHelper().updateMatrixWorld()` after `tc.attach()` in `_attachMobileTransform()`; call `_service._updateWorldPoses()` before `worldPoseOf()` in `_syncMobileTransformProxy()`; call `_syncMobileTransformProxy()` from `_toggleTcMode()` |
 
 ---
 

--- a/docs/code_contracts/architecture.md
+++ b/docs/code_contracts/architecture.md
@@ -288,6 +288,27 @@ this._updateMouse(e)   // ← must be here, not further down
 // ... rotate / grab / urban placement handlers follow
 ```
 
+## TC Gizmo Must Be Force-Updated After Proxy Repositioning
+
+- **Principle**: Three.js `TransformControls.attach()` stores the proxy reference but does NOT immediately reposition the gizmo. The gizmo only moves on the next render cycle when `TransformControlsGizmo.updateMatrixWorld()` runs. After `_attachMobileTransform()` repositions the proxy to a new object's world position, the gizmo remains at the previous object's position for one frame — visually separating TC from the new frame's origin.
+- **Concrete Rule 1**: After `_tc.attach(proxy)` in `_attachMobileTransform()`, immediately call `_tc.getHelper().updateMatrixWorld()` to force the gizmo's internal `_worldPosition` to reflect the proxy's new matrix. Without this, TC rotates/translates relative to the wrong pivot for the first drag.
+- **Concrete Rule 2**: `_syncMobileTransformProxy()` must call `_service._updateWorldPoses()` before reading `worldPoseOf()` when the active object is a `CoordinateFrame`. `MoveCommand.apply()` calls `invalidateWorldPose()` synchronously before `_syncMobileTransformProxy()` runs during undo/redo — leaving the cache empty. `worldPoseOf()` would return `null` and the fallback `new THREE.Vector3()` would snap the proxy to the world origin.
+- **Concrete Rule 3**: `_toggleTcMode()` must call `_syncMobileTransformProxy()` after resetting the proxy quaternion to re-anchor the gizmo at the frame's current world position. Without this, switching Rotate↔Translate leaves TC internally anchored to a stale world position.
+
+```js
+// _attachMobileTransform() — force gizmo sync after attach
+this._tc.attach(this._tcProxy)
+this._tc.getHelper().updateMatrixWorld()   // ← required; without this, gizmo stays at old position
+
+// _syncMobileTransformProxy() — flush world pose cache first
+if (obj instanceof CoordinateFrame) this._service._updateWorldPoses()  // ← before worldPoseOf()
+const centroid = this._service.worldPoseOf(obj.id)?.position?.clone() ?? new THREE.Vector3()
+
+// _toggleTcMode() — re-anchor after mode switch
+this._tcProxy.quaternion.identity()
+this._syncMobileTransformProxy()           // ← refresh proxy position + gizmo internal state
+```
+
 ## HTML Overlay Views Must Use the Active Camera for Screen Projection
 
 - **Principle**: `AppController.get _camera()` always returns the perspective camera (`SceneView.camera`). When Map mode activates the orthographic camera (`SceneView.activeCamera`), the renderer uses the ortho camera but views storing the old perspective camera reference will compute wrong screen positions.

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -1966,6 +1966,10 @@ export class AppController {
       this._tc.setMode('translate')
     }
     this._tc.attach(this._tcProxy)
+    // Force the TC gizmo to immediately update to the proxy's new world position.
+    // Without this, the gizmo stays at the previous object's position until the
+    // next render cycle, visually separating TC from the newly selected frame's origin.
+    this._tc.getHelper().updateMatrixWorld()
   }
 
   /** Detaches and hides the TC gizmo. Safe to call when TC is already detached. */
@@ -1983,16 +1987,28 @@ export class AppController {
     this._tcMode = this._tcMode === 'rotate' ? 'translate' : 'rotate'
     this._tc.setMode(this._tcMode)
     this._tcProxy.quaternion.identity()  // clear accumulated proxy rotation on mode switch
+    this._syncMobileTransformProxy()     // re-anchor gizmo to current frame world position
     this._updateMobileToolbar()
   }
 
   /**
-   * Repositions the TC proxy to match the current state of the active object.
-   * Call after undo/redo so the gizmo snaps back to the correct position.
+   * Repositions the TC proxy to match the current state of the active object
+   * and forces the TC gizmo to update its internal state.
+   *
+   * Called after undo/redo and mode switches.
+   *
+   * For CoordinateFrame: forces `_updateWorldPoses()` first, because undo/redo
+   * runs MoveCommand.apply() which calls `invalidateWorldPose()` before this
+   * method runs — leaving the cache empty and causing `worldPoseOf()` to return
+   * null (which would fall back to the world origin).
    */
   _syncMobileTransformProxy() {
     if (!this._tc || !this._tcProxy || !this._activeObj || !this._tc.object) return
     const obj = this._activeObj
+    // Ensure world pose cache is populated for CoordinateFrame. It may have been
+    // cleared by invalidateWorldPose() (e.g. in MoveCommand.apply during undo/redo)
+    // before the animation loop's _updateWorldPoses() has had a chance to run.
+    if (obj instanceof CoordinateFrame) this._service._updateWorldPoses()
     const centroid = (obj instanceof CoordinateFrame)
       ? (this._service.worldPoseOf(obj.id)?.position?.clone() ?? new THREE.Vector3())
       : getCentroid(obj.corners)


### PR DESCRIPTION
Three related bugs caused the TransformControls gizmo to visually separate
from the CoordinateFrame origin:

1. _attachMobileTransform: After tc.attach(proxy) the gizmo stays at the
   previous object's world position until the next render cycle because
   TransformControls.attach() stores the reference but does not immediately
   call updateMatrixWorld(). Fix: call _tc.getHelper().updateMatrixWorld()
   after attach so TC's internal _worldPosition is anchored to the new
   proxy position before the first drag.

2. _syncMobileTransformProxy: During undo/redo, MoveCommand.apply() calls
   invalidateWorldPose() synchronously before _syncMobileTransformProxy()
   runs. worldPoseOf() then returns null and the fallback new THREE.Vector3()
   snaps the proxy to the world origin. Fix: call _service._updateWorldPoses()
   first to repopulate the cache for CoordinateFrame objects.

3. _toggleTcMode: Switching Rotate<->Translate reset the proxy quaternion but
   left TC internally anchored to a potentially stale world position. Fix:
   call _syncMobileTransformProxy() after the quaternion reset.

Adds "TC Gizmo Force-Update After Proxy Repositioning" to CODE_CONTRACTS.

https://claude.ai/code/session_01DVv1rbRYH7RAw141cEKXzH