### PR TITLE
feat: Solid 任意回転 (R キー、コーナーベイク) — ADR-036

### DIFF
--- a/docs/CODE_CONTRACTS.md
+++ b/docs/CODE_CONTRACTS.md
@@ -44,7 +44,7 @@ Detail: `docs/code_contracts/architecture.md`
 |------|--------------|
 | Mode Transition Flow | `setMode()` is the single entry point; always call `setMode('object')` before `_switchActiveObject()` from edit mode |
 | State Restoration on Mode Exit | Restore `_objSelected = true` + `setObjectSelected(true)` when returning to Object mode if `_activeObj` exists |
-| Entity Capability Contracts | Use `instanceof` not `dimension`; `Sketch.extrude()` returns new Cuboid swapped via `SceneService.extrudeSketch()`; ImportedMesh/CoordinateFrame have restricted capabilities; MeasureLine supports 1D Edit Mode (endpoint drag via `_enterEditMode1D`) |
+| Entity Capability Contracts | Use `instanceof` not `dimension`; `Sketch.extrude()` returns new Cuboid swapped via `SceneService.extrudeSketch()`; ImportedMesh/CoordinateFrame have restricted capabilities; MeasureLine supports 1D Edit Mode (endpoint drag via `_enterEditMode1D`); Solid supports R-key rotation (bakes into corners, pivot = centroid, `SolidRotateCommand` for undo — ADR-036) |
 | MeasureLineView No-Op Interface | Every `_meshView` method called in AppController must exist as a no-op or real impl on MeasureLineView; `setEndpointHover(index)` and `clearEndpointHover()` are real impls used in `'1d'` edit substate |
 | Measure Snap Display | Use `_measure.snapMeshView` (not `_meshView`) for all snap display during measure placement |
 | MeasureLineView Label Lifecycle | Call `updateLabelPosition()` every animation frame for every MeasureLine in scene |

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -217,7 +217,7 @@ Prevents `_handleEditClick()` from firing erroneously on toolbar or UI panel cli
 | Key | Action |
 |-----|--------|
 | `G` | `_startGrab()` |
-| `R` | `_startRotate()` (CoordinateFrame selected only) |
+| `R` | `_startRotate()` (CoordinateFrame or Solid selected, ADR-019/ADR-036) |
 | `M` | `_startMeasurePlacement()` |
 | `Shift+A` | Show add menu |
 | `Shift+D` | Duplicate selected object |
@@ -251,7 +251,7 @@ Prevents `_handleEditClick()` from firing erroneously on toolbar or UI panel cli
 | `0`–`9` / `.` | Numeric input mode |
 | `Ctrl` (hold) | Enable snap mode |
 
-### Rotate Active (CoordinateFrame)
+### Rotate Active (CoordinateFrame / Solid)
 
 | Key | Action |
 |-----|--------|
@@ -259,6 +259,8 @@ Prevents `_handleEditClick()` from firing erroneously on toolbar or UI panel cli
 | `Y` | Rotate around Y axis |
 | `Z` | Rotate around Z axis |
 | `0`–`9` / `.` | Numeric input mode (degrees) |
+
+Pivot: CoordinateFrame = frame world origin. Solid = centroid of corners at rotation start (ADR-036).
 
 ---
 
@@ -399,7 +401,8 @@ Commands are recorded post-hoc via `push()` — never use `execute()` for pre-ex
 | `DeleteCommand` | After `_deleteObject()` confirmed | `attachObject()` + `setVisible(true)` |
 | `ExtrudeSketchCommand` | After `_confirmExtrude()` confirmed | Delete Solid, restore Profile |
 | `RenameCommand` | After `_confirmRename()` confirmed | Restore previous name |
