### PR TITLE
fix(mobile): prevent TC rotate ring tap from switching to Cuboid translate mode

### DIFF
--- a/docs/CODE_CONTRACTS.md
+++ b/docs/CODE_CONTRACTS.md
@@ -67,6 +67,8 @@ Detail: `docs/code_contracts/architecture.md`
 | CoordinateFrame.localOffset vs Geometry.corners | `CoordinateFrame` exposes `localOffset` (LocalVector3[]); geometry exposes `corners` (WorldVector3[]). `.corners` does NOT exist on `CoordinateFrame`. Use `_grabHandlesOf(obj)` for grab/move; use `_worldPoseCache` for world position. (PHILOSOPHY #21 Phase 3) |
 | HTML Overlay Active Camera | Views projecting 3D→screen for HTML labels must use `SceneView.activeCamera`, not `AppController._camera` (perspective-only); pass `this._sceneView.activeCamera` at each animation-loop call site |
 | TC Gizmo Force-Update After Proxy Repositioning | Call `_tc.getHelper().updateMatrixWorld()` after `tc.attach()` in `_attachMobileTransform()`; call `_service._updateWorldPoses()` before `worldPoseOf()` in `_syncMobileTransformProxy()`; call `_syncMobileTransformProxy()` from `_toggleTcMode()` |
+| TC Gizmo Hit Guard Before Object Selection | In `_onPointerDown`, raycast against `_tc.getHelper()` before `_hitAnyObject()` when TC is attached; return early if hit — otherwise the ray pierces TC handles to hit objects behind them, switching active object and gizmo mode unintentionally |
+| TC Mode Must Match _tcMode | `_attachMobileTransform()` must set `_tcMode = 'translate'` in the non-CoordinateFrame branch alongside `tc.setMode('translate')`; `_tcMode` must always reflect the current TC mode for all code paths |
 
 ---
 

--- a/docs/code_contracts/architecture.md
+++ b/docs/code_contracts/architecture.md
@@ -294,6 +294,8 @@ this._updateMouse(e)   // ← must be here, not further down
 - **Concrete Rule 1**: After `_tc.attach(proxy)` in `_attachMobileTransform()`, immediately call `_tc.getHelper().updateMatrixWorld()` to force the gizmo's internal `_worldPosition` to reflect the proxy's new matrix. Without this, TC rotates/translates relative to the wrong pivot for the first drag.
 - **Concrete Rule 2**: `_syncMobileTransformProxy()` must call `_service._updateWorldPoses()` before reading `worldPoseOf()` when the active object is a `CoordinateFrame`. `MoveCommand.apply()` calls `invalidateWorldPose()` synchronously before `_syncMobileTransformProxy()` runs during undo/redo — leaving the cache empty. `worldPoseOf()` would return `null` and the fallback `new THREE.Vector3()` would snap the proxy to the world origin.
 - **Concrete Rule 3**: `_toggleTcMode()` must call `_syncMobileTransformProxy()` after resetting the proxy quaternion to re-anchor the gizmo at the frame's current world position. Without this, switching Rotate↔Translate leaves TC internally anchored to a stale world position.
+- **Concrete Rule 4**: `_onPointerDown` must raycast against `_tc.getHelper()` BEFORE `_hitAnyObject()` whenever the TC gizmo is attached (`this._tc?.object`). TC registers its own pointer listeners AFTER `_onPointerDown`, so `_tcDragging` is still `false` at the time `_onPointerDown` fires — the only reliable way to detect a gizmo hit is to raycast explicitly. Without this guard, the ray passes through TC handles (rotate ring, translate arrows) to hit objects behind them, causing `_switchActiveObject()` → `_attachMobileTransform()` → `tc.setMode()` to run — unintentionally switching the active object and the gizmo mode.
+- **Concrete Rule 5**: `_attachMobileTransform()` must keep `_tcMode` in sync with the TC mode for ALL entity types. Previously only the `CoordinateFrame` branch set `_tcMode = 'rotate'`; the `else` branch set `tc.setMode('translate')` without updating `_tcMode`. Always set `_tcMode = 'translate'` alongside `tc.setMode('translate')`.
 
 ```js
 // _attachMobileTransform() — force gizmo sync after attach
@@ -307,6 +309,13 @@ const centroid = this._service.worldPoseOf(obj.id)?.position?.clone() ?? new THR
 // _toggleTcMode() — re-anchor after mode switch
 this._tcProxy.quaternion.identity()
 this._syncMobileTransformProxy()           // ← refresh proxy position + gizmo internal state
+
+// _onPointerDown — guard against TC gizmo hit before regular selection
+if (this._tc?.object) {
+  this._raycaster.setFromCamera(this._mouse, this._camera)
+  const tcHits = this._raycaster.intersectObject(this._tc.getHelper(), true)
+  if (tcHits.length > 0) return  // ← let TC handle its own pointer event
+}
 ```
 
 ## HTML Overlay Views Must Use the Active Camera for Screen Projection

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -1958,11 +1958,14 @@ export class AppController {
     this._tcProxy.position.copy(centroid)
     this._tcProxy.quaternion.identity()  // reset accumulated proxy rotation each attach
     this._tcProxy.updateMatrixWorld()
-    // CoordinateFrame: default to rotate mode; all other entities: translate only
+    // CoordinateFrame: default to rotate mode; all other entities: translate only.
+    // Always keep _tcMode in sync with the actual TC mode so that objectChange
+    // and dragging-changed handlers read the correct mode.
     if (obj instanceof CoordinateFrame) {
       this._tcMode = 'rotate'
       this._tc.setMode('rotate')
     } else {
+      this._tcMode = 'translate'
       this._tc.setMode('translate')
     }
     this._tc.attach(this._tcProxy)
@@ -4757,6 +4760,20 @@ export class AppController {
     }
 
     if (this._scene.selectionMode === 'object') {
+      // If TC gizmo is active, check if this pointer hits a gizmo handle BEFORE
+      // doing regular object selection. Without this guard, the ray passes through
+      // TC handles (rotate ring, translate arrows) and hits objects behind them,
+      // causing an unintended active-object switch and mode change.
+      // Example: tapping the TC rotate ring hits the Cuboid behind it →
+      //   _switchActiveObject(cuboid) → _attachMobileTransform(cuboid) → tc.setMode('translate')
+      // TC registers its own pointer listeners after _onPointerDown, so _tcDragging
+      // is still false at this point — we must raycast against the gizmo explicitly.
+      if (this._tc?.object) {
+        this._raycaster.setFromCamera(this._mouse, this._camera)
+        const tcHits = this._raycaster.intersectObject(this._tc.getHelper(), true)
+        if (tcHits.length > 0) return
+      }
+
       // Primary cuboid hit; fall back to annotation entity bounding-box hit.
       let result = this._hitAnyObject()
       if (!result) result = this._hitAnyAnnotation()


### PR DESCRIPTION
Root cause: `_onPointerDown` registered its listener before TransformControls,
so when the user tapped a TC gizmo handle (rotate ring or translate arrow) the
ray passed through it to hit objects behind it — notably the parent Cuboid.
_hitAnyObject() returned the Cuboid, causing _switchActiveObject(cuboid.id) →
_attachMobileTransform(cuboid) → tc.setMode('translate'), unintentionally:
  1. Changing the active object from CoordinateFrame to Cuboid
  2. Switching TC from rotate to translate mode
  3. After one Cuboid translation the TC proxy and CoordinateFrame origin
     visually diverged (Cuboid centroid ≠ frame origin for non-zero localOffset)

Fix 1 (_onPointerDown): Before _hitAnyObject(), raycast against _tc.getHelper()
when TC is attached. If any gizmo handle is hit, return early and let TC handle
the pointer event through its own registered listener.

Fix 2 (_attachMobileTransform): Set `_tcMode = 'translate'` in the else-branch
alongside tc.setMode('translate') so _tcMode always mirrors the actual TC mode.
Previously only the CoordinateFrame branch updated _tcMode; the else branch left
it at its previous value.

Adds TC Gizmo Hit Guard and TC Mode Must Match _tcMode rules to CODE_CONTRACTS.

https://claude.ai/code/session_01UJaBghxyL1ra3kjsiYEHez