### PR TITLE
fix(CF): reduce axis size to ~2/3 and switch to TC-like cylinder shafts

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -6240,11 +6240,11 @@ export class AppController {
               const r = centroid.distanceTo(c)
               if (r > maxR) maxR = r
             }
-            if (maxR > 0) maxWS = maxR * 1.5
+            if (maxR > 0) maxWS = maxR * 0.75
           }
           if (maxWS === Infinity) {
             // sceneRadius=0 means empty scene; use 1.0 so the CF is still visible
-            maxWS = sceneRadius > 0 ? sceneRadius * 0.3 : 1.0
+            maxWS = sceneRadius > 0 ? sceneRadius * 0.15 : 1.0
           }
           obj.meshView.updateScale(this._camera, this._sceneView.renderer, maxWS)
         }

--- a/src/view/CoordinateFrameView.js
+++ b/src/view/CoordinateFrameView.js
@@ -34,6 +34,7 @@
 import * as THREE from 'three'
 
 const AXIS_LENGTH   = 0.5
+const AXIS_RADIUS   = 0.015   // ~3% of axis length; matches TC shaft visual weight
 const ORIGIN_RADIUS = 0.04
 
 // Opacity levels for chain-visibility modes
@@ -49,11 +50,14 @@ const GHOST_GAP_SIZE  = 0.05
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-function makeAxisLine(x, y, z, color) {
-  const geo = new THREE.BufferGeometry()
-  geo.setAttribute('position', new THREE.Float32BufferAttribute([0, 0, 0, x, y, z], 3))
-  const mat = new THREE.LineBasicMaterial({ color, depthTest: true })
-  return new THREE.Line(geo, mat)
+function makeAxisMesh(direction, color) {
+  const geo = new THREE.CylinderGeometry(AXIS_RADIUS, AXIS_RADIUS, AXIS_LENGTH, 6, 1, false)
+  geo.translate(0, AXIS_LENGTH / 2, 0)   // base at origin, tip at +Y
+  const mat = new THREE.MeshBasicMaterial({ color, depthTest: true })
+  const mesh = new THREE.Mesh(geo, mat)
+  if      (direction === 'x') mesh.rotation.z = -Math.PI / 2
+  else if (direction === 'z') mesh.rotation.x =  Math.PI / 2
+  return mesh
 }
 
 function makeGhostAxisLine(x, y, z, color) {
@@ -85,10 +89,10 @@ export class CoordinateFrameView {
     const sphereMat = new THREE.MeshBasicMaterial({ color: 0xffffff })
     this._originSphere = new THREE.Mesh(sphereGeo, sphereMat)
 
-    // ── Axis lines (thin RGB, no arrowheads or labels) ─────────────────────
-    this._lineX = makeAxisLine(AXIS_LENGTH, 0, 0, 0xff4444)
-    this._lineY = makeAxisLine(0, AXIS_LENGTH, 0, 0x44cc44)
-    this._lineZ = makeAxisLine(0, 0, AXIS_LENGTH, 0x4488ff)
+    // ── Axis cylinders (RGB, TC-like shaft thickness) ──────────────────────
+    this._lineX = makeAxisMesh('x', 0xff4444)
+    this._lineY = makeAxisMesh('y', 0x44cc44)
+    this._lineZ = makeAxisMesh('z', 0x4488ff)
 
     // ── Group ──────────────────────────────────────────────────────────────
     this._group = new THREE.Group()
@@ -307,7 +311,7 @@ export class CoordinateFrameView {
     if (!camera.isPerspectiveCamera) return
     const tanHalfFov = Math.tan((camera.fov * Math.PI) / 360)
     const screenH    = renderer.domElement.clientHeight || 1
-    const targetPx   = 80   // axis length in screen pixels
+    const targetPx   = 50   // axis length in screen pixels
 
     if (this._group.visible) {
       const d       = camera.position.distanceTo(this._group.position)


### PR DESCRIPTION
- targetPx: 80 → 50 (axis length target in screen pixels)
- parent-Solid maxWS cap: maxR × 1.5 → maxR × 0.75
- no-parent fallback cap: sceneRadius × 0.3 → sceneRadius × 0.15
- Axis geometry: THREE.Line (1 px fixed) → CylinderGeometry (AXIS_RADIUS=0.015,
  ~3 % of axis length), matching TransformControls shaft visual weight

https://claude.ai/code/session_01ExJ8SLoyfiy1cPge2sGbMm