-| `FrameRotateCommand` | After `_confirmRotate()` confirmed | Restore startQuat |
+| `FrameRotateCommand` | After `_confirmRotate()` confirmed (CoordinateFrame) | Restore startQuat |
+| `SolidRotateCommand` | After `_confirmRotate()` confirmed (Solid) | Restore startCorners |
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -463,6 +463,7 @@ Phases A, B, C implemented (2026-03-21 to 2026-03-22). See ADR-015 and ADR-017 f
 | Priority | Item | Complexity | ADR / Notes |
 |----------|------|-----------|-------------|
 | ~~🔴 High~~ | ~~MeasureLine Edit Mode · 1D — endpoint drag to reposition after placement~~ ✅ 2026-04-17 | ~~Medium~~ | ADR-005 |
+| ~~🟡 Medium~~ | ~~**Solid arbitrary rotation (R key)** — R キーで Solid を直接回転（centroid pivot、コーナーベイク、Undo 対応）~~ ✅ 2026-05-02 | ~~Low~~ | ADR-036 |
 | ~~🟡 Medium~~ | ~~Right-click context menu (currently: cancel only)~~ ✅ 2026-04-17 | ~~Low~~ | ADR-006 |
 | 🔴 High | **fastened 拘束 CF チェーン伝播 (ADR-035)** — SOURCE CF の直接の親が CoordinateFrame の場合（孫CF同士の fastened）、現在は `source.translation` のみ更新され root Solid に delta が伝わらない。修正方針: `_findAncestorChain(sourceId)` で root Solid を特定し corners に delta を適用 → CF チェーンをインライン再伝播。加えて fastened グラフのサイクルを毎フレーム DFS で検出し、サイクル検出時は `showToast` + 該当 constraint をスキップ。実装ガイドは ADR-035 § 実装ガイド 参照。 | Medium | ADR-035; CODE_CONTRACTS "Fastened Constraint Limitations" |
 | 🔴 High | **fastened 拘束の回転伝播** — `_updateFastenedFrames()` は現在 translation delta のみ親 Solid に適用し rotation を伝播しない。Target CF が回転したとき Source CF の rotation は更新されるが親 Solid のコーナーは回転しないため、Solid の向きが拘束と乖離する。修正方針: `currentEntry.quaternion` を保存 → `deltaQuat = worldQuat × currentQuat⁻¹` → 各コーナーを source CF のワールド位置まわりに `deltaQuat` で回転させてから translation delta を加算。 | Medium | ADR-032 §5; CODE_CONTRACTS "Fastened Constraint Limitations" (1) |

--- a/docs/SCREEN_DESIGN.md
+++ b/docs/SCREEN_DESIGN.md
@@ -107,7 +107,7 @@ G = Grab   M = Measure   Shift+A = Add   Ctrl+Z = Undo
 
 #### [E] Status Bar
 ```
-G = Grab   Tab = Edit   Shift+D = Duplicate   X = Delete   M = Measure
+R = Rotate   G = Grab   Tab = Edit   Shift+D = Duplicate   X = Delete   M = Measure
 ```
 
 #### [F] Mobile Toolbar

