### PR TITLE
fix: propagate Solid R-key rotation to child CFs so fastened constraints sync

### DIFF
--- a/docs/CODE_CONTRACTS.md
+++ b/docs/CODE_CONTRACTS.md
@@ -44,7 +44,7 @@ Detail: `docs/code_contracts/architecture.md`
 |------|--------------|
 | Mode Transition Flow | `setMode()` is the single entry point; always call `setMode('object')` before `_switchActiveObject()` from edit mode |
 | State Restoration on Mode Exit | Restore `_objSelected = true` + `setObjectSelected(true)` when returning to Object mode if `_activeObj` exists |
-| Entity Capability Contracts | Use `instanceof` not `dimension`; `Sketch.extrude()` returns new Cuboid swapped via `SceneService.extrudeSketch()`; ImportedMesh/CoordinateFrame have restricted capabilities; MeasureLine supports 1D Edit Mode (endpoint drag via `_enterEditMode1D`); Solid supports R-key rotation (bakes into corners, pivot = centroid, `SolidRotateCommand` for undo — ADR-036) |
+| Entity Capability Contracts | Use `instanceof` not `dimension`; `Sketch.extrude()` returns new Cuboid swapped via `SceneService.extrudeSketch()`; ImportedMesh/CoordinateFrame have restricted capabilities; MeasureLine supports 1D Edit Mode (endpoint drag via `_enterEditMode1D`); Solid supports R-key rotation (bakes into corners, pivot = centroid, `SolidRotateCommand` for undo — ADR-036); child CFs' `rotation` and `translation` are baked in sync so fastened constraints track Solid orientation |
 | MeasureLineView No-Op Interface | Every `_meshView` method called in AppController must exist as a no-op or real impl on MeasureLineView; `setEndpointHover(index)` and `clearEndpointHover()` are real impls used in `'1d'` edit substate |
 | Measure Snap Display | Use `_measure.snapMeshView` (not `_meshView`) for all snap display during measure placement |
 | MeasureLineView Label Lifecycle | Call `updateLabelPosition()` every animation frame for every MeasureLine in scene |

--- a/docs/code_contracts/architecture.md
+++ b/docs/code_contracts/architecture.md
@@ -404,7 +404,7 @@ if (this._tcFastenedBlocked) return
 
 These are design-level constraints (not bugs) of the current `fastened` implementation.  Violating these silently produces wrong behaviour.
 
-- **Translation-only propagation**: `_updateFastenedFrames()` propagates the constraint as a world-space translation delta to the parent Solid's corners.  Rotation of the target entity is reflected in `source.rotation` (the CF rotates) but the parent Solid's corner geometry is NOT rotated.  If the target rotates, the Solid will appear at the correct position but with the wrong orientation.  Acceptable while Solid rotation is not a first-class operation.
+- **Solid R-key rotation propagates through child CFs**: When a Solid is rotated with R-key (or TC rotate on mobile), all direct child CoordinateFrames have their `rotation` and `translation` baked in sync with the delta quaternion: `cf.rotation = segStartRot ∘ deltaQ`, `cf.translation = segStartTrans.applyQuaternion(deltaQ)`.  This lets `_updateFastenedFrames()` detect the changed world pose of a target CF and propagate the rotation to the fastened Solid B.  Both values are snapshotted on operation start and restored on cancel; `SolidRotateCommand` stores start/end CF poses so undo/redo works correctly.
 
 - **One fastened CF per Solid**: If two child CFs of the same Solid are each fastened to different target CFs, the second iteration of `_updateFastenedFrames()` moves the Solid again — invalidating the first constraint.  Only the last constraint processed (Map insertion order) is satisfied at the end of each frame.  **Do not create multiple fastened links whose source CFs share the same parent Solid.**
 

