### PR TITLE
feat: clarify SpatialLink parent-child hierarchy in outliner, viewport, and N-panel

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -2573,17 +2573,21 @@ export class AppController {
   }
 
   /**
-   * Refreshes the outliner "linked" badge for an entity based on its current link count.
+   * Refreshes the outliner link-role badges for an entity.
+   * Passes separate source/target flags so the outliner can distinguish
+   * which role (child/dependent vs parent/reference) the entity plays.
    * @param {string} entityId
    */
   _refreshLinkBadge(entityId) {
     if (!this._outlinerView) return
-    const hasLinks = this._service.getLinksOf(entityId).length > 0
-    this._outlinerView.setObjectLinked(entityId, hasLinks)
+    const links = this._service.getLinksOf(entityId)
+    const asSource = links.some(l => l.sourceId === entityId)
+    const asTarget = links.some(l => l.targetId === entityId)
+    this._outlinerView.setObjectLinked(entityId, asSource, asTarget)
     // Also refresh the "unreferenced" badge for CoordinateFrames (ADR-033 Phase C-4)
     const obj = this._scene.getObject(entityId)
     if (obj instanceof CoordinateFrame) {
-      this._outlinerView.setFrameUnreferenced(entityId, !hasLinks)
+      this._outlinerView.setFrameUnreferenced(entityId, links.length === 0)
     }
   }
 
