### PR TITLE
fix: replace BoxHelper with EdgesGeometry for Solid selection highlight

### DIFF
--- a/docs/CODE_CONTRACTS.md
+++ b/docs/CODE_CONTRACTS.md
@@ -144,3 +144,4 @@ Detail: `docs/code_contracts/memory_management.md`
 | ImportedMesh Serialization | Base64 buffers; restore `cuboid.position` from `offset` BEFORE calling `initCorners()` |
 | THREE.Mesh Requires Valid Geometry | Never pass `null` to `new THREE.Mesh(null, mat)` — use `new THREE.BufferGeometry()` as placeholder; `updateMorphTargets()` throws on null geometry |
 | Zone Rim Ring Must Use Polygon Geometry | Use `ShapeGeometry` + polygon hole for the rim ring; `RingGeometry` always produces a circle regardless of Zone shape |
+| BoxHelper Forbidden for World-Space Baked Geometry | `THREE.BoxHelper` computes AABB; use `THREE.LineSegments`+`EdgesGeometry` for `MeshView` selection highlight so it matches the solid's actual orientation after rotation |

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -448,6 +448,7 @@ to the main body as a full principle and add a row to the Index.
 | Candidate Principle | First Context (date · file · what happened) | CODE_CONTRACTS Rule |
 |---------------------|---------------------------------------------|---------------------|
 | Overflow-escaping popups belong on body | 2026-05-01 · `UIView.js` · `_modeDropdownEl` was a child of the header (which has `overflow:hidden`); the dropdown was clipped below the header boundary and unselectable. Fixed by moving to `document.body` with `position:fixed` + `getBoundingClientRect()` positioning, matching the already-correct `_moreMenuDropdown` pattern. | Mobile Header Overflow |
+| Three.js helpers must match the actual geometry model, not an approximation | 2026-05-02 · `MeshView.js` · `THREE.BoxHelper` computes AABB; because `MeshView` bakes corner positions as world-space vertices with no mesh transform, the AABB diverges from the actual OBB after R-key rotation. After confirming rotation, the selection highlight appeared as an axis-aligned box larger than the solid, visually rotating independently. Fixed by replacing `BoxHelper` with `LineSegments+EdgesGeometry` kept in sync by `updateGeometry()`. | BoxHelper Forbidden for World-Space Baked Geometry |
 
 ---
 