--- a/src/command/SolidRotateCommand.js
+++ b/src/command/SolidRotateCommand.js
@@ -1,4 +1,5 @@
-import { Solid } from '../domain/Solid.js'
+import { Solid }           from '../domain/Solid.js'
+import { CoordinateFrame } from '../domain/CoordinateFrame.js'
 
 /**
  * SolidRotateCommand — records an R-key Solid rotation for undo/redo.
@@ -7,26 +8,40 @@ import { Solid } from '../domain/Solid.js'
  * Stores start/end corners and swaps them on execute/undo, identical to the
  * MoveCommand pattern.  The rotation itself is baked into the corner positions.
  *
+ * Child CoordinateFrames of the Solid have their rotation (quaternion) and
+ * translation (world-space offset from centroid) baked in sync with the corner
+ * rotation, so fastened constraints continue to track the Solid's orientation.
+ *
  * @param {import('../domain/Solid.js').Solid} solidRef
  * @param {import('three').Vector3[]} startCorners  Corner snapshot before rotation
  * @param {import('three').Vector3[]} endCorners    Corner snapshot after rotation
  * @param {import('../service/SceneService.js').SceneService} sceneService
  * @param {() => void} onApplied  Called after each apply (e.g. _updateNPanel)
+ * @param {Map<string, {rotation: import('three').Quaternion, translation: import('three').Vector3}>} [startCfPoses]
+ * @param {Map<string, {rotation: import('three').Quaternion, translation: import('three').Vector3}>} [endCfPoses]
  * @returns {{label: string, execute(): void, undo(): void}}
  */