@@ -3120,6 +3124,7 @@ export class AppController {
       placeType:        showPlaceType ? (obj.placeType ?? null) : undefined,
       placeTypeGeometry,
       spatialLinks:        spatialLinks.length > 0 ? spatialLinks : null,
+      currentEntityId:     obj.id,
       onDeleteSpatialLink,
       getEntityName:       (id) => this._scene.getObject(id)?.name ?? id,
       frames,

--- a/src/view/OutlinerView.js
+++ b/src/view/OutlinerView.js
@@ -99,7 +99,8 @@ export class OutlinerView {
      *   triEl: HTMLElement,
      *   ifcBadgeEl: HTMLElement,
      *   placeTypeBadgeEl: HTMLElement,
-     *   linkedBadgeEl: HTMLElement,
+     *   sourceBadgeEl: HTMLElement,
+     *   targetBadgeEl: HTMLElement,
      *   iconEl: HTMLElement,
      *   visible: boolean,
      *   parentId: string|null,
@@ -188,7 +189,7 @@ export class OutlinerView {
    */
   addObject(id, name, type = 'cuboid', parentId = null) {
     const depth = parentId ? this._getDepth(parentId) + 1 : 0
-    const { rowEl, eyeEl, nameEl, triEl, ifcBadgeEl, placeTypeBadgeEl, linkedBadgeEl, unreferencedBadgeEl, iconEl } = this._createRow(id, name, type, depth)
+    const { rowEl, eyeEl, nameEl, triEl, ifcBadgeEl, placeTypeBadgeEl, sourceBadgeEl, targetBadgeEl, unreferencedBadgeEl, iconEl } = this._createRow(id, name, type, depth)
 
     if (parentId) {
       // Find insertion point: after the entire subtree rooted at parentId so
@@ -207,19 +208,23 @@ export class OutlinerView {
       this._listEl.appendChild(rowEl)
     }
 
-    this._items.set(id, { rowEl, eyeEl, nameEl, triEl, ifcBadgeEl, placeTypeBadgeEl, linkedBadgeEl, unreferencedBadgeEl, iconEl, visible: true, parentId, locked: false })
+    this._items.set(id, { rowEl, eyeEl, nameEl, triEl, ifcBadgeEl, placeTypeBadgeEl, sourceBadgeEl, targetBadgeEl, unreferencedBadgeEl, iconEl, visible: true, parentId, locked: false })
   }
 
   /**
-   * Shows or hides the SpatialLink participation badge on an outliner row.
+   * Updates the SpatialLink role badges on an outliner row.
+   * Shows a source badge (⟡→) when the entity is the source of a link,
+   * and a target badge (←⟡) when it is the target (parent in the hierarchy).
    * Called by AppController when spatialLinkAdded / spatialLinkRemoved fires.
    * @param {string} id
-   * @param {boolean} hasLinks
+   * @param {boolean} asSource  entity is source (dependent/child) of ≥1 link
+   * @param {boolean} asTarget  entity is target (reference/parent) of ≥1 link
    */
-  setObjectLinked(id, hasLinks) {
+  setObjectLinked(id, asSource, asTarget) {
     const item = this._items.get(id)
     if (!item) return
-    item.linkedBadgeEl.style.display = hasLinks ? 'inline-block' : 'none'
+    item.sourceBadgeEl.style.display = asSource ? 'inline-block' : 'none'
+    item.targetBadgeEl.style.display = asTarget ? 'inline-block' : 'none'
   }
 
   /**
@@ -670,14 +675,28 @@ export class OutlinerView {
       cursor:         'default',
     })
 
-    // SpatialLink badge — small chain icon, hidden until entity participates in ≥ 1 link
-    const linkedBadgeEl = document.createElement('span')
-    linkedBadgeEl.textContent = '⟡'
-    linkedBadgeEl.title = 'Has spatial links'
-    Object.assign(linkedBadgeEl.style, {
+    // SpatialLink source badge — shown when entity is the source (dependent/child) of ≥1 link.
+    // Arrow points away: "this entity links TO others".
+    const sourceBadgeEl = document.createElement('span')
+    sourceBadgeEl.textContent = '⟡→'
+    sourceBadgeEl.title = 'Sends spatial links to other entities (source / child role)'
+    Object.assign(sourceBadgeEl.style, {
       display:    'none',
       fontSize:   '10px',
-      color:      '#a78bfa',  // soft violet, matches 'contains' link color
+      color:      '#F59E0B',  // amber — matches 'references' link color
+      flexShrink: '0',
+      cursor:     'default',
+    })
+
+    // SpatialLink target badge — shown when entity is the target (reference/parent) of ≥1 link.
+    // Arrow points in: "other entities link TO this".
+    const targetBadgeEl = document.createElement('span')
+    targetBadgeEl.textContent = '←⟡'
+    targetBadgeEl.title = 'Other entities spatially link to this (target / parent role)'
+    Object.assign(targetBadgeEl.style, {
+      display:    'none',
+      fontSize:   '10px',
+      color:      '#14B8A6',  // teal — matches 'aligned' link color
       flexShrink: '0',
       cursor:     'default',
     })
@@ -700,7 +719,8 @@ export class OutlinerView {
     rowEl.appendChild(nameEl)
     rowEl.appendChild(ifcBadgeEl)
     rowEl.appendChild(placeTypeBadgeEl)
-    rowEl.appendChild(linkedBadgeEl)
+    rowEl.appendChild(sourceBadgeEl)
+    rowEl.appendChild(targetBadgeEl)
     rowEl.appendChild(unreferencedBadgeEl)
     rowEl.appendChild(eyeEl)
     rowEl.appendChild(delEl)
@@ -797,6 +817,6 @@ export class OutlinerView {
       if (this._onReparentCb) this._onReparentCb(dragged, id)
     })
 
-    return { rowEl, eyeEl, nameEl, triEl, ifcBadgeEl, placeTypeBadgeEl, linkedBadgeEl, unreferencedBadgeEl, iconEl }
+    return { rowEl, eyeEl, nameEl, triEl, ifcBadgeEl, placeTypeBadgeEl, sourceBadgeEl, targetBadgeEl, unreferencedBadgeEl, iconEl }
   }
 }

--- a/src/view/SpatialLinkView.js
+++ b/src/view/SpatialLinkView.js
@@ -4,13 +4,21 @@
  *
  * Renders:
  *  - A dashed Three.js Line between the world centroids of source and target entities
- *  - A directional arrowhead (cone) for directed link types (references, contains)
+ *  - A directional arrowhead (cone) for all directed link types
  *
- * Color-coded by linkType (ADR-030 §7):
- *  - references → amber  #F59E0B
- *  - connects   → cyan   #06B6D4
- *  - contains   → violet #8B5CF6
- *  - adjacent   → slate  #64748B
+ * Color-coded by linkType (ADR-030 §7, extended for full vocabulary):
+ *  Category A — Geometric (directed, source in target's frame):
+ *   mounts    → green   #22C55E
+ *   fastened  → emerald #10B981
+ *   aligned   → teal    #14B8A6
+ *  Category B — Topological:
+ *   contains  → violet  #8B5CF6  (directed)
+ *   above     → indigo  #6366F1  (directed)
+ *   adjacent  → slate   #64748B  (undirected)
+ *   connects  → cyan    #06B6D4  (undirected)
+ *  Category C — Semantic (directed, source depends on target):
+ *   references → amber  #F59E0B
+ *   represents → rose   #F43F5E
  *
  * No-op interface: every MeshView method called through polymorphic references
  * in AppController is implemented as a no-op (PHILOSOPHY #17).
@@ -22,16 +30,27 @@
  */
 import * as THREE from 'three'
 
-/** Color hex values by linkType. */
+/** Color hex values by linkType (covers the full ADR-032 vocabulary). */
 export const LINK_TYPE_COLORS = {
-  references: 0xF59E0B,  // amber
-  connects:   0x06B6D4,  // cyan
+  // Category A — Geometric
+  mounts:     0x22C55E,  // green
+  fastened:   0x10B981,  // emerald
+  aligned:    0x14B8A6,  // teal
+  // Category B — Topological
   contains:   0x8B5CF6,  // violet
+  above:      0x6366F1,  // indigo
   adjacent:   0x64748B,  // slate
+  connects:   0x06B6D4,  // cyan
+  // Category C — Semantic
+  references: 0xF59E0B,  // amber
+  represents: 0xF43F5E,  // rose
 }
 
-/** Link types that have a directional arrowhead. */
-const DIRECTED = new Set(['references', 'contains'])
+/**
+ * Link types that carry a directional arrowhead (source → target).
+ * Undirected types (connects, adjacent) have no arrow.
+ */
+const DIRECTED = new Set(['mounts', 'fastened', 'aligned', 'contains', 'above', 'references', 'represents'])
 
 export class SpatialLinkView {
   /**

--- a/src/view/UIView.js
+++ b/src/view/UIView.js
@@ -1851,6 +1851,7 @@ export class UIView {
       ifcClass = undefined, showIfcClass = false,
       placeType = undefined, showPlaceType = false, placeTypeGeometry = null,
       spatialLinks = null,          // SpatialLink[] | null
+      currentEntityId = null,       // string | null — id of the entity being shown (for role context)
       onDeleteSpatialLink = null,   // (linkId: string) => void
       getEntityName = (id) => id,   // (id: string) => string
       frames = null,                // CoordinateFrame[] | null — child frames of this entity
@@ -2027,7 +2028,7 @@ export class UIView {
     // ── Spatial Links section (for any entity that participates in links) ──
     let spatialLinksSection = null
     if (spatialLinks && spatialLinks.length > 0) {
-      spatialLinksSection = this._buildSpatialLinksSection(spatialLinks, onDeleteSpatialLink, getEntityName)
+      spatialLinksSection = this._buildSpatialLinksSection(spatialLinks, onDeleteSpatialLink, getEntityName, currentEntityId)
     }
 
     // ── Frames section (child CoordinateFrames) ───────────────────────────
@@ -2744,10 +2745,15 @@ export class UIView {
     if (!this._nPanelVisible) return
 
     const LINK_COLORS = {
-      references: '#F59E0B',
-      connects:   '#06B6D4',
+      mounts:     '#22C55E',
+      fastened:   '#10B981',
+      aligned:    '#14B8A6',
       contains:   '#8B5CF6',
+      above:      '#6366F1',
       adjacent:   '#64748B',
+      connects:   '#06B6D4',
+      references: '#F59E0B',
+      represents: '#F43F5E',
     }
     const color = LINK_COLORS[link.linkType] ?? '#888'
 
@@ -2813,19 +2819,31 @@ export class UIView {
 
   /**
    * Builds the Spatial Links section for the N-panel.
-   * Lists all links this entity participates in, with a delete button per link.
+   * Groups links by the current entity's role: source (child) vs target (parent).
+   * When currentEntityId is provided, each link row shows only the *other* end
+   * with a directional indicator (⟡→ outgoing / ←⟡ incoming) so the user can
+   * immediately tell which entity is the parent in the relationship.
    * @param {import('../domain/SpatialLink.js').SpatialLink[]} links
    * @param {((linkId: string) => void)|null} onDelete
    * @param {(id: string) => string} getEntityName
+   * @param {string|null} currentEntityId
    * @returns {HTMLElement}
    * @private
    */
-  _buildSpatialLinksSection(links, onDelete, getEntityName) {
+  _buildSpatialLinksSection(links, onDelete, getEntityName, currentEntityId = null) {
     const LINK_COLORS = {
-      references: '#F59E0B',
-      connects:   '#06B6D4',
+      // Category A — Geometric
+      mounts:     '#22C55E',
+      fastened:   '#10B981',
+      aligned:    '#14B8A6',
+      // Category B — Topological
       contains:   '#8B5CF6',
+      above:      '#6366F1',
       adjacent:   '#64748B',
+      connects:   '#06B6D4',
+      // Category C — Semantic
+      references: '#F59E0B',
+      represents: '#F43F5E',
     }
 
     const sec = document.createElement('div')
@@ -2840,13 +2858,33 @@ export class UIView {
     })
     sec.appendChild(titleEl)
 
-    for (const link of links) {
+    // Partition links by role when currentEntityId is known
+    const outgoing = currentEntityId ? links.filter(l => l.sourceId === currentEntityId) : []
+    const incoming = currentEntityId ? links.filter(l => l.targetId === currentEntityId) : []
+    const unknown  = currentEntityId ? [] : links  // fallback: no role context
+
+    const makeSubHeader = (label, color) => {
+      const el = document.createElement('div')
+      el.textContent = label
+      Object.assign(el.style, {
+        fontSize: '10px', color, fontWeight: 'bold',
+        marginTop: '4px', marginBottom: '2px', fontFamily: 'sans-serif',
+      })
+      return el
+    }
+
+    const makeLinkRow = (link, directionGlyph, otherEntityId) => {
       const color = LINK_COLORS[link.linkType] ?? '#888'
       const rowEl = document.createElement('div')
       Object.assign(rowEl.style, {
-        display: 'flex', alignItems: 'center', gap: '6px',
+        display: 'flex', alignItems: 'center', gap: '5px',
         padding: '3px 0', fontFamily: 'sans-serif',
       })
+
+      const dirEl = document.createElement('span')
+      dirEl.textContent = directionGlyph
+      Object.assign(dirEl.style, { flexShrink: '0', fontSize: '11px', color: '#888' })
+      rowEl.appendChild(dirEl)
 
       const badge = document.createElement('span')
       badge.textContent = link.linkType
@@ -2860,13 +2898,13 @@ export class UIView {
       })
       rowEl.appendChild(badge)
 
-      const namesEl = document.createElement('span')
-      namesEl.textContent = `${getEntityName(link.sourceId)} → ${getEntityName(link.targetId)}`
-      Object.assign(namesEl.style, {
+      const nameEl = document.createElement('span')
+      nameEl.textContent = getEntityName(otherEntityId)
+      Object.assign(nameEl.style, {
         flex: '1', fontSize: '11px', color: '#ccc',
         overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
       })
-      rowEl.appendChild(namesEl)
+      rowEl.appendChild(nameEl)
 
       if (onDelete) {
         const delBtn = document.createElement('button')
@@ -2885,7 +2923,63 @@ export class UIView {
         rowEl.appendChild(delBtn)
       }
 
-      sec.appendChild(rowEl)
+      return rowEl
+    }
+
+    if (currentEntityId) {
+      // Outgoing links: this entity → target (child/dependent role)
+      if (outgoing.length > 0) {
+        sec.appendChild(makeSubHeader('⟡→ Links to (source role)', '#F59E0B'))
+        for (const link of outgoing) {
+          sec.appendChild(makeLinkRow(link, '→', link.targetId))
+        }
+      }
+      // Incoming links: source → this entity (parent/reference role)
+      if (incoming.length > 0) {
+        sec.appendChild(makeSubHeader('←⟡ Linked by (target role)', '#14B8A6'))
+        for (const link of incoming) {
+          sec.appendChild(makeLinkRow(link, '←', link.sourceId))
+        }
+      }
+    } else {
+      // Fallback: no entity context — show full source → target display
+      for (const link of unknown) {
+        const color = LINK_COLORS[link.linkType] ?? '#888'
+        const rowEl = document.createElement('div')
+        Object.assign(rowEl.style, {
+          display: 'flex', alignItems: 'center', gap: '6px',
+          padding: '3px 0', fontFamily: 'sans-serif',
+        })
+        const badge = document.createElement('span')
+        badge.textContent = link.linkType
+        Object.assign(badge.style, {
+          flexShrink: '0', background: color + '22',
+          border: `1px solid ${color}`, borderRadius: '3px',
+          padding: '1px 5px', color, fontSize: '10px', fontWeight: 'bold',
+        })
+        rowEl.appendChild(badge)
+        const namesEl = document.createElement('span')
+        namesEl.textContent = `${getEntityName(link.sourceId)} → ${getEntityName(link.targetId)}`
+        Object.assign(namesEl.style, {
+          flex: '1', fontSize: '11px', color: '#ccc',
+          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+        })
+        rowEl.appendChild(namesEl)
+        if (onDelete) {
+          const delBtn = document.createElement('button')
+          delBtn.textContent = '×'
+          delBtn.title = 'Delete this link'
+          Object.assign(delBtn.style, {
+            flexShrink: '0', background: 'transparent',
+            border: '1px solid #555', borderRadius: '3px',
+            color: '#e74c3c', fontSize: '13px',
+            cursor: 'pointer', padding: '0 5px', lineHeight: '16px',
+          })
+          delBtn.addEventListener('click', () => onDelete(link.id))
+          rowEl.appendChild(delBtn)
+        }
+        sec.appendChild(rowEl)
+      }
     }
 
     return sec


### PR DESCRIPTION
## Outliner
Replace the single ⟡ "has links" badge with two role-specific badges:
- `⟡→` (amber) — entity is a **source** (dependent/child role): sends links to others
- `←⟡` (teal)  — entity is a **target** (reference/parent role): other entities link to it
Both badges can appear simultaneously when an entity plays both roles.
`setObjectLinked(id, hasLinks)` → `setObjectLinked(id, asSource, asTarget)`.

## 3D Viewport (SpatialLinkView)
Extend DIRECTED arrowhead set from {references, contains} to all seven directed
link types: mounts, fastened, aligned, contains, above, references, represents.
Only the truly undirected types (connects, adjacent) remain without arrows.
Add colors for all nine link types in LINK_TYPE_COLORS (was only four).

## N-panel (UIView)
Split the Spatial Links section into two labelled sub-groups:
- `⟡→ Links to (source role)` — outgoing links showing the target entity name
- `←⟡ Linked by (target role)` — incoming links showing the source entity name
Each link row now shows only the *other* end with a directional glyph, making the
current entity's role immediately readable without decoding "A → B".
Passes `currentEntityId` through `updateNPanel()` → `_buildSpatialLinksSection()`.

## AppController
`_refreshLinkBadge()` now computes asSource/asTarget flags separately and passes
them to `setObjectLinked`. Adds `currentEntityId: obj.id` to the `updateNPanel`
options so the N-panel can partition links by role.

https://claude.ai/code/session_01JSDcDSReopp1Vdb2WhXj6q