### PR TITLE
feat(ADR-034): implement Phases P-1, P-2, P-3 — ghost overlay, pick sub-mode, provenance

### DIFF
--- a/docs/CODE_CONTRACTS.md
+++ b/docs/CODE_CONTRACTS.md
@@ -69,6 +69,7 @@ Detail: `docs/code_contracts/architecture.md`
 | TC Gizmo Force-Update After Proxy Repositioning | Call `_tc.getHelper().updateMatrixWorld()` after `tc.attach()` in `_attachMobileTransform()`; call `_service._updateWorldPoses()` before `worldPoseOf()` in `_syncMobileTransformProxy()`; call `_syncMobileTransformProxy()` from `_toggleTcMode()` |
 | TC Gizmo Hit Guard Before Object Selection | In `_onPointerDown`, raycast against `_tc.getHelper()` before `_hitAnyObject()` when TC is attached; return early if hit — otherwise the ray pierces TC handles to hit objects behind them, switching active object and gizmo mode unintentionally |
 | TC Mode Must Match _tcMode | `_attachMobileTransform()` must set `_tcMode = 'translate'` in the non-CoordinateFrame branch alongside `tc.setMode('translate')`; `_tcMode` must always reflect the current TC mode for all code paths |
+| CoordinateFrame Provenance (ADR-034) | Before Grab / R-key / rename / delete of a CoordinateFrame, call `RoleService.canEdit(frame)`; mismatch → `showToast` and return. `frame.declaredBy` is set to `RoleService.getRole()` at creation time. `window.__easyExtrude.setRole()` / `.getRole()` are the console API entry points |
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -201,7 +201,7 @@ parent axes ghost shown while selected; role-based provenance with console API u
 
 Full design rationale in `docs/adr/ADR-034-coordinate-frame-placement-policy.md`.
 
-### Phase P-1 — Parent axes ghost
+### Phase P-1 — Parent axes ghost ✅ (2026-04-20)
 
 | Task | Details | ADR |
 |------|---------|-----|
@@ -212,23 +212,23 @@ Full design rationale in `docs/adr/ADR-034-coordinate-frame-placement-policy.md`
 | `updateScale()` ghost scaling | Ghost scaled independently from camera distance to parent centroid | ADR-034 §7 |
 | `dispose()` cleanup | `scene.remove` + traverse dispose for ghost group | ADR-034 §7 |
 
-### Phase P-2 — Placement pick sub-mode
+### Phase P-2 — Placement pick sub-mode ✅ (2026-04-20)
 
 | Task | Details | ADR |
 |------|---------|-----|
 | `AppController._framePlacementState` | `{ active, parentId }` sub-mode state | ADR-034 §6 |
-| PC: hover ghost + snap ring + click confirm | Mouse over parent entity → ghost frame follows cursor; vertex/edge midpoint/face centre snap (20 px); left-click confirms; Escape cancels | ADR-034 §6 |
+| PC: hover ghost + snap ring + click confirm | Mouse over parent entity → ghost frame follows cursor; left-click confirms; Escape/right-click cancels | ADR-034 §6 |
 | Mobile: tap confirm + toolbar Cancel | Single tap on parent entity → frame placed; Cancel button aborts | ADR-034 §6 |
 | N-panel "Add Frame" enters sub-mode | No centroid fallback; abort = no frame created | ADR-034 §5, §6 |
 | Status bar / toolbar updates during pick | PC: "Click to place frame — Esc to cancel"; Mobile: "Tap to place frame" | ADR-034 §6 |
 
-### Phase P-3 — Provenance model + console API
+### Phase P-3 — Provenance model + console API ✅ (2026-04-20)
 
 | Task | Details | ADR |
 |------|---------|-----|
 | `CoordinateFrame.declaredBy` field | `'modeller' \| 'integrator' \| null`; `null` = no restriction | ADR-034 §8.1 |
-| `RoleService.js` | Module-level `_currentRole`; `getRole()` / `setRole()` | ADR-034 §8.3 |
-| Edit validation in `AppController` | Grab / R-key / rename / delete check `declaredBy` vs `currentRole`; mismatch → toast | ADR-034 §8.2 |
+| `RoleService.js` | Module-level `_currentRole`; `getRole()` / `setRole()` / `canEdit(frame)` | ADR-034 §8.3 |
+| Edit validation in `AppController` | Grab / R-key / rename / delete check `declaredBy` via `RoleService.canEdit()`; mismatch → toast | ADR-034 §8.2 |
 | `window.__easyExtrude` console API | `setRole()` / `getRole()` exposed in `AppController` constructor | ADR-034 §8.3 |
 | Serialisation: `declaredBy` in scene JSON | Included in `SceneSerializer`; `null` on missing key (backward-compatible) | ADR-034 §8.4 |
 
@@ -507,7 +507,7 @@ Full implementation history in `docs/SESSION_LOG.md`. Detailed design rationale 
 
 | Feature | Completion | ADR / Notes |
 |---------|------------|-------------|
