### PR TITLE
feat: implement fastened CF-to-CF rigid constraint solver (ADR-032 Phase H-7)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -190,6 +190,21 @@ linkType 語彙を英語前置詞体系（9 種）に整理し、位相的・意
 | 「Link to... 🔗」（Solid / CoordinateFrame） | 既存 `_linkPicking` フローへ；validation 済み linkType のみ表示 | ADR-032 §9 |
 | マウントピッキング中のステータスバー | 「Tap target frame (or empty space to cancel)」；Escape でキャンセル | ADR-032 §9 |
 
+### Phase H-7 — `fastened` Constraint Solver (CF→CF) ✅ (2026-04-26)
+
+| Task | Details | ADR |
+|------|---------|-----|
+| `SceneService._fastenedTransforms` Map | linkId → `{ sourceId, relativeOffset, relativeQuat }`；ADR-032 §3 インデックスと同パターン | ADR-032 §2 |
+| `SceneService.fastenFrame(sourceCFId, targetCFId)` | バインド時に相対変換を計算・保存；pre-bind の translation/rotation を返してコマンドに渡す | ADR-032 §5 |
+| `SceneService.unfastenFrame(link, translBefore, rotBefore)` | 拘束解除 + source CF を指定ポーズに復元（undo: pre-bind 値、forward: 現在値） | ADR-032 §5 |
+| `SceneService.refastenFrame(link, relativeOffset, relativeQuat)` | Redo パス：保存済み相対変換で拘束を再適用 | ADR-032 §5 |
+| `SceneService._updateFastenedFrames()` | 毎フレーム `_updateWorldPoses()` 末尾で呼び出し；source CF の世界ポーズを `targetPose × relativeTransform` に強制更新 | ADR-032 §5 |
+| `FastenFrameCommand` | `execute()` = `refastenFrame`、`undo()` = `unfastenFrame`；post-hoc push パターン | ADR-032 §7 |
+| `_computeValidLinkTypes` 更新 | CF→CF に `fastened` を追加（6-DOF 剛体結合） | ADR-032 §2 |
+| L キーフロー：`fastened` → `_confirmFastenFrame()` | linkType ピッカーで `fastened` 選択時に専用ハンドラへルーティング | ADR-032 §8 |
+| Mobile 長押しメニュー：「Unfasten ⊗」 | 拘束済み CF に対してのみ表示；Undo 可 | ADR-032 §9 |
+| `reattachSpatialLink` fastened ブランチ | シーンロード時に現在ポーズから相対変換を再計算して `_fastenedTransforms` に登録 | ADR-032 §5 |
+
 ---
 
 ## CoordinateFrame Placement Policy (ADR-034)

--- a/src/command/FastenFrameCommand.js
+++ b/src/command/FastenFrameCommand.js
@@ -1,0 +1,43 @@
+/**
+ * FastenFrameCommand — records the indivisible operation of fastening a
+ * CoordinateFrame to another CoordinateFrame (ADR-032 §2, linkType 'fastened').
+ *
+ * Fasten = relative-transform computation + SpatialLink creation.
+ * These two sub-steps are always executed and undone together.
+ *
+ * Follows the post-hoc push() pattern (CODE_CONTRACTS §CommandStack push() vs execute()):
+ * the fasten operation happens first in AppController via service.fastenFrame();
+ * this command is then pushed so undo/redo can replay it.
+ *
+ * execute() (redo): re-applies the constraint with the stored relative transform.
+ * undo():          removes the constraint and restores the source CF's pre-bind
+ *                  translation and rotation.
+ *
+ * @param {import('../domain/SpatialLink.js').SpatialLink} link
+ * @param {import('three').Vector3}    translationBefore  source CF translation before bind
+ * @param {import('three').Quaternion} rotationBefore     source CF rotation before bind
+ * @param {import('three').Vector3}    relativeOffset     source offset in target's local frame
+ * @param {import('three').Quaternion} relativeQuat       source rotation relative to target
+ * @param {import('../service/SceneService.js').SceneService} service
+ * @param {() => void} onAfterUndo
+ * @param {() => void} onAfterRedo
+ * @returns {{ label: string, execute(): void, undo(): void }}
+ */
+export function createFastenFrameCommand(
+  link, translationBefore, rotationBefore, relativeOffset, relativeQuat,
+  service, onAfterUndo, onAfterRedo,
+) {
+  return {
+    label: 'Fasten frame',
+
+    execute() {
+      service.refastenFrame(link, relativeOffset, relativeQuat)
+      onAfterRedo()
+    },
+
+    undo() {
+      service.unfastenFrame(link, translationBefore, rotationBefore)
+      onAfterUndo()
+    },
+  }
+}

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -52,6 +52,7 @@ import { createSpatialLinkCommand }           from '../command/CreateSpatialLink
 import { createDeleteSpatialLinkCommand }     from '../command/DeleteSpatialLinkCommand.js'
 import { createCreateCoordinateFrameCommand } from '../command/CreateCoordinateFrameCommand.js'
 import { createMountAnnotationCommand }       from '../command/MountAnnotationCommand.js'