--- a/docs/adr/ADR-036-solid-arbitrary-rotation.md
+++ b/docs/adr/ADR-036-solid-arbitrary-rotation.md
@@ -1,0 +1,134 @@
+# ADR-036 — Solid Arbitrary Rotation (R key)
+
+| Field | Value |
+|-------|-------|
+| **Status** | Accepted |
+| **Date** | 2026-05-02 |
+| **References** | ADR-007, ADR-019, ADR-022, ADR-012 |
+
+---
+
+## Context
+
+### 問題
+
+Solid（3D ソリッド）を直接回転させる手段がなかった。
+CoordinateFrame は ADR-019 (Phase B) で R キー回転が実装されているが、
+Solid の `R` キーは no-op であり、ユーザーは：
+
+- CF を作成して fastened リンクを張る（未完成：ROADMAP 🔴 High「fastened 拘束の回転伝播」が未実装）
+- 8 頂点を Grab で個別に動かす（非直感的）
+
+のいずれかしか選択肢がなかった。
+
+### 設計の中心的な問い
+
+Solid の回転を「どう表現するか」：
+
+| アプローチ | 格納形式 | 長所 | 短所 |
+|-----------|---------|------|------|
+| **A — コーナーベイク** | corners: Vector3[8] に回転結果を書き込む | ADR-007 の表現を維持; Grab と同じパターン | rotation quaternion は後から取り出せない |
+| B — CF 経由 | CF rotation を Solid に伝播 | 回転状態を分解できる | fastened 伝播が未実装; CF 生成の儀式が必要 |
+
+---
+
+## Decision
+
+**アプローチ A — コーナーへの直接ベイク** を採用する。
+
+### 根拠（Philosophy との対応）
+
+- **PHILOSOPHY #2（Type Is the Capability Contract）**：Solid の回転能力は Solid の型が直接保証すべき。CF という中間エンティティへの依存は型契約の外部化であり違反。
+- **PHILOSOPHY #6（Transformations Return New Instances）**：純粋関数 `rotateCuboid(corners, pivot, quat)` が新たな配列を返す。Solid ドメインメソッド `rotate()` がそれをインプレース適用。`extrudeFace()` / `move()` と完全に対称なパターン。
+- **PHILOSOPHY #3（Separate Pure Computation from Side Effects）**：幾何演算は `CuboidModel.js` の純粋関数、副作用（View 更新・コマンド記録）はコントローラ。
+
+### データモデル
+
+Solid に `rotation: Quaternion` フィールドを追加しない。ADR-007 の `corners: Vector3[8]` 表現を維持する。回転は 8 コーナーに bake される。
+
+### 操作フロー
+
+```
+Object モード、Solid 選択中
+  R         → rotate 開始（pivot = startCorners のセントロイド）
+  マウス移動 → セントロイド周りのスクリーン平面回転
+  X/Y/Z     → ワールド軸拘束（CF 回転と同一 UX）
+  数値入力   → 角度直接指定（CF 回転と同一 UX）
+  Enter     → 確定（SolidRotateCommand を push）
+  Esc / RMB → キャンセル（startCorners を復元）
+```
+
+### ピボット
+
+コーナーの重心（`getCentroid(startCorners)`）を固定ピボットとする。
+
+操作開始時に `startCorners` を snapshot し、`_applyRotate()` では
+常に startCorners のセントロイドを pivot として使う。
+これにより、回転中に pivot が揺れない（pivot は開始時点のセントロイドで固定）。
+
+### Undo / Redo
+
+`SolidRotateCommand(solidRef, startCorners, endCorners, sceneService, onApplied)` を新設。
+`MoveCommand` と同じ「開始/終了コーナーを保存して swap」方式。
+
+```
+execute(): endCorners → obj.corners → meshView.updateGeometry()
+undo():    startCorners → obj.corners → meshView.updateGeometry()
+```
+
+---
+
+## Consequences
+
+### 正の影響
+
+- Solid を R キーで直接回転できる。CF 作成や fastened 設定が不要。
+- `move()` / `extrudeFace()` と同じパターンで実装でき、コードの一貫性が高い。
+- `SolidRotateCommand` はシンプルな corners-swap で undo/redo が完結する。
+
+### 制約・既知の限界
+
+- 回転は corners に bake されるため、後から「何度回転した」という状態は取り出せない。
+- Solid の rotation quaternion が必要になる将来のユースケース（アニメーション、制約ソルバー等）では、Solid のデータモデル自体を再設計する必要がある。その際は別の ADR を作成すること。
+- CoordinateFrame の場合と異なり、Solid 回転に対してはプロベナンスチェック（ADR-034）は不要（Solid に `declaredBy` はない）。
+
+### 変更しないこと
+
+| 項目 | 理由 |
+|------|------|
+| `_rotate` 状態の基本構造 | CF 回転の UX と同一のため共有する |
+| CF 回転フロー | ADR-019 で確立済み；変更なし |
+| fastened 拘束の回転伝播 | 独立した ROADMAP 課題のまま |
+| モバイル TC の rotate モード | Solid には TC rotate を追加しない（スコープ外） |
+
+---
+
+## 実装ガイド
+
+```
+変更ファイル:
+  src/model/CuboidModel.js
+    - rotateCuboid(corners, pivot, quat): Vector3[]  を追加
+
+  src/domain/Solid.js
+    - rotate(startCorners, pivot, quat): void  を追加
+      (move() / extrudeFace() と対称なドメインメソッド)
+
+  src/command/SolidRotateCommand.js  (新規)
+    - createSolidRotateCommand(solidRef, startCorners, endCorners, sceneService, onApplied)
+
+  src/controller/AppController.js
+    - _rotate.startCorners: Vector3[] | null  を追加
+    - _startRotate():  instanceof Solid 分岐を追加
+    - _applyRotate():  instanceof Solid 分岐を追加
+    - _confirmRotate(): SolidRotateCommand を push
+    - _cancelRotate(): Solid コーナー復元
+    - _setRotateAxis(): Solid pivot 再投影
+    - R key 条件を Solid にも拡張
+
+更新するドキュメント:
+  docs/adr/README.md  (インデックス行追加)
+  docs/EVENTS.md      (keyboard 表: R キー Solid 行追加)
+  docs/SCREEN_DESIGN.md (ステータスバー行)
+  docs/CODE_CONTRACTS.md (Entity Capability Contracts 更新)
+```

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -47,6 +47,7 @@ This directory records the project's design decisions.
 | [ADR-033](ADR-033-coordinate-frame-phase-c.md) | **CoordinateFrame Phase C — Interface Contract Model** | Accepted | 2026-04-15 | ADR-018, ADR-019, ADR-032, ADR-030 |
 | [ADR-034](ADR-034-coordinate-frame-placement-policy.md) | **CoordinateFrame Placement and Pose Policy** | Accepted | 2026-04-20 | ADR-033, ADR-032, ADR-030, ADR-018, ADR-019 |
 | [ADR-035](ADR-035-fastened-chain-propagation.md) | **Fastened Constraint CF-Chain Propagation and Cycle Detection** | Accepted | 2026-05-02 | ADR-032, ADR-033, ADR-030, ADR-018, ADR-019 |