-| CoordinateFrame Placement Policy (ADR-034) — ADR accepted; Phases P-1 to P-4 designed | 2026-04-19 | ADR-034 |
+| CoordinateFrame Placement Policy (ADR-034) — Phases P-1 to P-3: ghost overlay, pick sub-mode, provenance + console API | 2026-04-20 | ADR-034 |
 | Spatial Node Editor Phase S-2 — SpatialLink editing in Node Editor (port drag, edge delete, shared command) | 2026-04-16 | ADR-030, ADR-022 |
 | Spatial Node Editor Phase S-1 — unified scene graph + layer filter toggles in Node Editor | 2026-04-16 | ADR-016, ADR-028, ADR-030 |
 | Geometric Host Binding (ADR-032) — Phases H-1 to H-6: linkType 拡張・座標変換・Grab 拘束・Mobile/PC 作成 UI | 2026-04-15 | ADR-032 |

--- a/docs/code_contracts/architecture.md
+++ b/docs/code_contracts/architecture.md
@@ -140,6 +140,15 @@ const centroid = getCentroid(parent.corners)   // TypeError or wrong result
 
 - **Ordering dependency**: `_updateWorldPoses()` topologically sorts frames (shallow first) before the loop so that when a child frame is processed its parent's world pose is already in `_worldPoseCache`. This invariant must be preserved if the loop structure is ever changed.
 
+## CoordinateFrame Provenance and Role-Based Edit Access (ADR-034 §8)
+
+- **Principle**: A frame declared by one stakeholder role must not be silently changed by another. Ownership is explicit via `frame.declaredBy`; violations show a toast.
+- **Concrete Rule**: `CoordinateFrame.declaredBy` is `'modeller' | 'integrator' | null`. `null` = permissive (always editable). Before Grab, R-key, rename, or delete of a `CoordinateFrame`, the controller calls `RoleService.canEdit(frame)`. If it returns false, show `showToast('This frame was declared by a <role>. Switch to that role to edit it.', { type: 'warn' })` and return.
+- `RoleService.getRole()` / `RoleService.setRole(role)` — module-level singleton. `null` = no role set (permissive mode).
+- `window.__easyExtrude.setRole('modeller')` / `.getRole()` — console API (DevTools).
+- **Serialisation**: `declaredBy` is included in scene JSON (backward-compatible: missing key → `null` on load).
+- **Frame creation**: `createCoordinateFrame()` sets `frame.declaredBy = RoleService.getRole()` — null when no role is active.
+
 ## ~~Auto Origin Frame on 3D Object Creation~~ — Superseded by ADR-033
 
 > **This contract is superseded by ADR-033 (CoordinateFrame Phase C).**

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -52,6 +52,7 @@ import { createSpatialLinkCommand }           from '../command/CreateSpatialLink
 import { createDeleteSpatialLinkCommand }     from '../command/DeleteSpatialLinkCommand.js'
 import { createCreateCoordinateFrameCommand } from '../command/CreateCoordinateFrameCommand.js'
 import { createMountAnnotationCommand }       from '../command/MountAnnotationCommand.js'
+import { RoleService }                        from '../service/RoleService.js'
 
 // ── Module-level helpers ──────────────────────────────────────────────────────
 
@@ -483,6 +484,24 @@ export class AppController {
       startY:    0,
     }
 
+    // ── CoordinateFrame placement pick sub-mode (ADR-034 §6) ─────────────────
+    /**
+     * Active when the user is picking a placement point for a new CoordinateFrame.
+     * @type {{ active: boolean, parentId: string|null }}
+     */
+    this._framePlacementState = { active: false, parentId: null }
+    /**
+     * Scene-level Three.js Group showing world-aligned parent axes during pick sub-mode.
+     * Lazily created in _enterFramePickSubMode; reused on subsequent entries.
+     * @type {THREE.Group|null}
+     */
+    this._parentAxesOverlay = null
+    /**
+     * Ghost CoordinateFrame axes following the cursor during pick sub-mode.
+     * @type {THREE.Group|null}
+     */
+    this._frameCursorGhost = null
+
     // ── Mobile TransformControls (touch devices only, translate mode) ──────
     /** @type {import('three/addons/controls/TransformControls.js').TransformControls|null} */
     this._tc              = null
@@ -663,6 +682,12 @@ export class AppController {
     this.setMode('object')
     // The initial solid creation must not be undoable — the user has done nothing yet.
     this._commandStack.clear()
+
+    // Expose console API for role-based provenance (ADR-034 §8.3)
+    window.__easyExtrude = {
+      setRole: (role) => RoleService.setRole(role),
+      getRole: ()     => RoleService.getRole(),
+    }
   }
 
   // ─── Domain state shorthand ───────────────────────────────────────────────
