### PR TITLE
fix(mobile): allow CF long-press context menu + guard fastenFrame type mismatch

### DIFF
--- a/docs/CODE_CONTRACTS.md
+++ b/docs/CODE_CONTRACTS.md
@@ -101,6 +101,8 @@ Detail: `docs/code_contracts/ui_layout.md`
 | Mobile Toolbar Stability | Fixed slot counts per mode; use `disabled` + `{spacer: true}` to prevent layout shifts |
 | Mobile Touch Gesture Model | Touch: tap=select, one-finger-drag=orbit, long-press=context menu; no rect selection or _objDragging |
 | Long-Press Context Menu | `showContextMenu()` with Grab/Dup/Rename/Delete; items filtered by entity type |
+| Long-Press for Non-Draggable Entities | CF/MeasureLine/Annotated* early-return must set long-press timer for touch BEFORE returning; without this CF "Link to..." is unreachable on mobile |
+| _confirmFastenFrame Type Guard | Check `instanceof CoordinateFrame` for both IDs and call `_service._updateWorldPoses()` before `fastenFrame()`; type mismatch must show "Select a coordinate frame as source and target" not "frame pose unknown" |
 | Measure Point Placement | Confirm in `_onPointerUp`; hold shows live snap feedback before release |
 | Stack Mode | Ray origin must be Z=10000; runs in both `_grab.active` and `_objDragging` paths |
 | Viewport-Aware Z-Index | Toast `bottom: 96px` on mobile (above 86px toolbar); status in `_infoEl` on mobile |

--- a/docs/code_contracts/interaction.md
+++ b/docs/code_contracts/interaction.md
@@ -58,6 +58,29 @@ if (this._grab.active) {
   - `_grab.segmentStartCorners` — snapshot taken in `_startGrab()` (initially = `allStartCorners`) **and re-taken on every touch re-down** during grab. Used by `_applyGrabDeltaToAll()` so the drag delta is measured from the current position, not the original. Updating only `segmentStartCorners` (not `allStartCorners`) ensures cancel/undo always revert to the pre-grab origin.
   - `_applyGrabDeltaToAll(delta)` must iterate `segmentStartCorners`, not `allStartCorners`.
 
+## Long-Press Context Menu for Non-Draggable Entities (Mobile)
+
+- **Principle**: Entity types that block pointer drag (CoordinateFrame, MeasureLine, Annotated*) must still receive the long-press context menu on touch so mobile users can access "Link to..." and other context actions.
+- **Concrete Rule**: In `_onPointerDown`, the early-return guard that blocks drag for non-draggable entity types must set up the long-press timer for touch events **before** returning. Without this, CoordinateFrames are never accessible from the long-press context menu on mobile — the user is forced to long-press the parent Solid, which sets `sourceId` to the Solid's ID instead of the CF's ID, causing `fastenFrame()` to fail with a type-mismatch that shows as "frame pose unknown".
+
+```js
+if (obj instanceof MeasureLine || obj instanceof CoordinateFrame || ...) {
+  // Set up long-press BEFORE returning so touch context menu still works
+  if (e.pointerType === 'touch' && this._objSelected && this._selectedIds.has(obj.id)) {
+    this._longPress.pointerId = e.pointerId
+    this._longPress.startX    = e.clientX
+    this._longPress.startY    = e.clientY
+    this._longPress.timer = setTimeout(() => { ... }, 400)
+  }
+  return  // still no drag
+}
+```
+
+## _confirmFastenFrame Type Guard
+
+- **Principle**: Before delegating to `fastenFrame()`, verify that both source and target are CoordinateFrames. `fastenFrame()` returning null is overloaded — it covers both type mismatch and missing world pose; the caller must distinguish these cases to show a meaningful error.
+- **Concrete Rule**: `_confirmFastenFrame()` must check `instanceof CoordinateFrame` for both IDs and show "Select a coordinate frame as source and target" before calling `fastenFrame()`. It must also call `this._service._updateWorldPoses()` immediately before `fastenFrame()` to refresh the cache (the same pattern used in `_switchActiveObject`).
+
 ## Global Event vs. UI Event Delegation
 
 - **Principle**: Global `window` listeners must explicitly ignore pointer events originating from UI overlays to avoid intercepting and canceling clicks meant for buttons.

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -2505,6 +2505,14 @@ export class AppController {
    * @param {string} targetId  CoordinateFrame entity ID (master / reference frame)
    */
   _confirmFastenFrame(sourceId, targetId) {
+    const source = this._scene.getObject(sourceId)
+    const target = this._scene.getObject(targetId)
+    if (!(source instanceof CoordinateFrame) || !(target instanceof CoordinateFrame)) {
+      this._uiView.showToast('Select a coordinate frame as source and target', { type: 'warn' })
+      return
+    }
+    // Force-update world poses so cache is fresh even if called between animation ticks
+    this._service._updateWorldPoses()
     const result = this._service.fastenFrame(sourceId, targetId)
     if (!result) {
       this._uiView.showToast('Cannot fasten — frame pose unknown', { type: 'warn' })
@@ -5653,8 +5661,26 @@ export class AppController {
 
         // MeasureLine, CoordinateFrame, and annotation entities cannot be pointer-dragged
         // (use G key to move them after selecting).
+        // On touch, still set up the long-press timer so the context menu (including
+        // "Link to...") can be triggered for these entity types on mobile.
         if (obj instanceof MeasureLine || obj instanceof CoordinateFrame ||
             obj instanceof AnnotatedLine || obj instanceof AnnotatedRegion || obj instanceof AnnotatedPoint) {
+          if (e.pointerType === 'touch' && this._objSelected && this._selectedIds.has(obj.id)) {
+            this._longPress.pointerId = e.pointerId
+            this._longPress.startX    = e.clientX
+            this._longPress.startY    = e.clientY
+            this._longPress.timer = setTimeout(() => {
+              this._longPress.timer = null
+              if (this._longPress.pointerId === e.pointerId) {
+                this._longPress.pointerId = null
+                this._showLongPressContextMenu(
+                  this._longPress.startX,
+                  this._longPress.startY,
+                  obj,
+                )
+              }
+            }, 400)
+          }
           return
         }
 


### PR DESCRIPTION
Two bugs caused "Cannot fasten — frame pose unknown" when connecting CFs on mobile:

1. The early-return guard that blocks pointer-drag for CoordinateFrame,
   MeasureLine and Annotated* also blocked the long-press timer, making
   the "Link to..." context menu unreachable for CFs on mobile.
   Users were forced to long-press the parent Solid instead, setting
   sourceId to the Solid's ID — then fastenFrame() rejected it with a
   misleading "frame pose unknown" error.

   Fix: set up the long-press timer for touch events before returning
   in the no-drag early-return block.

2. _confirmFastenFrame() did not distinguish a type mismatch (source is
   not a CoordinateFrame) from a missing world pose; both showed the
   same opaque error. Also added a proactive _updateWorldPoses() call
   (same pattern as _switchActiveObject) to ensure the cache is fresh.

   Fix: check instanceof CoordinateFrame for both IDs first, show a
   meaningful error if either is wrong, then force-refresh world poses.

Docs: CODE_CONTRACTS §2 + interaction.md updated.

https://claude.ai/code/session_01MC7SenfH4hGcxVCQxnhVNW