### PR TITLE
fix: cap CoordinateFrame axis size when zooming out (scene-wide maxWorldSize)

### DIFF
--- a/docs/CODE_CONTRACTS.md
+++ b/docs/CODE_CONTRACTS.md
@@ -70,6 +70,7 @@ Detail: `docs/code_contracts/architecture.md`
 | TC Gizmo Hit Guard Before Object Selection | In `_onPointerDown`, raycast against `_tc.getHelper()` before `_hitAnyObject()` when TC is attached; return early if hit — otherwise the ray pierces TC handles to hit objects behind them, switching active object and gizmo mode unintentionally |
 | TC Mode Must Match _tcMode | `_attachMobileTransform()` must set `_tcMode = 'translate'` in the non-CoordinateFrame branch alongside `tc.setMode('translate')`; `_tcMode` must always reflect the current TC mode for all code paths |
 | CoordinateFrame Provenance (ADR-034) | Before Grab / R-key / rename / delete of a CoordinateFrame, call `RoleService.canEdit(frame)`; mismatch → `showToast` and return. `frame.declaredBy` is set to `RoleService.getRole()` at creation time. `window.__easyExtrude.setRole()` / `.getRole()` are the console API entry points |
+| CoordinateFrame Scale Cap | `updateScale()` must always receive a finite `maxWorldSize`; use `sceneRadius × 0.3` (floor 1.0) as fallback for CFs without a solid parent — otherwise axes balloon to huge size when zooming out |
 
 ---
 

--- a/docs/code_contracts/architecture.md
+++ b/docs/code_contracts/architecture.md
@@ -149,6 +149,24 @@ const centroid = getCentroid(parent.corners)   // TypeError or wrong result
 - **Serialisation**: `declaredBy` is included in scene JSON (backward-compatible: missing key → `null` on load).
 - **Frame creation**: `createCoordinateFrame()` sets `frame.declaredBy = RoleService.getRole()` — null when no role is active.
 
+## CoordinateFrame Scale Cap — maxWorldSize Must Always Be Finite
+
+- **Principle**: CFs use constant-screen-size scaling (target: 80 px). Without an upper bound, the world-space axis length grows linearly with camera distance, making independent CFs visually dwarf all scene objects when the user zooms out.
+- **Concrete Rule**: The animation loop in `AppController.start()` must **always** pass a finite `maxWorldSize` to `CoordinateFrameView.updateScale()`. When a CF has a solid geometry parent, `maxWS = parentBoundingRadius × 1.5`. When no solid parent exists, fall back to `sceneRadius × 0.3` (where `sceneRadius` = max `c.length()` across all `corners` in the scene), with a floor of `1.0` for empty scenes.
+
+```js
+// ✓ Correct — always finite
+if (maxWS === Infinity) {
+  maxWS = sceneRadius > 0 ? sceneRadius * 0.3 : 1.0
+}
+obj.meshView.updateScale(camera, renderer, maxWS)
+
+// ✗ Wrong — passes Infinity for independent CFs; axes balloon to huge size at far zoom
+obj.meshView.updateScale(camera, renderer, Infinity)
+```
+
+- `sceneRadius` is computed once per frame before the object iteration loop (not per-CF), from all objects whose `corners?.length > 0`.
+
 ## ~~Auto Origin Frame on 3D Object Creation~~ — Superseded by ADR-033
 
 > **This contract is superseded by ADR-033 (CoordinateFrame Phase C).**

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -6209,6 +6209,17 @@ export class AppController {
       // Keep MeasureLine / AnnotatedPoint HTML labels positioned over the correct screen pixel,
       // drive per-element animations, and keep CoordinateFrame axes at constant screen size.
       const t = performance.now() * 0.001  // elapsed seconds for animation clock
+      // Compute scene bounding radius once per frame: used as a fallback cap for
+      // CFs that have no solid parent (otherwise they grow unboundedly when zooming out).
+      let sceneRadius = 0
+      for (const o of this._scene.objects.values()) {
+        if (o.corners?.length > 0) {
+          for (const c of o.corners) {
+            const r = c.length()
+            if (r > sceneRadius) sceneRadius = r
+          }
+        }
+      }
       for (const obj of this._scene.objects.values()) {
         if (obj instanceof MeasureLine)     obj.meshView.updateLabelPosition()
         if (obj instanceof AnnotatedPoint)  { obj.meshView.updateLabelPosition(this._sceneView.activeCamera); obj.meshView.tick(t) }
@@ -6218,8 +6229,8 @@ export class AppController {
           // Cap the frame's world size so it never visually dwarfs its parent.
           // Compute the parent object's bounding radius (max distance from centroid
           // to any corner) and allow the frame axes to grow to at most 1.5× that.
-          // Falls back to Infinity (uncapped) when the parent has no geometry corners
-          // (e.g. another CoordinateFrame parent).
+          // When no solid parent exists, fall back to a scene-wide cap (30% of the
+          // furthest corner from origin) so independent CFs also stay proportional.
           let maxWS = Infinity
           const frameParent = this._scene.getObject(obj.parentId)
           if (frameParent && !(frameParent instanceof CoordinateFrame) && frameParent.corners?.length > 0) {
@@ -6230,6 +6241,10 @@ export class AppController {
               if (r > maxR) maxR = r
             }
             if (maxR > 0) maxWS = maxR * 1.5
+          }
+          if (maxWS === Infinity) {
+            // sceneRadius=0 means empty scene; use 1.0 so the CF is still visible
+            maxWS = sceneRadius > 0 ? sceneRadius * 0.3 : 1.0
           }
           obj.meshView.updateScale(this._camera, this._sceneView.renderer, maxWS)
         }


### PR DESCRIPTION
Independent CFs (no solid parent) received maxWorldSize=Infinity, causing
their world-space axes to grow linearly with camera distance and visually
dwarf scene objects at far zoom distances.

Now compute sceneRadius once per frame from all objects with corners, and
pass sceneRadius×0.3 (floor 1.0 for empty scenes) as the maxWorldSize
fallback, keeping CF axes proportional to scene scale regardless of zoom.

https://claude.ai/code/session_01SE4fh2STzPmSGKaocadaGo