### PR TITLE
fix(mobile): CF tap selection + Add Interface Frame visibility

### DIFF
--- a/docs/CODE_CONTRACTS.md
+++ b/docs/CODE_CONTRACTS.md
@@ -71,6 +71,8 @@ Detail: `docs/code_contracts/architecture.md`
 | TC Mode Must Match _tcMode | `_attachMobileTransform()` must set `_tcMode = 'translate'` in the non-CoordinateFrame branch alongside `tc.setMode('translate')`; `_tcMode` must always reflect the current TC mode for all code paths |
 | CoordinateFrame Provenance (ADR-034) | Before Grab / R-key / rename / delete of a CoordinateFrame, call `RoleService.canEdit(frame)`; mismatch → `showToast` and return. `frame.declaredBy` is set to `RoleService.getRole()` at creation time. `window.__easyExtrude.setRole()` / `.getRole()` are the console API entry points |
 | CoordinateFrame Scale Cap | `updateScale()` must always receive a finite `maxWorldSize`; use `sceneRadius × 0.3` (floor 1.0) as fallback for CFs without a solid parent — otherwise axes balloon to huge size when zooming out |
+| CoordinateFrame Tap Selection | `_hitAnyObject()` never hits a CF (cuboid = null); `_onPointerDown` must call `_hitAnyCoordinateFrame()` as a third fallback. `CoordinateFrameView.group` getter exposes the Three.js Group for `intersectObject()`. Only visible groups are tested. |
+| _promptAddFrame Must Select Frame After Creation | After pushing the command in `_promptAddFrame()`, call `_switchActiveObject(frame.id, true)` — otherwise the frame stays hidden in the 3D viewport. Undo restores parent selection; redo re-selects the frame. |
 
 ---
 

--- a/docs/code_contracts/architecture.md
+++ b/docs/code_contracts/architecture.md
@@ -362,3 +362,27 @@ if (this._tc?.object) {
 - **Principle**: `AppController.get _camera()` always returns the perspective camera (`SceneView.camera`). When Map mode activates the orthographic camera (`SceneView.activeCamera`), the renderer uses the ortho camera but views storing the old perspective camera reference will compute wrong screen positions.
 - **Concrete Rule**: Any view that projects 3D positions to screen coordinates for HTML overlay positioning (e.g. `AnnotatedPointView.updateLabelPosition()`) must use the ACTIVE camera, not a stale stored reference. Call sites in the animation loop must pass `this._sceneView.activeCamera` explicitly: `obj.meshView.updateLabelPosition(this._sceneView.activeCamera)`. The same applies to `MeasureLineView` if it is ever used alongside Map mode's orthographic camera.
 - **Root bug**: `AnnotatedPointView` stored `this._camera` (perspective camera) at construction time. In Map mode the ortho camera was used for rendering, but labels were projected with the perspective camera → labels appeared at wrong screen positions relative to the rendered 3D markers.
+
+## CoordinateFrame Tap Selection Requires _hitAnyCoordinateFrame Fallback
+
+- **Principle**: `_hitAnyObject()` filters candidates by `o.meshView.cuboid?.visible`. `CoordinateFrame.cuboid` returns `null`, so frames are never hit by this method. `_hitAnyAnnotation()` also skips frames. Without a dedicated fallback, tapping a visible frame axis on mobile never calls `_switchActiveObject()` and TC never appears.
+- **Concrete Rule**: `_onPointerDown` must call `_hitAnyCoordinateFrame()` as a third fallback after `_hitAnyAnnotation()`. `CoordinateFrameView` exposes a `get group()` getter (returns `this._group`); `_hitAnyCoordinateFrame()` iterates over all `CoordinateFrame` entities, skips those with `!obj.meshView?.group?.visible`, and raycasts `intersectObject(group, true)` to find the nearest hit. Only frames that are currently shown (via `showFull()` or `showDimmed()`) are considered.
+
+## _promptAddFrame Must Select Frame After Creation
+
+- **Principle**: `CoordinateFrameView._group.visible` defaults to `false`. A frame only becomes visible when `_showFrameChain()` or `_setChildFramesVisible()` calls `showFull()` / `showDimmed()`. These are only called from `_switchActiveObject()`.
+- **Concrete Rule**: After `this._commandStack.push(...)` in `_promptAddFrame()`, always call `this._switchActiveObject(frame.id, true)`. Without this, the frame is soft-created in the model and shown in the outliner (via `objectAdded` event), but remains permanently invisible in the 3D viewport and TC is never attached. Match the pattern from `_confirmFramePlacement()` including proper undo/redo callbacks: undo → restore parent selection; redo → `_switchActiveObject(id, true)`.
+
+```js
+// _promptAddFrame() — correct pattern
+this._commandStack.push(createCreateCoordinateFrameCommand(frame, this._service,
+  () => {
+    const parent = this._scene.getObject(parentId)
+    if (parent) this._switchActiveObject(parentId, true)
+    else { this._objSelected = false; this._selectedIds.clear(); ... }
+    this._updateNPanel()
+  },
+  (id) => { this._switchActiveObject(id, true); this._updateNPanel() },
+))
+this._switchActiveObject(frame.id, true)  // ← make frame visible + attach TC
+```

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -2808,6 +2808,33 @@ export class AppController {
     return nearestObj ? { obj: nearestObj } : null
   }
 
+  /**
+   * Hits any visible CoordinateFrame by raycasting against its axis meshes and
+   * origin sphere.  Called as a third fallback in _onPointerDown when both
+   * _hitAnyObject() and _hitAnyAnnotation() miss (e.g. mobile tap on a frame axis).
+   * Only frames whose group.visible is true are considered — hidden frames are
+   * not tappable.
+   * @returns {{ obj: object }|null}
+   */
+  _hitAnyCoordinateFrame() {
+    this._raycaster.setFromCamera(this._mouse, this._camera)
+    let nearestDist = Infinity
+    let nearestObj  = null
+
+    for (const obj of this._scene.objects.values()) {
+      if (!(obj instanceof CoordinateFrame)) continue
+      if (!obj.meshView?.group?.visible) continue
+
+      const hits = this._raycaster.intersectObject(obj.meshView.group, true)
+      if (hits.length > 0 && hits[0].distance < nearestDist) {
+        nearestDist = hits[0].distance
+        nearestObj  = obj
+      }
+    }
+
+    return nearestObj ? { obj: nearestObj } : null
+  }
+
   /** Hits only the active object's mesh */
   _hitActiveSolid() {
     if (!this._activeObj) return null
@@ -3062,10 +3089,17 @@ export class AppController {
       if (!frame) return
       this._commandStack.push(createCreateCoordinateFrameCommand(
         frame, this._service,
-        () => { this._updateNPanel() },
-        () => { this._updateNPanel() },
+        () => {
+          // After undo: restore parent selection if parent still exists
+          const parent = this._scene.getObject(parentId)
+          if (parent) this._switchActiveObject(parentId, true)
+          else { this._objSelected = false; this._selectedIds.clear(); this._refreshObjectModeStatus(); this._updateMobileToolbar() }
+          this._updateNPanel()
+        },
+        (id) => { this._switchActiveObject(id, true); this._updateNPanel() },
       ))
       this._uiView.showToast(`Frame "${frame.name}" added`)
+      this._switchActiveObject(frame.id, true)
       this._updateNPanel()
     }, { title: 'Add Interface Frame' })
   }
