### PR TITLE
Fix timeout cleanup and add unreferencedBadgeEl to outliner

### DIFF
--- a/src/service/GeometryEngine.js
+++ b/src/service/GeometryEngine.js
@@ -67,10 +67,12 @@ export class GeometryEngine {
 
     this._initPromise = new Promise((resolve) => {
       let settled = false
+      let timeout
 
       const settle = (err) => {
         if (settled) return
         settled = true
+        clearTimeout(timeout)
         if (err) {
           console.warn('[GeometryEngine] Wasm worker unavailable, using JS fallback:', err)
           this._usingFallback = true
@@ -113,12 +115,9 @@ export class GeometryEngine {
         })
 
         // Timeout: if the worker does not become ready within 10 s, fall back.
-        const timeout = setTimeout(() => {
+        timeout = setTimeout(() => {
           settle(new Error('Worker init timeout'))
         }, 10_000)
-
-        // When settled (either way), cancel the timeout.
-        this._initPromise.then(() => clearTimeout(timeout))
 
         this._worker.postMessage({ type: 'init' })
       } catch (err) {

--- a/src/view/OutlinerView.js
+++ b/src/view/OutlinerView.js
@@ -188,7 +188,7 @@ export class OutlinerView {
    */
   addObject(id, name, type = 'cuboid', parentId = null) {
     const depth = parentId ? this._getDepth(parentId) + 1 : 0
-    const { rowEl, eyeEl, nameEl, triEl, ifcBadgeEl, placeTypeBadgeEl, linkedBadgeEl, iconEl } = this._createRow(id, name, type, depth)
+    const { rowEl, eyeEl, nameEl, triEl, ifcBadgeEl, placeTypeBadgeEl, linkedBadgeEl, unreferencedBadgeEl, iconEl } = this._createRow(id, name, type, depth)
 
     if (parentId) {
       // Find insertion point: after the entire subtree rooted at parentId so
@@ -797,6 +797,6 @@ export class OutlinerView {
       if (this._onReparentCb) this._onReparentCb(dragged, id)
     })
 
-    return { rowEl, eyeEl, nameEl, triEl, ifcBadgeEl, placeTypeBadgeEl, linkedBadgeEl, iconEl }
+    return { rowEl, eyeEl, nameEl, triEl, ifcBadgeEl, placeTypeBadgeEl, linkedBadgeEl, unreferencedBadgeEl, iconEl }
   }
 }


### PR DESCRIPTION
## Summary
This PR fixes a memory leak in the GeometryEngine initialization and adds support for the `unreferencedBadgeEl` element in the OutlinerView.

## Key Changes

- **GeometryEngine.js**: Fixed timeout cleanup logic
  - Moved `timeout` variable declaration to outer scope so it can be properly cleared in the `settle` function
  - Removed redundant `.then()` handler that was attempting to clear the timeout after promise settlement
  - Now the timeout is correctly cleared whenever the initialization settles (either successfully or with an error)

- **OutlinerView.js**: Added missing `unreferencedBadgeEl` to destructuring
  - Updated `_createRow()` call in `addObject()` to include `unreferencedBadgeEl` in the destructured object
  - Updated return statement in `_createRow()` to include `unreferencedBadgeEl` in the returned object
  - Ensures the unreferenced badge element is properly tracked and available for use

## Implementation Details

The timeout fix prevents potential memory leaks by ensuring the timeout is always cleared, regardless of whether the worker initialization succeeds or fails. The previous implementation relied on promise chaining which could leave the timeout active if the promise never settled properly.

The outliner change ensures consistency in the component's API by including all badge elements that are created in the row creation method.

https://claude.ai/code/session_01P686LPCVMr3ST3w4XfmS87