### PR TITLE
feat: right-click context menu on object (PC) — ADR-006

### DIFF
--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -186,6 +186,14 @@ Prevents `_handleEditClick()` from firing erroneously on toolbar or UI panel cli
 - `e.preventDefault()` suppresses the browser default menu
 - When `grab.active`, acts as a trigger for `_cancelGrab()`
 
+### Right-click (button === 2) — PC context menu (ADR-006)
+
+| State | Condition | Action |
+|-------|-----------|--------|
+| Operation in progress | `grab.active`, `measure.active`, `rotate.active`, etc. | Cancel the operation |
+| Object mode, hits object | `selectionMode === 'object'` + `pointerType !== 'touch'` | Select object + `showContextMenu()` (Grab / Dup / Rename / Delete) |
+| Object mode, hits empty | No hit result | No-op; OrbitControls handles right-drag orbit |
+
 ---
 
 ## [C] Keyboard Events

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -400,7 +400,7 @@ Phases A, B, C implemented (2026-03-21 to 2026-03-22). See ADR-015 and ADR-017 f
 | Priority | Item | Complexity | ADR / Notes |
 |----------|------|-----------|-------------|
 | ~~🔴 High~~ | ~~MeasureLine Edit Mode · 1D — endpoint drag to reposition after placement~~ ✅ 2026-04-17 | ~~Medium~~ | ADR-005 |
-| 🟡 Medium | Right-click context menu (currently: cancel only) | Low | ADR-006 |
+| ~~🟡 Medium~~ | ~~Right-click context menu (currently: cancel only)~~ ✅ 2026-04-17 | ~~Low~~ | ADR-006 |
 | 🟡 Medium | Multi-face extrude (Shift+click) | Medium | — |
 | 🟡 Medium | Export (OBJ / GLTF) | Low | Phase D via Geometry Service |
 | 🟢 Low | CoordinateFrame assembly-mate positioning — `matchedFrameId` field; declare frame coincidence to drive object placement | High | ADR-021 |

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -2409,7 +2409,32 @@ export class AppController {
       keydown:     e => this._onKeyDown(e),
       keyup:       e => this._onKeyUp(e),
       wheel:       e => this._onWheel(e),
-      contextmenu: e => e.preventDefault(),
+      contextmenu: e => {
+        e.preventDefault()
+        if (this._contextMenuSuppressed) { this._contextMenuSuppressed = false; return }
+        if (e.target !== this._sceneView.renderer.domElement) return
+        if (this._scene.selectionMode !== 'object') return
+        this._updateMouse(e)
+        let result = this._hitAnyObject()
+        if (!result) result = this._hitAnyAnnotation()
+        if (!result) return
+        const { obj } = result
+        if (!this._selectedIds.has(obj.id)) {
+          this._clearObjectSelection()
+          if (obj.id !== this._scene.activeId) {
+            this._switchActiveObject(obj.id, true)
+          } else if (!this._objSelected) {
+            this._setObjectSelected(true)
+          }
+          this._selectedIds.add(obj.id)
+        } else if (obj.id !== this._scene.activeId) {
+          this._service.setActiveObject(obj.id)
+          this._objSelected = true
+          this._refreshObjectModeStatus()
+          this._updateNPanel()
+        }
+        this._showLongPressContextMenu(e.clientX, e.clientY, obj)
+      },
     }
     window.addEventListener('pointermove', this._handlers.pointermove)
     window.addEventListener('pointerdown', this._handlers.pointerdown)
@@ -4954,6 +4979,13 @@ export class AppController {
     // an up-to-date _mouse — calling _updateMouse here covers all of them.
     this._updateMouse(e)
 
+    // Suppress contextmenu-triggered menu when right-click is a cancel (ADR-006)
+    this._contextMenuSuppressed = e.button === 2 && (
+      this._rotate.active || this._mountPicking.active ||
+      this._spatialLinkMode.active || this._grab.active ||
+      this._faceExtrude.active || !!this._mapMode.tool || this._measure.active
+    )
+
     if (this._rotate.active) {
       if (e.button === 0) { this._confirmRotate(); return }
       if (e.button === 2) { this._cancelRotate();  return }
@@ -5164,31 +5196,6 @@ export class AppController {
         return
       }
       return
-    }
-
-    // Right-click on object (PC only) → context menu (ADR-006)
-    if (e.button === 2 && e.pointerType !== 'touch' && this._scene.selectionMode === 'object') {
-      let result = this._hitAnyObject()
-      if (!result) result = this._hitAnyAnnotation()
-      if (result) {
-        const { obj } = result
-        if (!this._selectedIds.has(obj.id)) {
-          this._clearObjectSelection()
-          if (obj.id !== this._scene.activeId) {
-            this._switchActiveObject(obj.id, true)
-          } else if (!this._objSelected) {
-            this._setObjectSelected(true)
-          }
-          this._selectedIds.add(obj.id)
-        } else if (obj.id !== this._scene.activeId) {
-          this._service.setActiveObject(obj.id)
-          this._objSelected = true
-          this._refreshObjectModeStatus()
-          this._updateNPanel()
-        }
-        this._showLongPressContextMenu(e.clientX, e.clientY, obj)
-        return
-      }
     }
 
     if (e.button !== 0) return

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -5166,6 +5166,31 @@ export class AppController {
       return
     }
 
+    // Right-click on object (PC only) → context menu (ADR-006)
+    if (e.button === 2 && e.pointerType !== 'touch' && this._scene.selectionMode === 'object') {
+      let result = this._hitAnyObject()
+      if (!result) result = this._hitAnyAnnotation()
+      if (result) {
+        const { obj } = result
+        if (!this._selectedIds.has(obj.id)) {
+          this._clearObjectSelection()
+          if (obj.id !== this._scene.activeId) {
+            this._switchActiveObject(obj.id, true)
+          } else if (!this._objSelected) {
+            this._setObjectSelected(true)
+          }
+          this._selectedIds.add(obj.id)
+        } else if (obj.id !== this._scene.activeId) {
+          this._service.setActiveObject(obj.id)
+          this._objSelected = true
+          this._refreshObjectModeStatus()
+          this._updateNPanel()
+        }
+        this._showLongPressContextMenu(e.clientX, e.clientY, obj)
+        return
+      }
+    }
+
     if (e.button !== 0) return
 
     // ── 2D extrude height drag ────────────────────────────────────────────


### PR DESCRIPTION
Right-click on an object in Object mode now selects it and shows the
context menu (Grab / Duplicate / Mount / Link / Rename / Delete),
matching the long-press behaviour on touch.  Reuses the existing
_showLongPressContextMenu() and showContextMenu() infrastructure.

Selection logic mirrors the left-click path: unselected objects are
switched to, already-selected objects just update the active pointer.

Docs: EVENTS.md right-click table added; ROADMAP.md item marked done.

https://claude.ai/code/session_012Kf1VzeGsTuTMTB5HcGsu4