+import { createFastenFrameCommand }           from '../command/FastenFrameCommand.js'
 import { RoleService }                        from '../service/RoleService.js'
 
 // ── Module-level helpers ──────────────────────────────────────────────────────
@@ -70,6 +71,7 @@ function _computeValidLinkTypes(source, target) {
   const geometric = []
   if (isAnnotated(source) && isCF(target))  geometric.push('mounts')
   if ((source instanceof Solid || isAnnotated(source)) && isCF(target)) geometric.push('fastened')
+  if (isCF(source) && isCF(target)) geometric.push('fastened')
   if (isCF(source) && isCF(target)) geometric.push('aligned')
 
   const topological = ['adjacent', 'above']
@@ -2421,6 +2423,8 @@ export class AppController {
     this._uiView.showLinkTypePicker(x, y, (linkType) => {
       if (linkType === 'mounts') {
         this._confirmMountAnnotation(sourceId, targetId)
+      } else if (linkType === 'fastened') {
+        this._confirmFastenFrame(sourceId, targetId)
       } else {
         this._confirmSpatialLink(linkType)
       }
@@ -2473,6 +2477,29 @@ export class AppController {
     this._uiView.showToast(`Mounted on frame "${this._scene.getObject(targetId)?.name}"`)
     this._cancelSpatialLinkCreation()
     this._cancelMountPicking()
+    this._updateNPanel()
+  }
+
+  /**
+   * Fastens a source CoordinateFrame to a target CoordinateFrame and records the command.
+   * Called from the L-key link-type picker when the user selects 'fastened' for CF→CF.
+   * @param {string} sourceId  CoordinateFrame entity ID (slave / constrained frame)
+   * @param {string} targetId  CoordinateFrame entity ID (master / reference frame)
+   */
+  _confirmFastenFrame(sourceId, targetId) {
+    const result = this._service.fastenFrame(sourceId, targetId)
+    if (!result) {
+      this._uiView.showToast('Cannot fasten — frame pose unknown', { type: 'warn' })
+      return
+    }
+    const { link, translationBefore, rotationBefore, relativeOffset, relativeQuat } = result
+    this._commandStack.push(createFastenFrameCommand(
+      link, translationBefore, rotationBefore, relativeOffset, relativeQuat, this._service,
+      () => { this._updateNPanel() },
+      () => { this._updateNPanel() },
+    ))
+    this._uiView.showToast(`Fastened to "${this._scene.getObject(targetId)?.name}"`)
+    this._cancelSpatialLinkCreation()
     this._updateNPanel()
   }
 
@@ -3037,6 +3064,39 @@ export class AppController {
         : [{ label: 'Mount on frame ⊕', onClick: () => this._startMountPicking(id) }])
       : []
 
+    // ADR-032 §2: unfasten item for CoordinateFrame that is the source of a fastened link
+    const fastenedLink = (obj instanceof CoordinateFrame)
+      ? this._service.getLinksOf(id).find(l => l.linkType === 'fastened' && l.sourceId === id)
+      : null
+    const unfastenItems = fastenedLink
+      ? [{ label: `Unfasten ⊗ "${this._scene.getObject(fastenedLink.targetId)?.name ?? '?'}"`, onClick: () => {
+          const source = this._scene.getObject(id)
+          const transform = this._service.getFastenedTransform(fastenedLink.id)
+          if (!transform || !(source instanceof CoordinateFrame)) return
+          // "Stay in place": capture current constrained pose as the restore point
+          const translationCurrent = source.translation.clone()
+          const rotationCurrent    = source.rotation.clone()
+          this._service.unfastenFrame(fastenedLink, translationCurrent, rotationCurrent)
+          // Build command so undo re-applies the constraint and redo re-removes it
+          this._commandStack.push({
+            label: 'Unfasten frame',
+            execute: () => {
+              const src = this._scene.getObject(id)
+              const tc  = src instanceof CoordinateFrame ? src.translation.clone() : translationCurrent
+              const rc  = src instanceof CoordinateFrame ? src.rotation.clone()    : rotationCurrent
+              this._service.unfastenFrame(fastenedLink, tc, rc)
+              this._updateNPanel()
+            },
+            undo: () => {
+              this._service.refastenFrame(fastenedLink, transform.relativeOffset, transform.relativeQuat)
+              this._updateNPanel()
+            },
+          })
+          this._uiView.showToast('Unfastened')
+          this._updateNPanel()
+        }}]
+      : []
+
     // ADR-032 §9: generic Link to... for Solid / CoordinateFrame
     const linkItems = isSolidOrCF
       ? [{ label: 'Link to... 🔗', onClick: () => {
@@ -3056,6 +3116,7 @@ export class AppController {
         onClick: () => this._duplicateObject(),
       }] : []),
       ...mountItems,
+      ...unfastenItems,
       ...linkItems,
       ...(canAddFrame ? [{
         label: 'Add interface frame ⊞',

--- a/src/service/SceneService.js
+++ b/src/service/SceneService.js
@@ -99,6 +99,15 @@ export class SceneService extends EventEmitter {
      * @type {Map<string, { sourceId: string, localPositions: import('three').Vector3[] }>}
      */
     this._mountLocalPositions = new Map()
+    /**
+     * Relative transforms for fastened CoordinateFrame pairs (ADR-032 §2, 'fastened').
+     * Keyed by SpatialLink.id (fastened link).
+     * Populated by fastenFrame(); cleared by unfastenFrame() / detachSpatialLink().
+     * _updateFastenedFrames() reads this every frame and drives the source CF's
+     * world pose to match targetPose × relativeTransform.
+     * @type {Map<string, { sourceId: string, relativeOffset: import('three').Vector3, relativeQuat: import('three').Quaternion }>}
+     */
+    this._fastenedTransforms = new Map()
   }
 
   // ── BFF integration (ADR-015, Phase A) ────────────────────────────────────
@@ -659,6 +668,7 @@ export class SceneService extends EventEmitter {
     this._linkViews.clear()
     this._worldPoseCache.clear()
     this._mountLocalPositions.clear()
+    this._fastenedTransforms.clear()
     this._model = new SceneModel()
   }
 
@@ -752,6 +762,10 @@ export class SceneService extends EventEmitter {
     // Reposition mounted Annotated* entities (ADR-032 Phase H-2).
     // Must run after all CoordinateFrame poses are resolved.
     this._updateMountedAnnotations()
+
+    // Drive fastened CoordinateFrame pairs (ADR-032 §2, 'fastened').
+    // Must run after all CoordinateFrame poses are resolved.
+    this._updateFastenedFrames()
 
     // Reposition SpatialLink dashed lines between entity world centroids (ADR-030).
     this._updateSpatialLinkViews()
@@ -923,6 +937,158 @@ export class SceneService extends EventEmitter {
       v.position.clone().sub(pose.position).applyQuaternion(invQ),
     )
     this._mountLocalPositions.set(mountLink.id, { sourceId, localPositions })
+  }
+
+  // ── Geometric Host Binding — fastened constraint (ADR-032 §2, 'fastened') ──
+
+  /**
+   * Drives each fastened CoordinateFrame's world pose every animation frame.
+   * Called after all parentId-chain poses are resolved in _updateWorldPoses().
+   *
+   * For each fastened link (source CF → target CF):
+   *   sourceWorldPos  = targetPos + targetQuat.apply(relativeOffset)
+   *   sourceWorldQuat = targetQuat × relativeQuat
+   *
+   * The derived world pose is written back to source.translation and source.rotation
+   * so the existing cache / view update path remains correct.
+   *
+   * Limitation: if the source CF has CoordinateFrame children in the parentId tree,
+   * those children's poses were already computed with the pre-constraint values.
+   * Single-level fastening (no CF-of-CF chains) is the expected use case.
+   */
+  _updateFastenedFrames() {
+    for (const [linkId, { sourceId, relativeOffset, relativeQuat }] of this._fastenedTransforms) {
+      const link   = this._model.getLink(linkId)
+      const source = this._model.getObject(sourceId)
+      if (!link || !(source instanceof CoordinateFrame)) continue
+
+      const targetPose = this._worldPoseCache.get(link.targetId)
+      if (!targetPose) continue
+
+      // Compute desired world pose
+      const worldPos  = relativeOffset.clone().applyQuaternion(targetPose.quaternion).add(targetPose.position)
+      const worldQuat = targetPose.quaternion.clone().multiply(relativeQuat)
+
+      // Resolve parent centroid to back-derive translation
+      const parent = this._model.getObject(source.parentId)
+      if (!parent) continue
+      let parentWorldPos
+      if (parent instanceof CoordinateFrame) {
+        const cached = this._worldPoseCache.get(parent.id)
+        if (!cached) continue
+        parentWorldPos = cached.position
+      } else {
+        if (!parent.corners || parent.corners.length === 0) continue
+        const centroid = new Vector3()
+        for (const c of parent.corners) centroid.add(c)
+        centroid.divideScalar(parent.corners.length)
+        parentWorldPos = centroid
+      }
+
+      // Write back so subsequent code (N panel, Node editor) sees correct state
+      source.translation.copy(worldPos).sub(parentWorldPos)
+      source.rotation.copy(worldQuat)  // also updates cache entry (shared reference)
+
+      // Update cache position explicitly (quaternion already updated via shared ref)
+      const entry = this._worldPoseCache.get(sourceId)
+      if (entry) {
+        entry.position.copy(worldPos)
+      } else {
+        this._worldPoseCache.set(sourceId, { position: worldPos.clone(), quaternion: source.rotation })
+      }
+
+      // Update view
+      source.meshView.updatePosition(worldPos)
+      source.meshView.updateConnectionLine(parentWorldPos)
+    }
+  }
+
+  /**
+   * Rigidly fastens a source CoordinateFrame to a target CoordinateFrame.
+   *
+   * Computes the relative transform (source in target's local frame) once and
+   * stores it in _fastenedTransforms.  _updateFastenedFrames() then drives the
+   * source CF's world pose every animation frame.
+   *
+   * Returns the created link and the pre-bind state needed by the undo command.
+   *
+   * @param {string} sourceCFId  ID of the CoordinateFrame to constrain
+   * @param {string} targetCFId  ID of the CoordinateFrame to bind to
+   * @returns {{ link: SpatialLink, translationBefore: import('three').Vector3, rotationBefore: import('three').Quaternion, relativeOffset: import('three').Vector3, relativeQuat: import('three').Quaternion } | null}
+   */
+  fastenFrame(sourceCFId, targetCFId) {
+    const source = this._model.getObject(sourceCFId)
+    const target = this._model.getObject(targetCFId)
+    if (!(source instanceof CoordinateFrame) || !(target instanceof CoordinateFrame)) return null
+
+    const sourcePose = this._worldPoseCache.get(sourceCFId)
+    const targetPose = this._worldPoseCache.get(targetCFId)
+    if (!sourcePose || !targetPose) return null
+
+    // Snapshot pre-bind state for undo
+    const translationBefore = source.translation.clone()
+    const rotationBefore    = source.rotation.clone()
+
+    // Relative transform: source expressed in target's local frame
+    const invTargetQuat  = targetPose.quaternion.clone().conjugate()
+    const relativeOffset = sourcePose.position.clone().sub(targetPose.position).applyQuaternion(invTargetQuat)
+    const relativeQuat   = invTargetQuat.clone().multiply(sourcePose.quaternion)
+
+    const link = this.createSpatialLink(sourceCFId, targetCFId, 'fastened')
+    this._fastenedTransforms.set(link.id, { sourceId: sourceCFId, relativeOffset, relativeQuat })
+
+    return { link, translationBefore, rotationBefore, relativeOffset, relativeQuat }
+  }
+
+  /**
+   * Removes a fastened constraint and restores the source CF to the given pre-bind pose.
+   *
+   * For undo: pass the translationBefore / rotationBefore captured at bind time.
+   * For forward unfasten ("stay in place"): pass the current translation / rotation.
+   *
+   * @param {SpatialLink}                link               The fastened SpatialLink to remove
+   * @param {import('three').Vector3}    translationBefore  Translation to restore
+   * @param {import('three').Quaternion} rotationBefore     Rotation to restore
+   */
+  unfastenFrame(link, translationBefore, rotationBefore) {
+    this._fastenedTransforms.delete(link.id)
+    this.detachSpatialLink(link.id)
+    const source = this._model.getObject(link.sourceId)
+    if (source instanceof CoordinateFrame) {
+      source.translation.copy(translationBefore)
+      source.rotation.copy(rotationBefore)
+      this._worldPoseCache.delete(link.sourceId)  // force recompute on next frame
+    }
+  }
+
+  /**
+   * Re-applies a fastened constraint (redo path).
+   * Uses the previously computed relativeOffset / relativeQuat rather than
+   * recomputing from current world poses (which may have changed during undo).
+   *
+   * @param {SpatialLink}                link           The fastened SpatialLink to restore
+   * @param {import('three').Vector3}    relativeOffset Relative offset in target's local frame
+   * @param {import('three').Quaternion} relativeQuat   Relative rotation in target's local frame
+   */
+  refastenFrame(link, relativeOffset, relativeQuat) {
+    this.reattachSpatialLink(link)
+    // Override the recomputed transform with the original one from bind time
+    this._fastenedTransforms.set(link.id, {
+      sourceId: link.sourceId,
+      relativeOffset: relativeOffset.clone(),
+      relativeQuat:   relativeQuat.clone(),
+    })
+  }
+
+  /**
+   * Returns the stored relative transform for a fastened link, or null if unknown.
+   * Used by the unfasten UI to reconstruct the undo command.
+   * @param {string} linkId
+   * @returns {{ relativeOffset: import('three').Vector3, relativeQuat: import('three').Quaternion } | null}
+   */
+  getFastenedTransform(linkId) {
+    const entry = this._fastenedTransforms.get(linkId)
+    return entry ? { relativeOffset: entry.relativeOffset, relativeQuat: entry.relativeQuat } : null
   }
 
   // ── SpatialLink view helpers (ADR-030 Phase 3) ───────────────────────────
@@ -1338,8 +1504,9 @@ export class SceneService extends EventEmitter {
    */
   detachSpatialLink(id) {
     if (!this._model.getLink(id)) return
-    // Clean up mount local positions before removing the link record
+    // Clean up mount / fasten data before removing the link record
     this._mountLocalPositions.delete(id)
+    this._fastenedTransforms.delete(id)
     this._model.removeLink(id)
     this._linkViews.get(id)?.dispose(this._threeScene)
     this._linkViews.delete(id)
@@ -1368,6 +1535,18 @@ export class SceneService extends EventEmitter {
           v.position.clone().sub(pose.position).applyQuaternion(invQ),
         )
         this._mountLocalPositions.set(link.id, { sourceId: link.sourceId, localPositions })
+      }
+    }
+    // For fastened links, recompute the relative transform from current world poses
+    // (used when restoring a scene from file — ADR-032 §2).
+    if (link.linkType === 'fastened') {
+      const sourcePose = this._worldPoseCache.get(link.sourceId)
+      const targetPose = this._worldPoseCache.get(link.targetId)
+      if (sourcePose && targetPose) {
+        const invTargetQuat = targetPose.quaternion.clone().conjugate()
+        const relativeOffset = sourcePose.position.clone().sub(targetPose.position).applyQuaternion(invTargetQuat)
+        const relativeQuat   = invTargetQuat.clone().multiply(sourcePose.quaternion)
+        this._fastenedTransforms.set(link.id, { sourceId: link.sourceId, relativeOffset, relativeQuat })
       }
     }
     this.emit('spatialLinkAdded', link)


### PR DESCRIPTION
- SceneService: add _fastenedTransforms map, fastenFrame() / unfastenFrame() /
  refastenFrame() / getFastenedTransform() methods, and _updateFastenedFrames()
  called each animation frame after parentId-chain pose resolution
- FastenFrameCommand: post-hoc push command (execute=refasten, undo=unfasten)
- AppController: add 'fastened' to CF→CF valid link types, route linkType picker
  to _confirmFastenFrame(), add "Unfasten ⊗" to long-press context menu for
  fastened CoordinateFrames
- ROADMAP: add Phase H-7 completed entry

https://claude.ai/code/session_01QHqNgkQhyPkkexrSyRkA3V