### PR TITLE
fix: hide TC gizmo during Grab to prevent ghost position

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -3995,6 +3995,7 @@ export class AppController {
     }
 
     this._controls.enabled = false
+    this._detachMobileTransform()
     this._uiView.setCursor('grabbing')
     this._updateGrabStatus()
     this._updateMobileToolbar()
@@ -4064,6 +4065,7 @@ export class AppController {
     this._grab.stackMode     = false
     this._grab.stacking      = false
     this._controls.enabled = true
+    if (this._activeObj && this._objSelected) this._attachMobileTransform(this._activeObj)
     this._uiView.setCursor('default')
     this._refreshObjectModeStatus()
     this._updateNPanel()


### PR DESCRIPTION
Grab moves the object but the TransformControls gizmo was left at the
pre-grab position because _startGrab() never detached it. Added
_detachMobileTransform() at grab start, and _attachMobileTransform()
in _cancelGrab() to restore the gizmo at the original position.
_confirmGrab() already re-attached at the new position (line 4042).

https://claude.ai/code/session_01DCRxsefGqXMmxRiXj1gxcH