### PR TITLE
fix(coordinate-frame): sync TC after grab, default to translate, add Done button, cap scale

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -382,7 +382,7 @@ export class AppController {
 
     // ── TC mode toggle for mobile CoordinateFrame (translate / rotate) ────
     /** @type {'translate'|'rotate'} Current TC gizmo mode when a CoordinateFrame is active. */
-    this._tcMode           = 'rotate'
+    this._tcMode           = 'translate'
     /** Proxy quaternion snapshot at TC drag start (rotate mode only). @type {THREE.Quaternion|null} */
     this._tcStartProxyQuat = null
     /** Frame rotation snapshot at TC drag start (rotate mode only). @type {THREE.Quaternion|null} */
@@ -1958,12 +1958,13 @@ export class AppController {
     this._tcProxy.position.copy(centroid)
     this._tcProxy.quaternion.identity()  // reset accumulated proxy rotation each attach
     this._tcProxy.updateMatrixWorld()
-    // CoordinateFrame: default to rotate mode; all other entities: translate only.
+    // CoordinateFrame: default to translate mode (user adjusts position first, then
+    // switches to rotate with the toolbar button).  All other entities: translate only.
     // Always keep _tcMode in sync with the actual TC mode so that objectChange
     // and dragging-changed handlers read the correct mode.
     if (obj instanceof CoordinateFrame) {
-      this._tcMode = 'rotate'
-      this._tc.setMode('rotate')
+      this._tcMode = 'translate'
+      this._tc.setMode('translate')
     } else {
       this._tcMode = 'translate'
       this._tc.setMode('translate')
@@ -2659,17 +2660,17 @@ export class AppController {
     if (mode === 'object') {
       const hasObj = this._objSelected
 
-      // CoordinateFrame: TC mode toggle | spacer | Delete | Add Frame | spacer
+      // CoordinateFrame: TC mode toggle | Done | Delete | Add Frame | spacer
       if (hasObj && this._activeObj instanceof CoordinateFrame) {
         const isRotate = this._tcMode === 'rotate'
         this._uiView.setMobileToolbar([
           {
             icon:    isRotate ? ICONS.rotate    : ICONS.translate,
             label:   isRotate ? 'Rotate'        : 'Move',
-            active:  isRotate,
+            active:  true,  // always highlight current mode
             onClick: () => this._toggleTcMode(),
           },
-          { spacer: true },
+          { icon: ICONS.confirm, label: 'Done', onClick: () => this._setObjectSelected(false) },
           { icon: ICONS.delete, label: 'Delete', onClick: () => this._deleteObject(this._scene.activeId), danger: true },
           { icon: ICONS.frame,  label: 'Add Frame', onClick: () => this._addObject('frame') },
           { spacer: true },
@@ -3473,6 +3474,10 @@ export class AppController {
     this._refreshObjectModeStatus()
     this._updateNPanel()
     this._updateMobileToolbar()
+    // Re-anchor the TC gizmo to the object's new position after grab.
+    // During a regular touch/keyboard grab the proxy is never moved by the TC,
+    // so after confirm the gizmo would remain at the pre-grab position.
+    if (this._activeObj) this._attachMobileTransform(this._activeObj)
   }
 
   _cancelGrab() {
@@ -5414,7 +5419,25 @@ export class AppController {
         if (obj instanceof AnnotatedPoint)  { obj.meshView.updateLabelPosition(this._sceneView.activeCamera); obj.meshView.tick(t) }
         if (obj instanceof AnnotatedLine)   obj.meshView.tick(t)
         if (obj instanceof AnnotatedRegion) obj.meshView.tick(t)
-        if (obj instanceof CoordinateFrame) obj.meshView.updateScale(this._camera, this._sceneView.renderer)
+        if (obj instanceof CoordinateFrame) {
+          // Cap the frame's world size so it never visually dwarfs its parent.
+          // Compute the parent object's bounding radius (max distance from centroid
+          // to any corner) and allow the frame axes to grow to at most 1.5× that.
+          // Falls back to Infinity (uncapped) when the parent has no geometry corners
+          // (e.g. another CoordinateFrame parent).
+          let maxWS = Infinity
+          const frameParent = this._scene.getObject(obj.parentId)
+          if (frameParent && !(frameParent instanceof CoordinateFrame) && frameParent.corners?.length > 0) {
+            const centroid = getCentroid(frameParent.corners)
+            let maxR = 0
+            for (const c of frameParent.corners) {
+              const r = centroid.distanceTo(c)
+              if (r > maxR) maxR = r
+            }
+            if (maxR > 0) maxWS = maxR * 1.5
+          }
+          obj.meshView.updateScale(this._camera, this._sceneView.renderer, maxWS)
+        }
       }
       // Sync CoordinateFrame world poses every frame (ADR-020).
       // SceneService._updateWorldPoses() computes worldPos = parentCentroid + translation

--- a/src/view/CoordinateFrameView.js
+++ b/src/view/CoordinateFrameView.js
@@ -230,16 +230,21 @@ export class CoordinateFrameView {
    * Scales the entire frame so the axis length appears at a constant screen
    * pixel size regardless of camera distance.  Call every animation frame.
    * Uses the same perspective-correction formula as MeasureLineView._scaleDots().
+   *
    * @param {THREE.PerspectiveCamera} camera
    * @param {THREE.WebGLRenderer} renderer
+   * @param {number} [maxWorldSize=Infinity]  Upper bound for the axis world length.
+   *   Pass the parent object's bounding radius (× some factor) so the frame never
+   *   grows larger than the parent when the user zooms far out.
    */
-  updateScale(camera, renderer) {
+  updateScale(camera, renderer, maxWorldSize = Infinity) {
     if (!this._group.visible || !camera.isPerspectiveCamera) return
     const tanHalfFov = Math.tan((camera.fov * Math.PI) / 360)
     const screenH    = renderer.domElement.clientHeight || 1
     const targetPx   = 80   // axis length in screen pixels
     const d          = camera.position.distanceTo(this._group.position)
-    const worldSize  = (targetPx / screenH) * 2 * d * tanHalfFov
+    let worldSize    = (targetPx / screenH) * 2 * d * tanHalfFov
+    if (maxWorldSize < Infinity) worldSize = Math.min(worldSize, maxWorldSize)
     this._group.scale.setScalar(worldSize / AXIS_LENGTH)
   }
 


### PR DESCRIPTION
- After _confirmGrab(), call _attachMobileTransform() to re-anchor the TC
  gizmo to the object's new world position.  Without this, regular touch/
  keyboard grab leaves the TC at the pre-grab location while the solid and
  its Origin CoordinateFrame have moved (visible after Duplicate + grab).

- Change CoordinateFrame default TC mode from 'rotate' to 'translate':
  positioning the frame is more common than rotating it, so translate is
  the better first action on selection.

- Add "Done" (✓) button to the CoordinateFrame mobile toolbar so users can
  dismiss the frame selection without hunting in the outliner.  Replaces
  the leading spacer (slot count stays at 5).  Also fix `active: isRotate`
  → `active: true` so the current-mode button always appears highlighted.

- Cap CoordinateFrame axis world size to 1.5× the parent object's bounding
  radius.  Previously updateScale() maintained a constant 80 px screen size
  at all zoom levels, so zooming out made the frame visually larger than the
  parent Solid.  The cap kicks in only when zoomed far out; close-up
  behaviour is unchanged.

https://claude.ai/code/session_013ohLU1AWU6qv4nb4doayu2