+| [ADR-036](ADR-036-solid-arbitrary-rotation.md) | **Solid Arbitrary Rotation — R key, Corner-Baking** | Accepted | 2026-05-02 | ADR-007, ADR-019, ADR-022, ADR-012 |
 
 ## How to Add a New ADR
 

--- a/src/command/SolidRotateCommand.js
+++ b/src/command/SolidRotateCommand.js
@@ -1,0 +1,32 @@
+import { Solid } from '../domain/Solid.js'
+
+/**
+ * SolidRotateCommand — records an R-key Solid rotation for undo/redo.
+ * (ADR-036, ADR-022)
+ *
+ * Stores start/end corners and swaps them on execute/undo, identical to the
+ * MoveCommand pattern.  The rotation itself is baked into the corner positions.
+ *
+ * @param {import('../domain/Solid.js').Solid} solidRef
+ * @param {import('three').Vector3[]} startCorners  Corner snapshot before rotation
+ * @param {import('three').Vector3[]} endCorners    Corner snapshot after rotation
+ * @param {import('../service/SceneService.js').SceneService} sceneService
+ * @param {() => void} onApplied  Called after each apply (e.g. _updateNPanel)
+ * @returns {{label: string, execute(): void, undo(): void}}
+ */
+export function createSolidRotateCommand(solidRef, startCorners, endCorners, sceneService, onApplied) {
+  function apply(corners) {
+    const obj = sceneService.scene.getObject(solidRef.id)
+    if (!(obj instanceof Solid)) return
+    obj.corners.forEach((c, i) => c.copy(corners[i]))
+    obj.meshView.updateGeometry(obj.corners)
+    obj.meshView.updateBoxHelper()
+    sceneService.syncMountedPosition(solidRef.id)
+    onApplied()
+  }
+  return {
+    label: 'Rotate Solid',
+    execute() { apply(endCorners) },
+    undo()    { apply(startCorners) },
+  }
+}

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -38,6 +38,7 @@ import { createAddSolidCommand }      from '../command/AddSolidCommand.js'
 import { createDeleteCommand }        from '../command/DeleteCommand.js'
 import { createRenameCommand }        from '../command/RenameCommand.js'
 import { createFrameRotateCommand }   from '../command/FrameRotateCommand.js'