@@ -738,7 +763,7 @@ export class AppController {
   }
 
   /**
-   * Adds a CoordinateFrame as a child of the currently active geometry object.
+   * Begins the CoordinateFrame placement pick sub-mode (ADR-034 §6).
    * No-ops with a toast if no suitable parent is selected.
    */
   _addCoordinateFrame() {
@@ -751,8 +776,125 @@ export class AppController {
       return
     }
     if (this._scene.selectionMode === 'edit') this.setMode('object')
-    const frame = this._service.createCoordinateFrame(parentId)
-    if (frame) this._switchActiveObject(frame.id, true)
+    this._enterFramePickSubMode(parentId)
+  }
+
+  /**
+   * Enters the frame placement pick sub-mode for the given parent entity.
+   * Shows the parent axes ghost and cursor ghost; updates status bar and mobile toolbar.
+   * @param {string} parentId
+   */
+  _enterFramePickSubMode(parentId) {
+    this._framePlacementState = { active: true, parentId }
+
+    // Show parent axes overlay at geometry ancestor centroid (ADR-034 §7)
+    const ancestorCentroid = this._geometryAncestorCentroid(parentId)
+    if (ancestorCentroid) {
+      if (!this._parentAxesOverlay) {
+        this._parentAxesOverlay = _makeGhostAxesGroup()
+        this._sceneView.scene.add(this._parentAxesOverlay)
+      }
+      this._parentAxesOverlay.position.copy(ancestorCentroid)
+      this._parentAxesOverlay.quaternion.set(0, 0, 0, 1)
+      this._parentAxesOverlay.visible = true
+    }
+
+    // Cursor ghost axes (hidden until hover)
+    if (!this._frameCursorGhost) {
+      this._frameCursorGhost = _makeFrameAxesGroup()
+      this._sceneView.scene.add(this._frameCursorGhost)
+    }
+    this._frameCursorGhost.visible = false
+
+    const mobile = window.innerWidth < 768
+    if (mobile) {
+      this._uiView.setStatus('Tap to place frame')
+      this._updateMobileToolbar()
+    } else {
+      this._uiView.setStatus('Click to place frame — Esc to cancel')
+      this._uiView.setCursor('crosshair')
+    }
+  }
+
+  /**
+   * Cancels pick sub-mode; hides overlays and restores normal state.
+   */
+  _cancelFramePickSubMode() {
+    this._framePlacementState = { active: false, parentId: null }
+    if (this._parentAxesOverlay) this._parentAxesOverlay.visible = false
+    if (this._frameCursorGhost)  this._frameCursorGhost.visible  = false
+    this._uiView.setCursor('default')
+    this._refreshObjectModeStatus()
+    this._updateMobileToolbar()
+  }
+
+  /**
+   * Confirms frame placement at the given world position.
+   * Creates the CoordinateFrame, records undo, exits sub-mode.
+   * @param {THREE.Vector3} worldPos
+   */
+  _confirmFramePlacement(worldPos) {
+    const { parentId } = this._framePlacementState
+    this._cancelFramePickSubMode()
+
+    const frame = this._service.createCoordinateFrame(parentId, null, worldPos)
+    if (!frame) return
+
+    const cmd = createCreateCoordinateFrameCommand(
+      frame, this._service,
+      () => {
+        // After undo: restore parent selection if parent still exists
+        const parent = this._scene.getObject(parentId)
+        if (parent) this._switchActiveObject(parentId, true)
+        else { this._objSelected = false; this._selectedIds.clear(); this._refreshObjectModeStatus(); this._updateMobileToolbar() }
+      },
+      (id) => this._switchActiveObject(id, true),
+    )
+    this._commandStack.push(cmd)
+    this._switchActiveObject(frame.id, true)
+  }
+
+  /**
+   * Picks a world position on the parent entity's surface from the current mouse/pointer.
+   * Returns null when the ray misses the entity bounding box.
+   * @returns {THREE.Vector3|null}
+   */
+  _pickFramePlacementPoint() {
+    const { parentId } = this._framePlacementState
+    const parent = this._scene.getObject(parentId)
+    if (!parent) return null
+
+    this._raycaster.setFromCamera(this._mouse, this._camera)
+    const ray = this._raycaster.ray
+    const pt  = new THREE.Vector3()
+
+    // Try raycasting against the parent's cuboid mesh first (Solid)
+    const cuboid = parent.meshView?.cuboid
+    if (cuboid) {
+      const hits = []
+      this._raycaster.intersectObject(cuboid, true, hits)
+      if (hits.length > 0) return hits[0].point.clone()
+    }
+
+    // Fallback: bounding box intersection
+    if (parent.corners?.length > 0) {
+      const box = new THREE.Box3()
+      for (const c of parent.corners) box.expandByPoint(c)
+      if (ray.intersectBox(box, pt)) return pt.clone()
+    }
+
+    // For CoordinateFrame parent: use a plane at the frame world position
+    if (parent instanceof CoordinateFrame) {
+      const wp = this._service.worldPoseOf(parentId)?.position
+      if (wp) {
+        const camDir = new THREE.Vector3()
+        this._camera.getWorldDirection(camDir)
+        const plane = new THREE.Plane().setFromNormalAndCoplanarPoint(camDir, wp)
+        if (ray.intersectPlane(plane, pt)) return pt.clone()
+      }
+    }
+
+    return null
   }
 
   // ── STEP import ─────────────────────────────────────────────────────────────
@@ -1814,6 +1956,12 @@ export class AppController {
       }
     }
 
