### PR TITLE
fix: prioritise CF hit over parent Solid in _hitAnyEntityForLink

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,12 @@ If yes → this signals a missing or under-specified principle in `docs/PHILOSOP
 Either add a new principle or sharpen an existing one. Link it to the CODE_CONTRACTS
 rules it underlies. See PHILOSOPHY's "When to update" table for exact triggers.
 
+If **almost** (same value, but only 1 context so far) → add a row to the
+**Yellow Cards** table in `docs/PHILOSOPHY.md`. A Yellow Card is a first strike:
+it records the candidate principle and its first context so it can be found
+when the second violation surfaces. Without this, single-context patterns are
+forgotten and PHILOSOPHY never grows.
+
 ## Development commands
 
 ```bash

--- a/docs/CODE_CONTRACTS.md
+++ b/docs/CODE_CONTRACTS.md
@@ -73,6 +73,7 @@ Detail: `docs/code_contracts/architecture.md`
 | CoordinateFrame Scale Cap | `updateScale()` must always receive a finite `maxWorldSize`; use `sceneRadius × 0.3` (floor 1.0) as fallback for CFs without a solid parent — otherwise axes balloon to huge size when zooming out |
 | CoordinateFrame Tap Selection | `_hitAnyObject()` never hits a CF (cuboid = null); `_onPointerDown` must call `_hitAnyCoordinateFrame()` as a third fallback. `CoordinateFrameView.group` getter exposes the Three.js Group for `intersectObject()`. Only visible groups are tested. |
 | _promptAddFrame Must Select Frame After Creation | After pushing the command in `_promptAddFrame()`, call `_switchActiveObject(frame.id, true)` — otherwise the frame stays hidden in the 3D viewport. Undo restores parent selection; redo re-selects the frame. |
+| _hitAnyEntityForLink CF Priority | `_hitAnyEntityForLink()` must call `_hitAnyCoordinateFrame()` as Step 0 before the cuboid raycast; CFs sit on top of Solids so the cuboid step would return the Solid, causing `_computeValidLinkTypes(CF, Solid)` to omit "fastened". |
 
 ---
 

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -44,6 +44,7 @@ If a rule applies to one file or one class, it belongs in CODE_CONTRACTS, not he
 | Experience reveals a principle applies more broadly than written | Widen its scope; update examples |
 | A principle is now enforced structurally (type system, linter) | **Retire it** — structure is the source of truth, prose is redundant |
 | A principle is really a single code rule | Move it to CODE_CONTRACTS; remove from here |
+| A bug fix where Q2 is "almost but only 1 context" | Add a row to the **Yellow Cards** table (above the Index); graduate when 2nd context found |
 
 ### How to update
 
@@ -370,6 +371,27 @@ For verification, give an agent a small named file list rather than `src/**/*.js
 - This is Pass 1 → Pass 2 in the two-pass pattern (see `DEVELOPMENT.md`).
 
 *Underlies DEVELOPMENT rules: Two-pass pattern, Focused Agents > Broad Agents*
+
+---
+
+## Yellow Cards — Pending Elevation
+
+Single-context violations that do not yet meet the 2+ threshold for a named principle.
+When the same root value is violated in a second **unrelated** context, move the entry
+to the main body as a full principle and add a row to the Index.
+
+### How to update
+
+| Action | When |
+|--------|------|
+| Add a row | After a bug fix where the CODE_CONTRACTS Q2 answer is "almost, but only 1 context so far" |
+| Add a second context | When the same root value appears in a new unrelated file/feature |
+| Graduate to principle | Once 2+ contexts exist — extract a full principle above, remove the row here |
+| Remove stale row | If the codebase is refactored such that the violation can no longer occur |
+
+| Candidate Principle | First Context (date · file · what happened) | CODE_CONTRACTS Rule |
+|---------------------|---------------------------------------------|---------------------|
+| **Children Before Parents in Hit-Testing** — In a parent-child scene hierarchy, hit-test the child (more specific/inner entity) before the parent (container). The parent's geometry physically covers the child, so arrival order in the raycast pipeline determines what the user can select, not visual prominence. | 2026-04-29 · `AppController._hitAnyEntityForLink` · CF sat on top of Solid; cuboid raycast returned the Solid, making `_computeValidLinkTypes(CF→Solid)` omit "fastened" | `_hitAnyEntityForLink CF Priority` |
 
 ---
 

--- a/docs/code_contracts/architecture.md
+++ b/docs/code_contracts/architecture.md
@@ -388,3 +388,8 @@ this._commandStack.push(createCreateCoordinateFrameCommand(frame, this._service,
 ))
 this._switchActiveObject(frame.id, true)  // ← make frame visible + attach TC
 ```
+
+## _hitAnyEntityForLink Must Prioritise CoordinateFrame Over Parent Solid
+
+- **Principle**: CFs are visually rendered on top of (and often at the origin of) their parent Solid. A cuboid raycast (step 1) reaches the Solid first, making it impossible for the user to select a CF as a link target by tapping.
+- **Concrete Rule**: `_hitAnyEntityForLink()` must call `_hitAnyCoordinateFrame()` as **Step 0** before the cuboid raycast. If a CF is found and it is not the link source, return it immediately. Only fall through to the cuboid and bounding-box steps when no CF is hit. `_startSpatialLinkCreation()` already calls `showFull()` on all CFs, so they are always visible during linking.

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -2576,6 +2576,13 @@ export class AppController {
    * @returns {{ obj: object }|null}
    */
   _hitAnyEntityForLink() {
+    // Step 0: prioritise CoordinateFrame hits — CFs are rendered on top of Solids,
+    // so the cuboid raycast (step 1) would return the parent Solid instead of the CF.
+    const cfHit = this._hitAnyCoordinateFrame()
+    if (cfHit && cfHit.obj.id !== this._spatialLinkMode.sourceId) {
+      return cfHit
+    }
+
     // Step 1: cuboid-based raycast (same as _hitAnyObject but excludes source)
     const cuboidHit = this._hitAnyObject()
     if (cuboidHit && cuboidHit.obj.id !== this._spatialLinkMode.sourceId) {


### PR DESCRIPTION
When the user taps a CF to link-to during spatial link creation,
_hitAnyObject (cuboid raycast) returns the parent Solid instead
of the CF — causing _computeValidLinkTypes(CF→Solid) to omit
"fastened". Fix by calling _hitAnyCoordinateFrame() as Step 0
before the cuboid step. Adds CODE_CONTRACTS rule.

https://claude.ai/code/session_01DSYY1cZqRBswitB1Rso8Gp