### PR TITLE
feat: add mobile rotation button for Solid objects

### DIFF
--- a/docs/CODE_CONTRACTS.md
+++ b/docs/CODE_CONTRACTS.md
@@ -89,6 +89,7 @@ Detail: `docs/code_contracts/interaction.md`
 | Touch vs. Pointer Asymmetry | Re-run hit tests in `_onPointerDown` before `_handleEditClick`; hover does not fire before touch tap |
 | Gesture-Based Interaction Priority | Auto-start face extrude on touch tap in Edit 3D; gesture-only, no toolbar button |
 | Interaction Confirmation Lifecycle | FaceExtrude confirms on `pointerup`; Grab on touch confirms via toolbar only, never in `pointerup` |
+| Mobile Rotate Interaction Lifecycle | Rotate button calls `_startRotate(true)`; each canvas touch re-anchors `segmentStart*`; `_onPointerUp` keeps rotate active; confirm via toolbar only |
 | Grab State: allStartCorners vs segmentStartCorners | `allStartCorners` = undo anchor (never update mid-grab); `segmentStartCorners` = per-drag delta (re-snapshot on re-touch) |
 | Global Event vs. UI Event Delegation | First guard in `_onPointerDown`: `if (e.target !== renderer.domElement) return` |
 | OrbitControls Disable Strategy | Use `matchMedia('(pointer: coarse)')` not `innerWidth < 768`; disable only for single-finger-consuming ops |
@@ -101,7 +102,7 @@ Detail: `docs/code_contracts/ui_layout.md`
 
 | Rule | Core Takeaway |
 |------|--------------|
-| Mobile Toolbar Stability | Fixed slot counts per mode; use `disabled` + `{spacer: true}` to prevent layout shifts |
+| Mobile Toolbar Stability | Fixed slot counts per mode; use `disabled` + `{spacer: true}` to prevent layout shifts. Solid selected: slot 5 = Rotate (replaces Stack; Stack still accessible via Grab toolbar) |
 | Mobile Touch Gesture Model | Touch: tap=select, one-finger-drag=orbit, long-press=context menu; no rect selection or _objDragging |
 | Long-Press Context Menu | `showContextMenu()` with Grab/Dup/Rename/Delete; items filtered by entity type |
 | Long-Press for Non-Draggable Entities | CF/MeasureLine/Annotated* early-return must set long-press timer for touch BEFORE returning; without this CF "Link to..." is unreachable on mobile |

--- a/docs/adr/ADR-024-mobile-toolbar-architecture.md
+++ b/docs/adr/ADR-024-mobile-toolbar-architecture.md
@@ -33,6 +33,7 @@ Each mode shows a **fixed number of slots**. The toolbar width never changes wit
 | Edit 2D extrude | 4 |
 | Edit 3D | 4 |
 | Grab active | 4 |
+| Rotate active | 4 |
 
 Object mode uses 5 slots (the widest); all other modes use 4.
 The toolbar is sized to 5 slots and never shrinks.
@@ -52,12 +53,17 @@ identical dimensions occupying layout space without being tappable.
 
 ```
 Object mode (generic):      [ Add | Dup | Edit | Delete | Stack ]
+Object mode (Solid):        [ Add | Dup | Edit | Delete | Rotate ]
 Object mode (CoordFrame):   [ Rotate | Grab | Delete | Add Frame | (spacer) ]
 Edit 2D sketch:             [ <- Object | Extrude | (spacer) | (spacer) ]
 Edit 2D extrude:            [ Confirm | Cancel | (spacer) | (spacer) ]
 Edit 3D:                    [ <- Object | Vertex | Edge | Face ]
 Grab active:                [ Confirm | Stack | Cancel | (spacer) ]
+Rotate active:              [ Confirm | (spacer) | Cancel | (spacer) ]
 ```