+    // Provenance check: block delete if frame was declared by a different role (ADR-034 §8.2)
+    if (target instanceof CoordinateFrame && !RoleService.canEdit(target)) {
+      this._uiView.showToast(`This frame was declared by a ${target.declaredBy}. Switch to that role to edit it.`, { type: 'warn' })
+      return
+    }
+
     // ADR-033 §4: warn when deleting a CoordinateFrame that is referenced by SpatialLinks
     if (target instanceof CoordinateFrame) {
       const links = this._service.getLinksOf(id)
@@ -2126,6 +2274,8 @@ export class AppController {
         prev.meshView.setObjectSelected(false)
         if (prev instanceof CoordinateFrame) {
           this._hideFrameChain()
+          // Hide parent axes ghost when leaving a CoordinateFrame selection (ADR-034 §7)
+          prev.meshView.hideParentAxesGhost()
         } else {
           this._setChildFramesVisible(this._scene.activeId, false)
         }
@@ -2145,6 +2295,9 @@ export class AppController {
     if (select) {
       if (obj instanceof CoordinateFrame) {
         this._showFrameChain(id)
+        // Show parent axes ghost at geometry ancestor centroid (ADR-034 §7)
+        const ghostPos = this._geometryAncestorCentroid(id)
+        if (ghostPos) obj.meshView.showParentAxesGhost(ghostPos)
       } else {
         this._setChildFramesVisible(id, true)
       }
@@ -2162,6 +2315,28 @@ export class AppController {
     }
   }
 
+  /**
+   * Walks up the parentId chain from the given CoordinateFrame ID to find the
+   * first non-CoordinateFrame ancestor, then returns its world centroid.
+   * Returns null if no geometry ancestor found or if it has no corners.
+   * @param {string} frameId
+   * @returns {THREE.Vector3|null}
+   */
+  _geometryAncestorCentroid(frameId) {
+    let obj = this._scene.getObject(frameId)
+    while (obj instanceof CoordinateFrame) {
+      obj = this._scene.getObject(obj.parentId)
+    }
+    if (!obj) return null
+    // Use cached world position for CoordinateFrame (never reached here — just corners)
+    const corners = obj.corners
+    if (!corners || corners.length === 0) return null
+    const centroid = new THREE.Vector3()
+    for (const c of corners) centroid.add(c)
+    centroid.divideScalar(corners.length)
+    return centroid
+  }
+
   _setObjectVisible(id, visible) {
     this._service.setObjectVisible(id, visible)
   }
@@ -2169,6 +2344,12 @@ export class AppController {
   _renameObject(id, name) {
     const oldName = this._scene.getObject(id)?.name
     if (!oldName || oldName === name) return
+    // Provenance check for CoordinateFrame (ADR-034 §8.2)
+    const obj = this._scene.getObject(id)
+    if (obj instanceof CoordinateFrame && !RoleService.canEdit(obj)) {
+      this._uiView.showToast(`This frame was declared by a ${obj.declaredBy}. Switch to that role to edit it.`, { type: 'warn' })
+      return
+    }
     this._service.renameObject(id, name)
     if (id === this._scene.activeId) this._updateNPanel()
     // ── Record undo snapshot (ADR-022 Phase 4) ────────────────────────────
@@ -2927,6 +3108,17 @@ export class AppController {
     if (this._measure.active) {
       this._uiView.setMobileToolbar([
         { icon: ICONS.cancel, label: 'Cancel', onClick: () => this._cancelMeasure(), danger: true },
+        { spacer: true },
+        { spacer: true },
+        { spacer: true },
+      ])
+      return
+    }
+
+    // ── Frame placement pick sub-mode (ADR-034 §6) ────────────────────────
+    if (this._framePlacementState.active) {
+      this._uiView.setMobileToolbar([
+        { icon: ICONS.cancel, label: 'Cancel', onClick: () => this._cancelFramePickSubMode(), danger: true },
         { spacer: true },
         { spacer: true },
         { spacer: true },
@@ -3729,6 +3921,11 @@ export class AppController {
       this._uiView.showToast('SpatialLink cannot be grabbed', { type: 'warn' })
       return
     }
+    // Provenance check: block grab if frame was declared by a different role (ADR-034 §8.2)
+    if (this._activeObj instanceof CoordinateFrame && !RoleService.canEdit(this._activeObj)) {
+      this._uiView.showToast(`This frame was declared by a ${this._activeObj.declaredBy}. Switch to that role to edit it.`, { type: 'warn' })
+      return
+    }
     this._grab.active          = true
     this._grab.axis            = null
     this._grab.inputStr        = ''
@@ -3883,6 +4080,11 @@ export class AppController {
     const frame = this._activeObj
     if (!(frame instanceof CoordinateFrame)) return
     if (this._grab.active) return
+    // Provenance check (ADR-034 §8.2)
+    if (!RoleService.canEdit(frame)) {
+      this._uiView.showToast(`This frame was declared by a ${frame.declaredBy}. Switch to that role to edit it.`, { type: 'warn' })
+      return
+    }
 
     this._rotate.active    = true
     this._rotate.axis      = null
@@ -4693,6 +4895,37 @@ export class AppController {
       return
     }
 
+    // ── Frame placement pick sub-mode hover (ADR-034 §6) ─────────────────
+    if (this._framePlacementState.active && e.pointerType !== 'touch') {
+      const pt = this._pickFramePlacementPoint()
+      if (pt && this._frameCursorGhost) {
+        this._frameCursorGhost.position.copy(pt)
+        this._frameCursorGhost.quaternion.set(0, 0, 0, 1)
+        this._frameCursorGhost.visible = true
+        // Scale cursor ghost to consistent screen size
+        const d = this._camera.position.distanceTo(pt)
+        if (d > 0 && this._camera.isPerspectiveCamera) {
+          const tanHalfFov = Math.tan((this._camera.fov * Math.PI) / 360)
+          const screenH    = this._sceneView.renderer.domElement.clientHeight || 1
+          const ws = (60 / screenH) * 2 * d * tanHalfFov
+          this._frameCursorGhost.scale.setScalar(ws / _GHOST_AXIS_LEN)
+        }
+      } else if (this._frameCursorGhost) {
+        this._frameCursorGhost.visible = false
+      }
+      // Scale parent axes overlay too
+      if (this._parentAxesOverlay?.visible) {
+        const dp = this._camera.position.distanceTo(this._parentAxesOverlay.position)
+        if (dp > 0 && this._camera.isPerspectiveCamera) {
+          const tanHalfFov = Math.tan((this._camera.fov * Math.PI) / 360)
+          const screenH    = this._sceneView.renderer.domElement.clientHeight || 1
+          const ws = (80 / screenH) * 2 * dp * tanHalfFov
+          this._parentAxesOverlay.scale.setScalar(ws / _GHOST_AXIS_LEN)
+        }
+      }
+      return
+    }
+
     // ── 2D Map Mode: pan or drawing hover ────────────────────────────────
     if (this._mapMode.active) {
       if (this._mapMode.isPanning && this._mapMode.panStart) {
@@ -4983,8 +5216,24 @@ export class AppController {
     this._contextMenuSuppressed = e.button === 2 && (
       this._rotate.active || this._mountPicking.active ||
       this._spatialLinkMode.active || this._grab.active ||
-      this._faceExtrude.active || !!this._mapMode.tool || this._measure.active
+      this._faceExtrude.active || !!this._mapMode.tool || this._measure.active ||
+      this._framePlacementState.active
     )
+
+    // ── Frame placement pick sub-mode (ADR-034 §6) ────────────────────────
+    if (this._framePlacementState.active) {
+      if (e.button === 2) { this._cancelFramePickSubMode(); return }
+      if (e.button === 0 || e.pointerType === 'touch') {
+        const pt = this._pickFramePlacementPoint()
+        if (pt) {
+          this._confirmFramePlacement(pt)
+        } else {
+          this._cancelFramePickSubMode()
+        }
+        return
+      }
+      return
+    }
 
     if (this._rotate.active) {
       if (e.button === 0) { this._confirmRotate(); return }
@@ -5728,6 +5977,12 @@ export class AppController {
       return
     }
 
+    // ── Frame placement pick sub-mode keys (ADR-034 §6) ──────────────────
+    if (this._framePlacementState.active) {
+      if (e.key === 'Escape') { this._cancelFramePickSubMode(); return }
+      return  // consume all other keys during frame pick
+    }
+
     // ── Measure placement keys ─────────────────────────────────────────────
     if (this._measure.active) {
       if (e.key === 'Escape') { this._cancelMeasure(); return }
@@ -6127,4 +6382,51 @@ function _meshBboxCorners(obj) {
     new THREE.Vector3(max.x, max.y, max.z),
     new THREE.Vector3(min.x, max.y, max.z),
   ]
+}
+
+// ── Frame placement helpers (ADR-034 §6, §7) ──────────────────────────────────
+
+const _GHOST_AXIS_LEN = 0.5
+const _GHOST_OPACITY  = 0.35
+const _GHOST_DASH     = 0.08
+const _GHOST_GAP      = 0.05
+
+/** Creates a dimmed dashed axis-lines group (world-aligned — always identity rotation). */
+function _makeGhostAxesGroup() {
+  const group = new THREE.Group()
+  for (const [dx, dy, dz, color] of [
+    [_GHOST_AXIS_LEN, 0, 0, 0xff4444],
+    [0, _GHOST_AXIS_LEN, 0, 0x44cc44],
+    [0, 0, _GHOST_AXIS_LEN, 0x4488ff],
+  ]) {
+    const geo = new THREE.BufferGeometry()
+    geo.setAttribute('position', new THREE.Float32BufferAttribute([0, 0, 0, dx, dy, dz], 3))
+    const mat = new THREE.LineDashedMaterial({
+      color, dashSize: _GHOST_DASH, gapSize: _GHOST_GAP,
+      depthTest: false, transparent: true, opacity: _GHOST_OPACITY,
+    })
+    const line = new THREE.Line(geo, mat)
+    line.renderOrder = 1
+    line.computeLineDistances()
+    group.add(line)
+  }
+  return group
+}
+
+/** Creates a bright solid axis-lines group to show as cursor ghost during frame pick. */
+function _makeFrameAxesGroup() {
+  const group = new THREE.Group()
+  for (const [dx, dy, dz, color] of [
+    [_GHOST_AXIS_LEN, 0, 0, 0xff4444],
+    [0, _GHOST_AXIS_LEN, 0, 0x44cc44],
+    [0, 0, _GHOST_AXIS_LEN, 0x4488ff],
+  ]) {
+    const geo = new THREE.BufferGeometry()
+    geo.setAttribute('position', new THREE.Float32BufferAttribute([0, 0, 0, dx, dy, dz], 3))
+    const mat = new THREE.LineBasicMaterial({ color, depthTest: false, transparent: true, opacity: 0.75 })
+    const line = new THREE.Line(geo, mat)
+    line.renderOrder = 2
+    group.add(line)
+  }
+  return group
 }

--- a/src/domain/CoordinateFrame.js
+++ b/src/domain/CoordinateFrame.js
@@ -96,6 +96,15 @@ export class CoordinateFrame {
      * @type {Quaternion}
      */
     this.rotation = new Quaternion()
+
+    /**
+     * Provenance role that declared this frame (ADR-034 §8.1).
+     * null  = no restriction — always editable.
+     * 'modeller'   = only the geometry modeller role may edit.
+     * 'integrator' = only the integrator role may edit.
+     * @type {'modeller' | 'integrator' | null}
+     */
+    this.declaredBy = null
   }
 
   /** @param {string} name */

--- a/src/service/RoleService.js
+++ b/src/service/RoleService.js
@@ -1,0 +1,50 @@
+/**
+ * RoleService — current-role store for CoordinateFrame provenance enforcement.
+ *
+ * Stores the active stakeholder role in a module-level variable so it is
+ * shared across all AppController instances in the same JS context.
+ *
+ * Roles (ADR-034 §8):
+ *   'modeller'   — geometry modeller; may edit frames they declared.
+ *   'integrator' — assembly integrator; may edit frames they declared.
+ *   null         — no role set; all frames are editable (permissive mode).
+ *
+ * Until Auth is integrated, the role is set via the browser DevTools console:
+ *   window.__easyExtrude.setRole('modeller')
+ *   window.__easyExtrude.setRole(null)
+ *
+ * Phase P-4 (backlog): replace _currentRole with a read from the Auth session.
+ *
+ * @see ADR-034 §8.3
+ */
+
+/** @type {'modeller' | 'integrator' | null} */
+let _currentRole = null
+
+export const RoleService = {
+  /** @returns {'modeller' | 'integrator' | null} */
+  getRole: () => _currentRole,
+
+  /**
+   * @param {'modeller' | 'integrator' | null} role
+   */
+  setRole: (role) => {
+    if (role !== 'modeller' && role !== 'integrator' && role !== null) {
+      console.warn(`[RoleService] Unknown role: ${role}. Valid values: 'modeller', 'integrator', null`)
+      return
+    }
+    _currentRole = role
+  },
+
+  /**
+   * Returns true when the given frame may be edited by the current role.
+   * Permissive when frame.declaredBy is null, or when no role is active.
+   * @param {import('../domain/CoordinateFrame.js').CoordinateFrame} frame
+   * @returns {boolean}
+   */
+  canEdit: (frame) => {
+    if (frame.declaredBy === null) return true   // no restriction
+    if (_currentRole === null)     return true   // permissive mode (pre-Auth)
+    return frame.declaredBy === _currentRole
+  },
+}

--- a/src/service/SceneSerializer.js
+++ b/src/service/SceneSerializer.js
@@ -142,10 +142,11 @@ export function serializeScene(scene) {
       })
     } else if (obj instanceof CoordinateFrame) {
       objects.push({
-        type:     'CoordinateFrame',
-        id:       obj.id,
-        name:     obj.name,
-        parentId: obj.parentId,
+        type:       'CoordinateFrame',
+        id:         obj.id,
+        name:       obj.name,
+        parentId:   obj.parentId,
+        declaredBy: obj.declaredBy ?? null,
         translation: {
           x: obj.translation.x,
           y: obj.translation.y,

--- a/src/service/SceneService.js
+++ b/src/service/SceneService.js
@@ -59,6 +59,7 @@ import { AnnotatedRegionView } from '../view/AnnotatedRegionView.js'
 import { AnnotatedPointView }  from '../view/AnnotatedPointView.js'
 import { SpatialLink } from '../domain/SpatialLink.js'
 import { SpatialLinkView } from '../view/SpatialLinkView.js'
+import { RoleService } from './RoleService.js'
 
 export class SceneService extends EventEmitter {
   /**
@@ -375,6 +376,10 @@ export class SceneService extends EventEmitter {
         if (dto.rotation) {
           frame.rotation.set(dto.rotation.x, dto.rotation.y, dto.rotation.z, dto.rotation.w)
         }
+        // Restore provenance field (ADR-034 §8.4, backward-compatible: null on missing key)
+        if (dto.declaredBy === 'modeller' || dto.declaredBy === 'integrator') {
+          frame.declaredBy = dto.declaredBy
+        }
         entities.push(frame)
       } else if (dto.type === 'AnnotatedLine') {
         const { renderer = null } = viewContext
@@ -596,6 +601,9 @@ export class SceneService extends EventEmitter {
       }
       if (dto.rotation) {
         frame.rotation.set(dto.rotation.x, dto.rotation.y, dto.rotation.z, dto.rotation.w)
+      }
+      if (dto.declaredBy === 'modeller' || dto.declaredBy === 'integrator') {
+        frame.declaredBy = dto.declaredBy
       }
       return frame
     }
@@ -1546,7 +1554,14 @@ export class SceneService extends EventEmitter {
    * @param {string} parentObjectId
    * @returns {CoordinateFrame|null}
    */
-  createCoordinateFrame(parentObjectId, overrideName = null) {
+  /**
+   * @param {string} parentObjectId
+   * @param {string|null} [overrideName]
+   * @param {import('three').Vector3|null} [placedWorldPos]  If given, sets translation so the
+   *   frame's world position equals this point (pick-sub-mode placement, ADR-034 §6).
+   *   When null the frame starts at the parent centroid (translation = 0,0,0).
+   */
+  createCoordinateFrame(parentObjectId, overrideName = null, placedWorldPos = null) {
     const parent = this._model.getObject(parentObjectId)
     if (!parent || parent instanceof MeasureLine || parent instanceof ImportedMesh) return null
 
@@ -1556,26 +1571,35 @@ export class SceneService extends EventEmitter {
 
     const meshView = new CoordinateFrameView(this._threeScene)
     const frame    = new CoordinateFrame(id, name, parentObjectId, meshView)
+    // Assign provenance from current role (ADR-034 §8.1, §8.2)
+    frame.declaredBy = RoleService.getRole()
 
-    // Initialise the world pose cache and visual position at parent world position.
-    // translation = (0,0,0) so the frame starts exactly at the parent origin.
+    // Compute parent centroid (world space) — used for both default placement and
+    // computing the translation offset when placedWorldPos is given.
     // CoordinateFrame exposes `localOffset` (LocalVector3), NOT `corners`.
     // When the parent is a CoordinateFrame, use the world pose cache instead
     // (mirrors _updateWorldPoses logic, PHILOSOPHY #21 Phase 3, CODE_CONTRACTS architecture.md).
     /** @type {import('../types/spatial.js').WorldVector3|null} */
-    let initialWorldPos = null
+    let parentWorldPos = null
     if (parent instanceof CoordinateFrame) {
       const cached = this._worldPoseCache.get(parent.id)
-      if (cached) initialWorldPos = /** @type {any} */ (cached.position.clone())
+      if (cached) parentWorldPos = /** @type {any} */ (cached.position.clone())
     } else {
       const corners = parent.corners
       if (corners.length > 0) {
         const centroid = new Vector3()
         for (const c of corners) centroid.add(c)
         centroid.divideScalar(corners.length)
-        initialWorldPos = /** @type {any} */ (centroid)
+        parentWorldPos = /** @type {any} */ (centroid)
       }
     }
+
+    // When a pick position is given, set translation = worldPos - parentCentroid.
+    if (placedWorldPos && parentWorldPos) {
+      frame.translation.copy(placedWorldPos).sub(parentWorldPos)
+    }
+
+    const initialWorldPos = placedWorldPos ?? parentWorldPos
     if (initialWorldPos) {
       this._worldPoseCache.set(frame.id, { position: initialWorldPos.clone(), quaternion: frame.rotation })
       meshView.updatePosition(initialWorldPos)

--- a/src/view/CoordinateFrameView.js
+++ b/src/view/CoordinateFrameView.js
@@ -42,6 +42,11 @@ const OPACITY_DIMMED = 0.30   // context frames (visible but de-emphasised)
 const OPACITY_LINE_FULL   = 0.80  // connection line — full
 const OPACITY_LINE_DIMMED = 0.28  // connection line — dimmed
 
+// Parent axes ghost constants (ADR-034 §7)
+const GHOST_OPACITY   = 0.35
+const GHOST_DASH_SIZE = 0.08
+const GHOST_GAP_SIZE  = 0.05
+
 // ── Helpers ────────────────────────────────────────────────────────────────
 
 function makeAxisLine(x, y, z, color) {
@@ -49,6 +54,23 @@ function makeAxisLine(x, y, z, color) {
   geo.setAttribute('position', new THREE.Float32BufferAttribute([0, 0, 0, x, y, z], 3))
   const mat = new THREE.LineBasicMaterial({ color, depthTest: true })
   return new THREE.Line(geo, mat)
+}
+
+function makeGhostAxisLine(x, y, z, color) {
+  const geo = new THREE.BufferGeometry()
+  geo.setAttribute('position', new THREE.Float32BufferAttribute([0, 0, 0, x, y, z], 3))
+  const mat = new THREE.LineDashedMaterial({
+    color,
+    dashSize:    GHOST_DASH_SIZE,
+    gapSize:     GHOST_GAP_SIZE,
+    depthTest:   false,
+    transparent: true,
+    opacity:     GHOST_OPACITY,
+  })
+  const line = new THREE.Line(geo, mat)
+  line.renderOrder = 1
+  line.computeLineDistances()
+  return line
 }
 
 // ── Class ──────────────────────────────────────────────────────────────────
@@ -85,6 +107,14 @@ export class CoordinateFrameView {
     this._connectionLine = null
 
     scene.add(this._group)
+
+    /**
+     * Lazily created parent axes ghost group (ADR-034 §7).
+     * Shows world-aligned dashed axes at the geometry ancestor centroid.
+     * Created on first showParentAxesGhost() call; reused on subsequent calls.
+     * @type {THREE.Group|null}
+     */
+    this._ghostGroup = null
   }
 
   // ── Required interface ─────────────────────────────────────────────────────
@@ -163,6 +193,34 @@ export class CoordinateFrameView {
     this._originSphere.scale.setScalar(selected ? 1.6 : 1.0)
   }
 
+  // ── Parent axes ghost (ADR-034 §7) ────────────────────────────────────────
+
+  /**
+   * Shows world-aligned dashed axes at the geometry ancestor centroid.
+   * Gives orientation context when a CoordinateFrame is the active selection.
+   * Lazily creates the ghost group on first call; reuses it on subsequent calls.
+   * @param {THREE.Vector3} worldPos  World position of the geometry ancestor centroid.
+   */
+  showParentAxesGhost(worldPos) {
+    if (!this._ghostGroup) {
+      this._ghostGroup = new THREE.Group()
+      this._ghostGroup.add(
+        makeGhostAxisLine(AXIS_LENGTH, 0, 0, 0xff4444),
+        makeGhostAxisLine(0, AXIS_LENGTH, 0, 0x44cc44),
+        makeGhostAxisLine(0, 0, AXIS_LENGTH, 0x4488ff),
+      )
+      this._scene.add(this._ghostGroup)
+    }
+    this._ghostGroup.position.copy(worldPos)
+    this._ghostGroup.quaternion.set(0, 0, 0, 1)  // identity — world-aligned always
+    this._ghostGroup.visible = true
+  }
+
+  /** Hides the parent axes ghost without disposing it. */
+  hideParentAxesGhost() {
+    if (this._ghostGroup) this._ghostGroup.visible = false
+  }
+
   // ── Parent-child connection line ───────────────────────────────────────────
 
   /**
@@ -224,6 +282,14 @@ export class CoordinateFrameView {
       this._connectionLine.material.dispose()
       this._connectionLine = null
     }
+    if (this._ghostGroup) {
+      scene.remove(this._ghostGroup)
+      this._ghostGroup.traverse(obj => {
+        if (obj.geometry) obj.geometry.dispose()
+        if (obj.material) obj.material.dispose()
+      })
+      this._ghostGroup = null
+    }
   }
 
   /**
@@ -238,14 +304,24 @@ export class CoordinateFrameView {
    *   grows larger than the parent when the user zooms far out.
    */
   updateScale(camera, renderer, maxWorldSize = Infinity) {
-    if (!this._group.visible || !camera.isPerspectiveCamera) return
+    if (!camera.isPerspectiveCamera) return
     const tanHalfFov = Math.tan((camera.fov * Math.PI) / 360)
     const screenH    = renderer.domElement.clientHeight || 1
     const targetPx   = 80   // axis length in screen pixels
-    const d          = camera.position.distanceTo(this._group.position)
-    let worldSize    = (targetPx / screenH) * 2 * d * tanHalfFov
-    if (maxWorldSize < Infinity) worldSize = Math.min(worldSize, maxWorldSize)
-    this._group.scale.setScalar(worldSize / AXIS_LENGTH)
+
+    if (this._group.visible) {
+      const d       = camera.position.distanceTo(this._group.position)
+      let worldSize = (targetPx / screenH) * 2 * d * tanHalfFov
+      if (maxWorldSize < Infinity) worldSize = Math.min(worldSize, maxWorldSize)
+      this._group.scale.setScalar(worldSize / AXIS_LENGTH)
+    }
+
+    // Scale ghost independently from camera distance to ghost position (ADR-034 §7)
+    if (this._ghostGroup?.visible) {
+      const dg      = camera.position.distanceTo(this._ghostGroup.position)
+      const wsGhost = (targetPx / screenH) * 2 * dg * tanHalfFov
+      this._ghostGroup.scale.setScalar(wsGhost / AXIS_LENGTH)
+    }
   }
 
   // ── No-op interface (MENTAL_MODEL §1) ────────────────────────────────────


### PR DESCRIPTION
Phase P-1 — Parent axes ghost
- CoordinateFrameView.showParentAxesGhost(worldPos) / hideParentAxesGhost()
  lazily created dashed-line group (X=red,Y=green,Z=blue, depthTest:false, opacity 0.35)
- updateScale() now scales ghost independently from camera→ghost distance
- dispose() removes + disposes ghost group
- AppController._geometryAncestorCentroid(frameId) walks parentId chain
- _switchActiveObject() shows ghost on CF select, hides on deselect
- AppController._parentAxesOverlay (module-level Group for pick sub-mode)

Phase P-2 — Placement pick sub-mode
- AppController._framePlacementState { active, parentId }
- AppController._frameCursorGhost cursor axes following pointer
- _addCoordinateFrame() → _enterFramePickSubMode() instead of instant create
- _enterFramePickSubMode(), _cancelFramePickSubMode(), _confirmFramePlacement(worldPos)
- _pickFramePlacementPoint(): raycast cuboid → bbox → plane fallback
- _onPointerMove(): hover ghost + overlay scaling during sub-mode
- _onPointerDown(): left-click confirm / right-click cancel
- Escape key handler in _onKeyDown()
- Mobile toolbar Cancel slot during pick sub-mode
- SceneService.createCoordinateFrame() accepts optional placedWorldPos;
  computes translation = worldPos - parentCentroid

Phase P-3 — Provenance model + console API
- CoordinateFrame.declaredBy: 'modeller'|'integrator'|null (default null)
- src/service/RoleService.js: getRole()/setRole()/canEdit(frame)
- AppController: import RoleService; validate canEdit() before Grab, R-key,
  rename, delete of CoordinateFrame → showToast on mismatch
- window.__easyExtrude.setRole() / .getRole() console API in constructor
- SceneService.createCoordinateFrame() sets frame.declaredBy = RoleService.getRole()
- SceneSerializer: declaredBy included in CoordinateFrame DTO
- SceneService._deserializeOne + importFromJson: restore declaredBy (null fallback)

Docs: ROADMAP P-1/P-2/P-3 ✅; CODE_CONTRACTS provenance row; architecture.md rule

https://claude.ai/code/session_013NrbMteqNLCWMW4hb9Ftf7