--- a/docs/code_contracts/memory_management.md
+++ b/docs/code_contracts/memory_management.md
@@ -58,6 +58,12 @@ _clearScene() {
 - **Principle**: `THREE.RingGeometry` always produces a circular ring regardless of the polygon's actual shape. When this is used for an animation that is meant to "pulse outward from the boundary", rectangular or irregular Zones get a visually mismatched circular pulse.
 - **Concrete Rule**: In `AnnotatedRegionView._setPoints()`, build the rim ring as a `THREE.ShapeGeometry` with a polygonal hole: outer boundary = polygon vertices in local space (centroid at origin); inner boundary = vertices scaled 92% toward centroid. Position `_rimRing` at the centroid in world space. `scale.setScalar()` in `tick()` then expands the ring outward along the real polygon shape.
 
+## BoxHelper Must Not Be Used for World-Space Baked Geometry
+
+- **Principle**: `THREE.BoxHelper` computes an **axis-aligned bounding box (AABB)** from the mesh's geometry vertices. In `MeshView`, corner positions are baked directly into geometry as world-space vertices (no Three.js mesh transform is applied). After an R-key rotation, the AABB is axis-aligned and larger than the actual solid — it does not follow the solid's orientation.
+- **Concrete Rule**: In `MeshView`, the selection highlight (`boxHelper`) must be a `THREE.LineSegments` with `THREE.EdgesGeometry` built from the actual corner positions, not a `THREE.BoxHelper`. Update `boxHelper.geometry` in `updateGeometry()`, `rebuildGeometry()`, and `rebuildExtrudedProfile()` (all three geometry-update paths). `updateBoxHelper()` is a no-op; `setObjectSelected()` only toggles `visible`. Dispose `boxHelper.geometry` in `dispose()`.
+- **Root bug**: After confirming rotation (`_confirmRotate` → `setObjectSelected(true)` → `boxHelper.update()`), the AABB of the rotated geometry was displayed — axis-aligned, larger than the solid, and visually rotating independently from it.
+
 ## ImportedMesh Serialization: Base64 Typed Arrays + Position Offset
 
 - **Principle**: Raw Float32/Uint32 buffers cannot be stored directly in JSON. Base64 encoding is used so geometry survives round-trip through the BFF DB without loss.

--- a/src/view/MeshView.js
+++ b/src/view/MeshView.js
@@ -30,8 +30,13 @@ export class MeshView {
     )
     scene.add(this.wireframe)
 
-    // BoxHelper for object-selected highlight
-    this.boxHelper = new THREE.BoxHelper(this.cuboid, 0x4fc3f7)
+    // Selection highlight: LineSegments from actual corner edges (OBB, not AABB).
+    // THREE.BoxHelper computes an AABB which diverges from the solid after R-key
+    // rotation because corners are baked as world-space vertices with no mesh transform.
+    this.boxHelper = new THREE.LineSegments(
+      new THREE.BufferGeometry(),
+      new THREE.LineBasicMaterial({ color: 0x4fc3f7 }),
+    )
     this.boxHelper.visible = false
     scene.add(this.boxHelper)
 
@@ -255,8 +260,11 @@ export class MeshView {
     const newGeo = buildGeometry(corners)
     this.cuboid.geometry.dispose()
     this.cuboid.geometry = newGeo
+    const edgesGeo = new THREE.EdgesGeometry(newGeo, 1)
     this.wireframe.geometry.dispose()
-    this.wireframe.geometry = new THREE.EdgesGeometry(newGeo, 1)
+    this.wireframe.geometry = edgesGeo
+    this.boxHelper.geometry.dispose()
+    this.boxHelper.geometry = new THREE.EdgesGeometry(newGeo, 1)
   }
 
   /**
@@ -281,6 +289,8 @@ export class MeshView {
     this.cuboid.geometry = newGeo
     this.wireframe.geometry.dispose()
     this.wireframe.geometry = new THREE.EdgesGeometry(newGeo, 1)
+    this.boxHelper.geometry.dispose()
+    this.boxHelper.geometry = new THREE.EdgesGeometry(newGeo, 1)
   }
 
   /**
@@ -304,19 +314,18 @@ export class MeshView {
     this.cuboid.geometry = newGeo
     this.wireframe.geometry.dispose()
     this.wireframe.geometry = new THREE.EdgesGeometry(newGeo, 1)
+    this.boxHelper.geometry.dispose()
+    this.boxHelper.geometry = new THREE.EdgesGeometry(newGeo, 1)
   }
 
   /** Updates the visual appearance for object-selected state */
   setObjectSelected(sel) {
     this.cuboidMat.emissive.set(sel ? 0x112244 : 0x000000)
     this.boxHelper.visible = sel
-    if (sel) this.boxHelper.update()
   }
 
-  /** Updates the BoxHelper to match the current geometry */
-  updateBoxHelper() {
-    this.boxHelper.update()
-  }
+  /** No-op: boxHelper geometry is kept in sync by updateGeometry() */
+  updateBoxHelper() {}
 
   /**
    * Updates the extrusion display lines (I-type dimension line).
@@ -683,6 +692,7 @@ export class MeshView {
     scene.remove(this._selFaceMesh)
     this.cuboid.geometry.dispose()
     this.wireframe.geometry.dispose()
+    this.boxHelper.geometry.dispose()
     this._hlGeo.dispose()
     this._extrusionLinesGeo.dispose()
     this._pivotVertGeo.dispose()


### PR DESCRIPTION
THREE.BoxHelper computes AABB from world-space baked vertex positions.
After R-key rotation the AABB diverges from the solid's actual OBB,
producing an axis-aligned wireframe that appears to rotate independently.

Replace MeshView.boxHelper with THREE.LineSegments+EdgesGeometry kept
in sync by all three geometry-update paths (updateGeometry, rebuildGeometry,
rebuildExtrudedProfile). updateBoxHelper() becomes a no-op; setObjectSelected()
only toggles visibility. boxHelper.geometry now disposed in dispose().

Docs: CODE_CONTRACTS §4 + detail file rule added; PHILOSOPHY Yellow Card added.

https://claude.ai/code/session_015eaEJALfarUb3SYXfqAhM7