+
+**Solid exception**: when a Solid is selected, slot 5 shows Rotate instead of Stack.
+Stack mode is still accessible via the Grab-active toolbar after starting a grab.
 
 **CoordinateFrame exception**: when a CoordinateFrame is selected, the entire Object mode
 toolbar switches to the specialized 5-slot layout (Rotate | Grab | Delete | Add Frame |
@@ -70,7 +76,8 @@ applicable actions is categorically different.
 |--------|-------------|
 | Dup | `ImportedMesh`, `MeasureLine`, `CoordinateFrame`, `Profile` |
 | Edit | `ImportedMesh`, `MeasureLine`, `CoordinateFrame` |
-| Stack | `ImportedMesh`, `MeasureLine`, `CoordinateFrame` |
+| Stack | `ImportedMesh`, `MeasureLine`, `CoordinateFrame` (slot 5 hidden when Solid selected — Rotate takes its place) |
+| Rotate | Only shown when `Solid` is selected (slot 5); never disabled |
 | Delete | Never disabled |
 | Add | Never disabled |
 

--- a/docs/code_contracts/interaction.md
+++ b/docs/code_contracts/interaction.md
@@ -50,6 +50,15 @@ if (this._grab.active) {
 }
 ```
 
+## Mobile Rotate Interaction Lifecycle
+
+- **Principle**: On mobile, the rotate operation follows the same multi-segment drag pattern as Grab: each new canvas touch re-anchors the drag reference so subsequent drags accumulate naturally.
+- **Concrete Rule**: Tapping the Rotate button calls `_startRotate(true)` (deferStartAngle = true). In `_onPointerDown` during rotate, touch events: (1) re-snapshot `segmentStartCorners` (Solid) or `segmentStartRot` (CF) from the current object state; (2) set `needsStartAngle = true`; (3) set `_activeDragPointerId`. In `_applyRotate`, when `needsStartAngle` is true, capture `segmentStartAngle = currentAngle` and return without applying rotation. Subsequent pointer moves apply `angle = segmentStartAngle - currentAngle` from `segmentStartCorners`. In `_onPointerUp` during rotate, return immediately — rotate stays active until the Confirm/Cancel toolbar button fires.
+
+  `startCorners` / `startRot` remain unchanged throughout (undo anchor). `segmentStart*` fields are re-initialized on each touch re-down.
+
+  Left-click on canvas still confirms on PC; right-click cancels. Touch `pointerdown` during rotate must NOT confirm — add `if (e.pointerType === 'touch') { ... return }` before the `e.button === 0` confirm check.
+
 ## Grab State: allStartCorners vs segmentStartCorners
 
 - **Principle**: A multi-drag grab (multiple finger-lift + re-touch cycles before confirming) needs two distinct corner snapshots: one for undo/cancel anchoring, and one for per-segment drag delta calculation.

--- a/docs/code_contracts/ui_layout.md
+++ b/docs/code_contracts/ui_layout.md
@@ -12,15 +12,19 @@ Detail file for `docs/CODE_CONTRACTS.md` Section 3.
 | Mode | Slot 1 | Slot 2 | Slot 3 | Slot 4 | Slot 5 |
 |------|--------|--------|--------|--------|--------|
 | Object (generic) | Add | Dup | Edit | Delete | Stack |
+| Object (Solid selected) | Add | Dup | Edit | Delete | Rotate |
 | Object (CoordinateFrame selected) | Rotate | Grab | Delete | Add Frame | *(spacer)* |
 | Edit 2D sketch | <- Object | Extrude | *(spacer)* | *(spacer)* | — |
 | Edit 2D extrude | Confirm | Cancel | *(spacer)* | *(spacer)* | — |
 | Edit 3D | <- Object | Vertex | Edge | Face | — |
 | Grab active | Confirm | Stack | Cancel | *(spacer)* | — |
+| Rotate active | Confirm | *(spacer)* | Cancel | *(spacer)* | — |
 
 `{ spacer: true }` renders as a `visibility: hidden` div of identical dimensions. It occupies layout space without being tappable.
 
 Dup, Edit, and Stack are disabled for `ImportedMesh`, `MeasureLine`, and `CoordinateFrame`. Dup is additionally disabled for `Profile`. Delete remains enabled for all object types. All Object-mode slots maintain consistent disabled states so slot positions never shift.
+
+**Solid exception**: when a Solid is selected, slot 5 shows Rotate instead of Stack. Stack is still available via the Grab-active toolbar after starting a grab.
 
 **CoordinateFrame exception**: when a CoordinateFrame is selected the entire toolbar switches to a specialised 5-slot layout (Rotate|Grab|Delete|Add Frame|spacer) rather than disabling individual generic slots.
 

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -470,6 +470,15 @@ export class AppController {
       hasInput:   false,
       /** Degree increment for Ctrl snap. Cycled with Ctrl+Wheel. */
       stepSize:   1,
+      // Mobile multi-segment drag support: re-initialized on each new touch drag.
+      /** True when startAngle should be captured from the next pointer position (mobile). */
+      needsStartAngle:      false,
+      /** Per-segment start angle; equals startAngle on PC (single drag). */
+      segmentStartAngle:    0,
+      /** Per-segment corner snapshot for Solid; equals startCorners on PC. @type {import('three').Vector3[]|null} */
+      segmentStartCorners:  null,
+      /** Per-segment quaternion for CoordinateFrame; equals startRot on PC. */
+      segmentStartRot:      new THREE.Quaternion(),
     }
 
     this._ctrlHeld  = false
@@ -3325,6 +3334,16 @@ export class AppController {
       return
     }
 
+    if (this._rotate.active) {
+      this._uiView.setMobileToolbar([
+        { icon: ICONS.confirm, label: 'Confirm', onClick: () => this._confirmRotate() },
+        { spacer: true },
+        { icon: ICONS.cancel,  label: 'Cancel',  onClick: () => this._cancelRotate(), danger: true },
+        { spacer: true },
+      ])
+      return
+    }
+
     if (this._grab.active) {
       this._uiView.setMobileToolbar([
         { icon: ICONS.confirm, label: 'Confirm', onClick: () => this._confirmGrab() },
@@ -3378,15 +3397,14 @@ export class AppController {
         return
       }
 
-      // 5-slot layout: Add | Dup | Edit | Delete | Stack
+      // 5-slot layout: Add | Dup | Edit | Delete | Rotate (Solid) / Stack (others)
       // All slots always present; unavailable actions are disabled to prevent layout shifts.
-      const canDup   = hasObj && !(this._activeObj instanceof ImportedMesh) && !(this._activeObj instanceof MeasureLine) && !(this._activeObj instanceof CoordinateFrame) && !(this._activeObj instanceof Profile) && !_isAnnotated(this._activeObj) && !_isSpatialLink(this._activeObj)
-      const canEdit  = hasObj && !(this._activeObj instanceof ImportedMesh) && !(this._activeObj instanceof CoordinateFrame) && !_isAnnotated(this._activeObj) && !_isSpatialLink(this._activeObj)
-      const canStack = hasObj && !(this._activeObj instanceof ImportedMesh) && !(this._activeObj instanceof MeasureLine)
-        && !(this._activeObj instanceof ImportedMesh)
-        && !(this._activeObj instanceof MeasureLine)
+      const canDup    = hasObj && !(this._activeObj instanceof ImportedMesh) && !(this._activeObj instanceof MeasureLine) && !(this._activeObj instanceof CoordinateFrame) && !(this._activeObj instanceof Profile) && !_isAnnotated(this._activeObj) && !_isSpatialLink(this._activeObj)
+      const canEdit   = hasObj && !(this._activeObj instanceof ImportedMesh) && !(this._activeObj instanceof CoordinateFrame) && !_isAnnotated(this._activeObj) && !_isSpatialLink(this._activeObj)
+      const canStack  = hasObj && !(this._activeObj instanceof ImportedMesh) && !(this._activeObj instanceof MeasureLine)
         && !_isAnnotated(this._activeObj)
         && !_isSpatialLink(this._activeObj)
+      const canRotate = hasObj && this._activeObj instanceof Solid
       this._uiView.setMobileToolbar([
         {
           icon: ICONS.add, label: 'Add',
@@ -3405,7 +3423,9 @@ export class AppController {
         { icon: ICONS.duplicate, label: 'Dup',    onClick: () => this._duplicateObject(),                                        disabled: !canDup },
         { icon: ICONS.edit,      label: 'Edit',   onClick: () => this.setMode('edit'),                                           disabled: !canEdit },
         { icon: ICONS.delete,    label: 'Delete', onClick: () => this._deleteObject(this._scene.activeId), danger: hasObj,       disabled: !hasObj },
-        { icon: ICONS.stack,     label: 'Stack',  onClick: () => { this._grab.stackMode = !this._grab.stackMode; this._updateMobileToolbar() }, active: this._grab.stackMode, disabled: !canStack },
+        canRotate
+          ? { icon: ICONS.rotate, label: 'Rotate', onClick: () => { this._startRotate(true); this._updateMobileToolbar() } }
+          : { icon: ICONS.stack,  label: 'Stack',  onClick: () => { this._grab.stackMode = !this._grab.stackMode; this._updateMobileToolbar() }, active: this._grab.stackMode, disabled: !canStack },
       ])
       return
     }
@@ -4278,7 +4298,7 @@ export class AppController {
    * For CoordinateFrame: rotates the quaternion around the frame origin.
    * For Solid: bakes the rotation into corner positions (ADR-036).
    */
-  _startRotate() {
+  _startRotate(deferStartAngle = false) {
     const obj = this._activeObj
     if (!(obj instanceof CoordinateFrame) && !(obj instanceof Solid)) return
     if (this._grab.active) return
@@ -4298,22 +4318,34 @@ export class AppController {
         return
       }
       this._rotate.startRot.copy(obj.rotation)
+      this._rotate.segmentStartRot.copy(obj.rotation)
       projected = (this._service.worldPoseOf(obj.id)?.position ?? obj.translation).clone().project(this._camera)
     } else {
       // Solid: snapshot corners; pivot = centroid of startCorners (ADR-036)
-      this._rotate.startCorners = obj.corners.map(c => c.clone())
+      this._rotate.startCorners        = obj.corners.map(c => c.clone())
+      this._rotate.segmentStartCorners = obj.corners.map(c => c.clone())
       const pivot = getCentroid(this._rotate.startCorners)
       projected = pivot.clone().project(this._camera)
     }
 
-    // Screen-space start angle: angle from projected pivot to current mouse.
-    this._rotate.startAngle = Math.atan2(
-      this._mouse.y - projected.y,
-      this._mouse.x - projected.x,
-    )
+    if (deferStartAngle) {
+      // Mobile: startAngle will be captured from the first canvas touch (CODE_CONTRACTS §2)
+      this._rotate.needsStartAngle   = true
+      this._rotate.startAngle        = 0
+      this._rotate.segmentStartAngle = 0
+    } else {
+      // PC: startAngle from current mouse position
+      this._rotate.startAngle = Math.atan2(
+        this._mouse.y - projected.y,
+        this._mouse.x - projected.x,
+      )
+      this._rotate.segmentStartAngle = this._rotate.startAngle
+      this._rotate.needsStartAngle   = false
+    }
 
     this._controls.enabled = false
     this._updateRotateStatus()
+    if (window.matchMedia('(pointer: coarse)').matches) this._updateMobileToolbar()
   }
 
   /**
@@ -4345,14 +4377,17 @@ export class AppController {
         this._commandStack.push(cmd)
       }
     }
-    this._rotate.active      = false
-    this._rotate.axis        = null
-    this._rotate.inputStr    = ''
-    this._rotate.hasInput    = false
-    this._rotate.startCorners = null
-    this._controls.enabled   = true
+    this._rotate.active             = false
+    this._rotate.axis               = null
+    this._rotate.inputStr           = ''
+    this._rotate.hasInput           = false
+    this._rotate.startCorners       = null
+    this._rotate.segmentStartCorners = null
+    this._rotate.needsStartAngle    = false
+    this._controls.enabled          = true
     this._refreshObjectModeStatus()
     this._updateNPanel()
+    if (window.matchMedia('(pointer: coarse)').matches) this._updateMobileToolbar()
   }
 
   /**
@@ -4369,13 +4404,16 @@ export class AppController {
       obj.meshView.updateGeometry(obj.corners)
       obj.meshView.updateBoxHelper()
     }
-    this._rotate.active      = false
-    this._rotate.axis        = null
-    this._rotate.inputStr    = ''
-    this._rotate.hasInput    = false
-    this._rotate.startCorners = null
-    this._controls.enabled   = true
+    this._rotate.active             = false
+    this._rotate.axis               = null
+    this._rotate.inputStr           = ''
+    this._rotate.hasInput           = false
+    this._rotate.startCorners       = null
+    this._rotate.segmentStartCorners = null
+    this._rotate.needsStartAngle    = false
+    this._controls.enabled          = true
     this._refreshObjectModeStatus()
+    if (window.matchMedia('(pointer: coarse)').matches) this._updateMobileToolbar()
   }
 
   /**
@@ -4419,18 +4457,24 @@ export class AppController {
       const parsed = parseFloat(this._rotate.inputStr)
       angle = isNaN(parsed) ? 0 : parsed * (Math.PI / 180)
     } else {
-      // Mouse-driven: measure signed angle from start to current mouse position.
+      // Mouse/touch-driven: measure signed angle from segment start to current position.
       let pivotScreen
       if (obj instanceof CoordinateFrame) {
         pivotScreen = (this._service.worldPoseOf(obj.id)?.position ?? obj.translation).clone().project(this._camera)
       } else {
-        pivotScreen = getCentroid(this._rotate.startCorners).clone().project(this._camera)
+        pivotScreen = getCentroid(this._rotate.segmentStartCorners).clone().project(this._camera)
       }
       const currentAngle = Math.atan2(
         this._mouse.y - pivotScreen.y,
         this._mouse.x - pivotScreen.x,
       )
-      angle = this._rotate.startAngle - currentAngle
+      // Mobile: defer start angle to first canvas touch so there's no jump.
+      if (this._rotate.needsStartAngle) {
+        this._rotate.segmentStartAngle = currentAngle
+        this._rotate.needsStartAngle   = false
+        return
+      }
+      angle = this._rotate.segmentStartAngle - currentAngle
       // Ctrl: snap to stepSize degree increments
       if (this._ctrlHeld) {
         const stepRad = this._rotate.stepSize * (Math.PI / 180)
@@ -4452,12 +4496,12 @@ export class AppController {
     const deltaQ = new THREE.Quaternion().setFromAxisAngle(axisVec, angle)
 
     if (obj instanceof CoordinateFrame) {
-      obj.rotation.copy(this._rotate.startRot).premultiply(deltaQ)
+      obj.rotation.copy(this._rotate.segmentStartRot).premultiply(deltaQ)
       obj.meshView.updateRotation(obj.rotation)
     } else {
-      // Solid: rotate all corners around the centroid of startCorners (ADR-036)
-      const pivot = getCentroid(this._rotate.startCorners)
-      obj.rotate(this._rotate.startCorners, pivot, deltaQ)
+      // Solid: rotate all corners around the centroid of segmentStartCorners (ADR-036)
+      const pivot = getCentroid(this._rotate.segmentStartCorners)
+      obj.rotate(this._rotate.segmentStartCorners, pivot, deltaQ)
       obj.meshView.updateGeometry(obj.corners)
       obj.meshView.updateBoxHelper()
     }
@@ -5484,6 +5528,19 @@ export class AppController {
     }
 
     if (this._rotate.active) {
+      if (e.pointerType === 'touch') {
+        // Mobile: drag rotates the object; confirmation is via the toolbar button.
+        // Re-snapshot segmentStart* so each new drag segment starts from current state.
+        const obj = this._activeObj
+        if (obj instanceof Solid && obj.corners) {
+          this._rotate.segmentStartCorners = obj.corners.map(c => c.clone())
+        } else if (obj instanceof CoordinateFrame) {
+          this._rotate.segmentStartRot.copy(obj.rotation)
+        }
+        this._rotate.needsStartAngle  = true
+        this._activeDragPointerId     = e.pointerId
+        return
+      }
       if (e.button === 0) { this._confirmRotate(); return }
       if (e.button === 2) { this._cancelRotate();  return }
       return
@@ -6044,6 +6101,10 @@ export class AppController {
     // wasDragging: a canvas drag started for this pointer (via _onPointerDown)
     const wasDragging = this._activeDragPointerId === e.pointerId
     if (wasDragging) this._activeDragPointerId = null
+    if (this._rotate.active) {
+      // Mobile rotate: keep active after finger lift; user confirms via toolbar button.
+      return
+    }
     if (this._grab.active) {
       // Touch grab: keep grab active after finger release.
       // The object stays at the dragged position; user confirms via the Confirm button.


### PR DESCRIPTION
Tap Rotate (slot 5 in Object mode toolbar) to enter rotate mode;
drag on canvas to rotate around the centroid; tap Confirm/Cancel
to finish. Replaces the Stack pre-set slot for Solid — Stack is
still accessible via the Grab-active toolbar.

Multi-segment drag support: each new canvas touch re-anchors
segmentStartCorners / segmentStartAngle so rotation accumulates
naturally across multiple drag strokes before confirming.
undo/redo uses the original startCorners snapshot (ADR-036 pattern).

- _rotate state: add needsStartAngle, segmentStart{Angle,Corners,Rot}
- _startRotate(deferStartAngle): defer angle capture to first touch
- _applyRotate: use segmentStart* fields; handle needsStartAngle
- _onPointerDown: touch during rotate re-anchors segments, no confirm
- _onPointerUp: return early during rotate (confirm via toolbar only)
- _updateMobileToolbar: rotate-active toolbar + canRotate slot 5
- Docs: ADR-024, CODE_CONTRACTS, interaction.md, ui_layout.md

https://claude.ai/code/session_012kU5VbYGWZadmbu7VRWrMj