### PR TITLE
fix: show all CFs during link creation and improve CF tap selection

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -2394,6 +2394,10 @@ export class AppController {
     this._spatialLinkMode.active   = true
     this._spatialLinkMode.sourceId = this._scene.activeId
     this._spatialLinkMode.pendingTargetId = null
+    // Show all CFs so the target frame is visible for picking regardless of selection state
+    for (const obj of this._scene.objects.values()) {
+      if (obj instanceof CoordinateFrame && obj.meshView) obj.meshView.showFull()
+    }
     this._uiView.setStatus('Click target entity  [Esc: cancel]')
     this._uiView.setCursor('crosshair')
   }
@@ -2403,8 +2407,22 @@ export class AppController {
     this._spatialLinkMode.active   = false
     this._spatialLinkMode.sourceId = null
     this._spatialLinkMode.pendingTargetId = null
+    this._restoreCoordinateFrameVisibility()
     this._uiView.setCursor('default')
     this._refreshObjectModeStatus()
+  }
+
+  /** Restores CF visibility after link-creation mode: show only CFs whose parent (or self) is the active object. */
+  _restoreCoordinateFrameVisibility() {
+    const activeId = this._activeObj?.id
+    for (const obj of this._scene.objects.values()) {
+      if (!(obj instanceof CoordinateFrame) || !obj.meshView) continue
+      if (obj.id === activeId || obj.parentId === activeId) {
+        obj.meshView.showFull()
+      } else {
+        obj.meshView.hide()
+      }
+    }
   }
 
   /**
@@ -2845,6 +2863,8 @@ export class AppController {
    */
   _hitAnyCoordinateFrame() {
     this._raycaster.setFromCamera(this._mouse, this._camera)
+    const ray = this._raycaster.ray
+    const pt  = new THREE.Vector3()
     let nearestDist = Infinity
     let nearestObj  = null
 
@@ -2852,10 +2872,23 @@ export class AppController {
       if (!(obj instanceof CoordinateFrame)) continue
       if (!obj.meshView?.group?.visible) continue
 
+      // Geometry hit (axes + origin sphere)
       const hits = this._raycaster.intersectObject(obj.meshView.group, true)
       if (hits.length > 0 && hits[0].distance < nearestDist) {
         nearestDist = hits[0].distance
         nearestObj  = obj
+        continue
+      }
+
+      // Bounding box fallback — enlarges effective tap area on mobile
+      const wp = this._service.worldPoseOf(obj.id)?.position
+      if (wp) {
+        const box = new THREE.Box3(wp.clone().subScalar(0.4), wp.clone().addScalar(0.4))
+        const hitPt = ray.intersectBox(box, pt)
+        if (hitPt) {
+          const dist = ray.origin.distanceTo(hitPt)
+          if (dist < nearestDist) { nearestDist = dist; nearestObj = obj }
+        }
       }
     }
 


### PR DESCRIPTION
During spatial link creation (L-key), target CFs on non-selected Solids
were invisible, making it impossible to pick them in the viewport.
Now _startSpatialLinkCreation() shows all CFs, and _cancelSpatialLinkCreation()
restores only those parented to the active object.

Also adds bounding-box fallback (±0.4) to _hitAnyCoordinateFrame() so
CFs are easier to tap on mobile without requiring pixel-perfect aim
on the small axis geometry.

https://claude.ai/code/session_01U2G93nFxuvZmVk8VXgfG3y