@@ -5486,9 +5520,10 @@ export class AppController {
         if (tcHits.length > 0) return
       }
 
-      // Primary cuboid hit; fall back to annotation entity bounding-box hit.
+      // Primary cuboid hit; fall back to annotation bounding-box; last fallback is CF axis mesh.
       let result = this._hitAnyObject()
       if (!result) result = this._hitAnyAnnotation()
+      if (!result) result = this._hitAnyCoordinateFrame()
       if (result) {
         const { hit, obj } = result
         if (!this._selectedIds.has(obj.id)) {

--- a/src/view/CoordinateFrameView.js
+++ b/src/view/CoordinateFrameView.js
@@ -123,8 +123,11 @@ export class CoordinateFrameView {
 
   // ── Required interface ─────────────────────────────────────────────────────
 
-  /** No raycasting surface for CoordinateFrames. */
+  /** No raycasting surface via cuboid; use group for tap selection instead. */
   get cuboid() { return null }
+
+  /** Exposes the Three.js Group for mobile tap raycasting (_hitAnyCoordinateFrame). */
+  get group() { return this._group }
 
   /** @param {THREE.Vector3} position */
   updatePosition(position) {


### PR DESCRIPTION
Bug 1 — CoordinateFrame tap (TC doesn't appear):
_hitAnyObject() skips CoordinateFrame (cuboid = null) and
_hitAnyAnnotation() only covers AnnotatedLine/Region/Point.
Added _hitAnyCoordinateFrame() that raycasts against visible
CoordinateFrameView groups (axis cylinders + origin sphere).
Called as a third fallback in _onPointerDown so tapping a
visible frame axis selects it and attaches TC.
CoordinateFrameView.get group() exposes the Three.js Group.

Bug 2 — Add Interface Frame invisible after context menu:
_promptAddFrame() created the frame but never called
_switchActiveObject(), so _showFrameChain() was never run and
the frame's _group.visible stayed false. Now matches the
_confirmFramePlacement() pattern: switchActiveObject(frame.id, true)
after push(), with proper undo (restore parent selection) /
redo (re-select frame) callbacks.

CODE_CONTRACTS: two new rows + architecture.md detail rules.

https://claude.ai/code/session_01Uft7Y14Kx7GGN5qLXg71yt