-export function createSolidRotateCommand(solidRef, startCorners, endCorners, sceneService, onApplied) {
-  function apply(corners) {
+export function createSolidRotateCommand(solidRef, startCorners, endCorners, sceneService, onApplied, startCfPoses = new Map(), endCfPoses = new Map()) {
+  function apply(corners, cfPoses) {
     const obj = sceneService.scene.getObject(solidRef.id)
     if (!(obj instanceof Solid)) return
     obj.corners.forEach((c, i) => c.copy(corners[i]))
     obj.meshView.updateGeometry(obj.corners)
     obj.meshView.updateBoxHelper()
+    for (const [cfId, { rotation, translation }] of cfPoses) {
+      const cf = sceneService.scene.getObject(cfId)
+      if (cf instanceof CoordinateFrame) {
+        cf.rotation.copy(rotation)
+        cf.meshView.updateRotation(cf.rotation)
+        cf.translation.copy(translation)
+      }
+    }
     sceneService.syncMountedPosition(solidRef.id)
     onApplied()
   }
   return {
     label: 'Rotate Solid',
-    execute() { apply(endCorners) },
-    undo()    { apply(startCorners) },
+    execute() { apply(endCorners, endCfPoses) },
+    undo()    { apply(startCorners, startCfPoses) },
   }
 }

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -451,6 +451,8 @@ export class AppController {
     this._tcStartProxyQuat = null
     /** Frame rotation snapshot at TC drag start (rotate mode only). @type {THREE.Quaternion|null} */
     this._tcStartFrameRot  = null
+    /** Child CF pose snapshots at TC drag start for Solid rotate — for undo. @type {Map<string,{rotation,translation}>|null} */
+    this._tcStartCfPoses   = null
 
     // ── CoordinateFrame / Solid rotate state (R key, ADR-019 Phase B / ADR-036) ─
     // Shared for both CoordinateFrame (quaternion-based) and Solid (corner-baking).
@@ -479,6 +481,10 @@ export class AppController {
       segmentStartCorners:  null,
       /** Per-segment quaternion for CoordinateFrame; equals startRot on PC. */
       segmentStartRot:      new THREE.Quaternion(),
+      /** Child CF pose snapshot at rotate start — for undo. @type {Map<string,{rotation,translation}>|null} */
+      startCfPoses:    null,
+      /** Child CF pose snapshot at segment start — reapplied each frame. @type {Map<string,{rotation,translation}>|null} */
+      segStartCfPoses: null,
     }
 
     this._ctrlHeld  = false
@@ -2128,6 +2134,9 @@ export class AppController {
         if (this._tcMode === 'rotate' && this._activeObj instanceof CoordinateFrame) {
           this._tcStartFrameRot = this._activeObj.rotation.clone()
         }
+        if (this._tcMode === 'rotate' && this._activeObj instanceof Solid) {
+          this._tcStartCfPoses = this._snapshotChildCfPoses(this._activeObj.id)
+        }
         // Block movement on fastened-source CFs and Solids that own them:
         // _updateFastenedFrames() overrides translation every frame, so any delta
         // from objectChange is silently discarded and the TC proxy drifts.
@@ -2168,14 +2177,17 @@ export class AppController {
           if (startPts) {
             const endPts = obj.corners.map(c => c.clone())
             if (startPts.some((c, i) => !c.equals(endPts[i]))) {
+              const startCfPoses = this._tcStartCfPoses ?? new Map()
+              const endCfPoses   = this._snapshotChildCfPoses(obj.id)
               const cmd = createSolidRotateCommand(
                 obj, startPts.map(c => c.clone()), endPts, this._service,
-                () => this._updateNPanel(),
+                () => this._updateNPanel(), startCfPoses, endCfPoses,
               )
               this._commandStack.push(cmd)
               this._refreshUndoRedoState()
             }
           }
+          this._tcStartCfPoses = null
           this._updateNPanel()
         } else {
           // Translate: record MoveCommand
@@ -2220,6 +2232,7 @@ export class AppController {
         })
         obj.meshView.updateGeometry(obj.corners)
         obj.meshView.updateBoxHelper()
+        this._applyChildCfPosesDelta(this._tcStartCfPoses, deltaQ)
       } else {
         // Translate mode: apply position delta to handles
         const delta    = this._tcProxy.position.clone().sub(this._tcStartProxyPos)
@@ -4326,6 +4339,60 @@ export class AppController {
 
   // ── CoordinateFrame / Solid rotation (R key, ADR-019 / ADR-036) ──────────
 
+  // ── Child-CF pose helpers (Solid rotation sync) ─────────────────────────────
+
+  /** Returns CoordinateFrames whose parentId === solidId. */
+  _childCfsOf(solidId) {
+    const result = []
+    for (const obj of this._scene.objects.values()) {
+      if (obj instanceof CoordinateFrame && obj.parentId === solidId) result.push(obj)
+    }
+    return result
+  }
+
+  /**
+   * Snapshot {rotation, translation} of every direct-child CF of a Solid.
+   * @returns {Map<string,{rotation: THREE.Quaternion, translation: THREE.Vector3}>}
+   */
+  _snapshotChildCfPoses(solidId) {
+    const poses = new Map()
+    for (const cf of this._childCfsOf(solidId)) {
+      poses.set(cf.id, { rotation: cf.rotation.clone(), translation: cf.translation.clone() })
+    }
+    return poses
+  }
+
+  /**
+   * Apply deltaQ to all CF poses in the snapshot: rotation = segStartRot ∘ deltaQ,
+   * translation = segStartTrans rotated by deltaQ.
+   * @param {Map<string,{rotation,translation}>|null} segStartPoses
+   * @param {THREE.Quaternion} deltaQ
+   */
+  _applyChildCfPosesDelta(segStartPoses, deltaQ) {
+    if (!segStartPoses) return
+    for (const [cfId, { rotation: segStartRot, translation: segStartTrans }] of segStartPoses) {
+      const cf = this._scene.getObject(cfId)
+      if (!(cf instanceof CoordinateFrame)) continue
+      cf.rotation.copy(segStartRot).premultiply(deltaQ)
+      cf.meshView.updateRotation(cf.rotation)
+      cf.translation.copy(segStartTrans).applyQuaternion(deltaQ)
+    }
+  }
+
+  /**
+   * Restore CF rotations and translations from a saved pose map (used on cancel/undo).
+   * @param {Map<string,{rotation,translation}>} poses
+   */
+  _restoreChildCfPoses(poses) {
+    for (const [cfId, { rotation, translation }] of poses) {
+      const cf = this._scene.getObject(cfId)
+      if (!(cf instanceof CoordinateFrame)) continue
+      cf.rotation.copy(rotation)
+      cf.meshView.updateRotation(cf.rotation)
+      cf.translation.copy(translation)
+    }
+  }
+
   /**
    * Starts rotate mode for the active CoordinateFrame or Solid.
    * For CoordinateFrame: rotates the quaternion around the frame origin.
@@ -4360,6 +4427,9 @@ export class AppController {
       const pivot = getCentroid(this._rotate.startCorners)
       projected = pivot.clone().project(this._camera)
       obj.meshView.boxHelper.visible = false
+      // Snapshot child CF poses so fastened constraints track the Solid's rotation
+      this._rotate.startCfPoses    = this._snapshotChildCfPoses(obj.id)
+      this._rotate.segStartCfPoses = this._snapshotChildCfPoses(obj.id)
     }
 
     if (deferStartAngle) {
@@ -4404,9 +4474,11 @@ export class AppController {
       const endCorners = solid.corners.map(c => c.clone())
       const changed = endCorners.some((c, i) => !c.equals(this._rotate.startCorners[i]))
       if (changed) {
+        const startCfPoses = this._rotate.startCfPoses ?? new Map()
+        const endCfPoses   = this._snapshotChildCfPoses(solid.id)
         const cmd = createSolidRotateCommand(
           solid, this._rotate.startCorners, endCorners, this._service,
-          () => this._updateNPanel(),
+          () => this._updateNPanel(), startCfPoses, endCfPoses,
         )
         this._commandStack.push(cmd)
       }
@@ -4419,6 +4491,8 @@ export class AppController {
     this._rotate.startCorners       = null
     this._rotate.segmentStartCorners = null
     this._rotate.needsStartAngle    = false
+    this._rotate.startCfPoses       = null
+    this._rotate.segStartCfPoses    = null
     this._controls.enabled          = true
     this._refreshObjectModeStatus()
     this._updateNPanel()
@@ -4438,6 +4512,7 @@ export class AppController {
       this._rotate.startCorners.forEach((c, i) => { obj.vertices[i].position.copy(c) })
       obj.meshView.updateGeometry(obj.corners)
       obj.meshView.setObjectSelected(true)
+      if (this._rotate.startCfPoses) this._restoreChildCfPoses(this._rotate.startCfPoses)
     }
     this._rotate.active             = false
     this._rotate.axis               = null
@@ -4446,6 +4521,8 @@ export class AppController {
     this._rotate.startCorners       = null
     this._rotate.segmentStartCorners = null
     this._rotate.needsStartAngle    = false
+    this._rotate.startCfPoses       = null
+    this._rotate.segStartCfPoses    = null
     this._controls.enabled          = true
     this._refreshObjectModeStatus()
     if (window.matchMedia('(pointer: coarse)').matches) this._updateMobileToolbar()
@@ -4539,6 +4616,9 @@ export class AppController {
       obj.rotate(this._rotate.segmentStartCorners, pivot, deltaQ)
       obj.meshView.updateGeometry(obj.corners)
       obj.meshView.updateBoxHelper()
+      // Keep child CF poses in sync so fastened constraints track the Solid's rotation.
+      // rotation = segStartRot composed with deltaQ; translation = segStartTrans rotated by deltaQ.
+      this._applyChildCfPosesDelta(this._rotate.segStartCfPoses, deltaQ)
     }
     this._updateRotateStatus()
   }
@@ -5569,6 +5649,7 @@ export class AppController {
         const obj = this._activeObj
         if (obj instanceof Solid && obj.corners) {
           this._rotate.segmentStartCorners = obj.corners.map(c => c.clone())
+          this._rotate.segStartCfPoses     = this._snapshotChildCfPoses(obj.id)
         } else if (obj instanceof CoordinateFrame) {
           this._rotate.segmentStartRot.copy(obj.rotation)
         }


### PR DESCRIPTION
When a Solid was rotated with R-key (or TC rotate on mobile), child
CoordinateFrames kept their old rotation/translation, so
_updateFastenedFrames() detected no world-pose delta in the target CF
and the fastened Solid B never moved.

Fix: in _applyRotate() and TC objectChange for Solid, apply the same
deltaQ to every direct child CF: `cf.rotation = segStartRot ∘ deltaQ`
and `cf.translation = segStartTrans.applyQuaternion(deltaQ)`.  Both
are snapshotted at operation start (startCfPoses / segStartCfPoses) and
restored on cancel.  SolidRotateCommand now accepts startCfPoses /
endCfPoses so undo/redo correctly restores CF state.

Docs: CODE_CONTRACTS + architecture.md updated; obsolete
"translation-only propagation" limitation note replaced.

https://claude.ai/code/session_01RN5J5CpKiJyCXFG26LxAwj