+import { createSolidRotateCommand }   from '../command/SolidRotateCommand.js'
 import { createSetIfcClassCommand }   from '../command/SetIfcClassCommand.js'
 import { createSetPlaceTypeCommand }  from '../command/SetPlaceTypeCommand.js'  // N-panel place type change (post-hoc push)
 import { createReparentFrameCommand } from '../command/ReparentFrameCommand.js'
@@ -451,16 +452,18 @@ export class AppController {
     /** Frame rotation snapshot at TC drag start (rotate mode only). @type {THREE.Quaternion|null} */
     this._tcStartFrameRot  = null
 
-    // ── CoordinateFrame rotate state (R key, ADR-019 Phase B) ─────────────
-    // Symmetric to _grab but applies a quaternion rotation to CoordinateFrame.rotation.
+    // ── CoordinateFrame / Solid rotate state (R key, ADR-019 Phase B / ADR-036) ─
+    // Shared for both CoordinateFrame (quaternion-based) and Solid (corner-baking).
     this._rotate = {
       active:     false,
       /** World-space axis to rotate around: null = view-space Z, 'x'|'y'|'z' = world axes. */
       axis:       null,
-      /** Screen-angle (radians) from frame projected position to mouse at start. */
+      /** Screen-angle (radians) from projected pivot to mouse at start. */
       startAngle: 0,
-      /** Saved rotation quaternion at the moment rotation begins (for cancel). */
+      /** Saved rotation quaternion at the moment rotation begins (CoordinateFrame only). */
       startRot:   new THREE.Quaternion(),
+      /** Corner snapshot taken at the moment rotation begins (Solid only). @type {import('three').Vector3[]|null} */
+      startCorners: null,
       /** Numeric degree string typed by the user; empty when mouse-driven. */
       inputStr:   '',
       /** True when the user has typed at least one digit. */
@@ -4268,31 +4271,42 @@ export class AppController {
     this._updateMobileToolbar()
   }
 
-  // ── CoordinateFrame rotation (R key, ADR-019) ────────────────────────────
+  // ── CoordinateFrame / Solid rotation (R key, ADR-019 / ADR-036) ──────────
 
   /**
-   * Starts rotate mode for the active CoordinateFrame.
-   * Only valid when the active object is a CoordinateFrame and no grab is active.
+   * Starts rotate mode for the active CoordinateFrame or Solid.
+   * For CoordinateFrame: rotates the quaternion around the frame origin.
+   * For Solid: bakes the rotation into corner positions (ADR-036).
    */
   _startRotate() {
-    const frame = this._activeObj
-    if (!(frame instanceof CoordinateFrame)) return
+    const obj = this._activeObj
+    if (!(obj instanceof CoordinateFrame) && !(obj instanceof Solid)) return
     if (this._grab.active) return
-    // Provenance check (ADR-034 §8.2)
-    if (!RoleService.canEdit(frame)) {
-      this._uiView.showToast(`This frame was declared by a ${frame.declaredBy}. Switch to that role to edit it.`, { type: 'warn' })
-      return
+
+    this._rotate.active      = true
+    this._rotate.axis        = null
+    this._rotate.inputStr    = ''
+    this._rotate.hasInput    = false
+    this._rotate.startCorners = null
+
+    let projected
+    if (obj instanceof CoordinateFrame) {
+      // Provenance check (ADR-034 §8.2)
+      if (!RoleService.canEdit(obj)) {
+        this._uiView.showToast(`This frame was declared by a ${obj.declaredBy}. Switch to that role to edit it.`, { type: 'warn' })
+        this._rotate.active = false
+        return
+      }
+      this._rotate.startRot.copy(obj.rotation)
+      projected = (this._service.worldPoseOf(obj.id)?.position ?? obj.translation).clone().project(this._camera)
+    } else {
+      // Solid: snapshot corners; pivot = centroid of startCorners (ADR-036)
+      this._rotate.startCorners = obj.corners.map(c => c.clone())
+      const pivot = getCentroid(this._rotate.startCorners)
+      projected = pivot.clone().project(this._camera)
     }
 
-    this._rotate.active    = true
-    this._rotate.axis      = null
-    this._rotate.inputStr  = ''
-    this._rotate.hasInput  = false
-    this._rotate.startRot.copy(frame.rotation)
-
-    // Compute the screen-space angle from the projected frame origin to the mouse.
-    // This allows the mouse-driven angle to be relative to where it started.
-    const projected = (this._service.worldPoseOf(frame.id)?.position ?? frame.translation).clone().project(this._camera)
+    // Screen-space start angle: angle from projected pivot to current mouse.
     this._rotate.startAngle = Math.atan2(
       this._mouse.y - projected.y,
       this._mouse.x - projected.x,
@@ -4308,7 +4322,7 @@ export class AppController {
   _confirmRotate() {
     if (!this._rotate.active) return
     this._applyRotate()
-    // ── Record undo snapshot (ADR-022 Phase 4) ────────────────────────────
+    // ── Record undo snapshot (ADR-022) ────────────────────────────────────
     if (this._activeObj instanceof CoordinateFrame) {
       const frame = this._activeObj
       const endQuat = frame.rotation.clone()
@@ -4319,31 +4333,48 @@ export class AppController {
         )
         this._commandStack.push(cmd)
       }
+    } else if (this._activeObj instanceof Solid && this._rotate.startCorners) {
+      const solid = this._activeObj
+      const endCorners = solid.corners.map(c => c.clone())
+      const changed = endCorners.some((c, i) => !c.equals(this._rotate.startCorners[i]))
+      if (changed) {
+        const cmd = createSolidRotateCommand(
+          solid, this._rotate.startCorners, endCorners, this._service,
+          () => this._updateNPanel(),
+        )
+        this._commandStack.push(cmd)
+      }
     }
-    this._rotate.active   = false
-    this._rotate.axis     = null
-    this._rotate.inputStr = ''
-    this._rotate.hasInput = false
-    this._controls.enabled = true
+    this._rotate.active      = false
+    this._rotate.axis        = null
+    this._rotate.inputStr    = ''
+    this._rotate.hasInput    = false
+    this._rotate.startCorners = null
+    this._controls.enabled   = true
     this._refreshObjectModeStatus()
     this._updateNPanel()
   }
 
   /**
-   * Cancels the rotation, restoring the frame to its saved rotation.
+   * Cancels the rotation, restoring the object to its saved state.
    */
   _cancelRotate() {
     if (!this._rotate.active) return
-    const frame = this._activeObj
-    if (frame instanceof CoordinateFrame) {
-      frame.rotation.copy(this._rotate.startRot)
-      frame.meshView.updateRotation(frame.rotation)
+    const obj = this._activeObj
+    if (obj instanceof CoordinateFrame) {
+      obj.rotation.copy(this._rotate.startRot)
+      obj.meshView.updateRotation(obj.rotation)
+    } else if (obj instanceof Solid && this._rotate.startCorners) {
+      this._rotate.startCorners.forEach((c, i) => { obj.vertices[i].position.copy(c) })
+      obj.meshView.updateGeometry(obj.corners)
+      obj.meshView.updateBoxHelper()
     }
-    this._rotate.active   = false
-    this._rotate.axis     = null
-    this._rotate.inputStr = ''
-    this._rotate.hasInput = false
-    this._controls.enabled = true
+    this._rotate.active      = false
+    this._rotate.axis        = null
+    this._rotate.inputStr    = ''
+    this._rotate.hasInput    = false
+    this._rotate.startCorners = null
+    this._controls.enabled   = true
     this._refreshObjectModeStatus()
   }
 
@@ -4357,9 +4388,14 @@ export class AppController {
     this._rotate.inputStr = ''
     this._rotate.hasInput = false
     // Recompute start angle with new axis
-    const frame = this._activeObj
-    if (frame instanceof CoordinateFrame) {
-      const projected = (this._service.worldPoseOf(frame.id)?.position ?? frame.translation).clone().project(this._camera)
+    const obj = this._activeObj
+    let projected
+    if (obj instanceof CoordinateFrame) {
+      projected = (this._service.worldPoseOf(obj.id)?.position ?? obj.translation).clone().project(this._camera)
+    } else if (obj instanceof Solid && this._rotate.startCorners) {
+      projected = getCentroid(this._rotate.startCorners).clone().project(this._camera)
+    }
+    if (projected) {
       this._rotate.startAngle = Math.atan2(
         this._mouse.y - projected.y,
         this._mouse.x - projected.x,
@@ -4370,12 +4406,13 @@ export class AppController {
   }
 
   /**
-   * Applies the current rotation delta to the active CoordinateFrame.
+   * Applies the current rotation delta to the active CoordinateFrame or Solid.
    * Called on every pointer move and on numeric input changes.
    */
   _applyRotate() {
-    const frame = this._activeObj
-    if (!(frame instanceof CoordinateFrame) || !this._rotate.active) return
+    const obj = this._activeObj
+    if (!this._rotate.active) return
+    if (!(obj instanceof CoordinateFrame) && !(obj instanceof Solid)) return
 
     let angle
     if (this._rotate.hasInput) {
@@ -4383,11 +4420,15 @@ export class AppController {
       angle = isNaN(parsed) ? 0 : parsed * (Math.PI / 180)
     } else {
       // Mouse-driven: measure signed angle from start to current mouse position.
-      // Negated so that moving the mouse CCW around the frame rotates CCW (natural tracking).
-      const projected = (this._service.worldPoseOf(frame.id)?.position ?? frame.translation).clone().project(this._camera)
+      let pivotScreen
+      if (obj instanceof CoordinateFrame) {
+        pivotScreen = (this._service.worldPoseOf(obj.id)?.position ?? obj.translation).clone().project(this._camera)
+      } else {
+        pivotScreen = getCentroid(this._rotate.startCorners).clone().project(this._camera)
+      }
       const currentAngle = Math.atan2(
-        this._mouse.y - projected.y,
-        this._mouse.x - projected.x,
+        this._mouse.y - pivotScreen.y,
+        this._mouse.x - pivotScreen.x,
       )
       angle = this._rotate.startAngle - currentAngle
       // Ctrl: snap to stepSize degree increments
@@ -4409,8 +4450,17 @@ export class AppController {
     }
 
     const deltaQ = new THREE.Quaternion().setFromAxisAngle(axisVec, angle)
-    frame.rotation.copy(this._rotate.startRot).premultiply(deltaQ)
-    frame.meshView.updateRotation(frame.rotation)
+
+    if (obj instanceof CoordinateFrame) {
+      obj.rotation.copy(this._rotate.startRot).premultiply(deltaQ)
+      obj.meshView.updateRotation(obj.rotation)
+    } else {
+      // Solid: rotate all corners around the centroid of startCorners (ADR-036)
+      const pivot = getCentroid(this._rotate.startCorners)
+      obj.rotate(this._rotate.startCorners, pivot, deltaQ)
+      obj.meshView.updateGeometry(obj.corners)
+      obj.meshView.updateBoxHelper()
+    }
     this._updateRotateStatus()
   }
 
@@ -6355,8 +6405,9 @@ export class AppController {
         this._startGrab()
         return
       }
-      // R: rotate (CoordinateFrame only, ADR-019)
-      if ((e.key === 'r' || e.key === 'R') && this._activeObj instanceof CoordinateFrame) {
+      // R: rotate (CoordinateFrame or Solid, ADR-019 / ADR-036)
+      if ((e.key === 'r' || e.key === 'R') &&
+          (this._activeObj instanceof CoordinateFrame || this._activeObj instanceof Solid)) {
         this._startRotate()
         return
       }

--- a/src/domain/Solid.js
+++ b/src/domain/Solid.js
@@ -82,6 +82,19 @@ export class Solid {
   }
 
   /**
+   * Rotates all vertices around `pivot` by `quat`, starting from `startCorners`.
+   * Symmetric to move(): takes a pre-drag snapshot so the operation is reapplyable.
+   * @param {import('three').Vector3[]} startCorners  snapshot taken before rotation
+   * @param {import('three').Vector3}  pivot          world-space rotation pivot
+   * @param {import('three').Quaternion} quat         rotation to apply
+   */
+  rotate(startCorners, pivot, quat) {
+    startCorners.forEach((c, i) => {
+      this.vertices[i].position.copy(c).sub(pivot).applyQuaternion(quat).add(pivot)
+    })
+  }
+
+  /**
    * Applies a face extrusion offset in-place.
    * @param {import('../graph/Face.js').Face} face  the face to extrude
    * @param {import('three').Vector3[]} savedFaceCorners  4 corner snapshots before drag

--- a/src/model/CuboidModel.js
+++ b/src/model/CuboidModel.js
@@ -271,6 +271,18 @@ export function getFacePivotCandidates(corners) {
 }
 
 /**
+ * Pure function that rotates all 8 corners around a pivot by the given quaternion.
+ * Returns a new array of cloned Vector3 — does not mutate the input.
+ * @param {import('three').Vector3[]} corners  Current 8 corner positions
+ * @param {import('three').Vector3}  pivot     World-space rotation pivot
+ * @param {import('three').Quaternion} quat    Rotation to apply
+ * @returns {import('three').Vector3[]}
+ */
+export function rotateCuboid(corners, pivot, quat) {
+  return corners.map(c => c.clone().sub(pivot).applyQuaternion(quat).add(pivot))
+}
+
+/**
  * Pivot candidates: all of the above combined (8 vertices + 12 edge midpoints + 6 face centers).
  * @param {THREE.Vector3[]} corners
  * @returns {{ label: string, position: THREE.Vector3, type: string }[]}


### PR DESCRIPTION
Solid を選択した状態で R キーを押すと直接回転できるようになった。
CF 作成・fastened リンクなしで Solid を任意軸に回転させられる。

- `rotateCuboid(corners, pivot, quat)` — CuboidModel.js に純粋関数を追加
- `Solid.rotate(startCorners, pivot, quat)` — move() と対称なドメインメソッドを追加
- `createSolidRotateCommand` — 開始/終了コーナーを保存する Undo コマンドを新設
- AppController `_rotate` 状態を Solid に拡張:
  pivot = startCorners のセントロイド、X/Y/Z 軸拘束・数値入力・Ctrl スナップは CF と共通 UX
- R キー条件を `instanceof CoordinateFrame || instanceof Solid` に拡張
- ADR-036 を作成; EVENTS/SCREEN_DESIGN/ROADMAP/CODE_CONTRACTS を更新

https://claude.ai/code/session_0157GYLqnPumdsp8dwCqsUyi