### PR TITLE
fix: cast localCorners initialiser to LocalVector3[] to resolve TS2322

### DIFF
--- a/src/domain/Solid.js
+++ b/src/domain/Solid.js
@@ -88,7 +88,7 @@ export class Solid {
      * worldCorner[i] = _position + orientation.apply(localCorners[i]).
      * @type {import('../types/spatial.js').LocalVector3[]}
      */
-    this.localCorners = vertices.map(() => new Vector3())
+    this.localCorners = /** @type {import('../types/spatial.js').LocalVector3[]} */ (vertices.map(() => new Vector3()))
 
     // Initialise pose from passed world corners (identity orientation, centroid as origin).
     this._initFromWorldCorners(vertices.map(v => v.position))


### PR DESCRIPTION
`vertices.map(() => new Vector3())` infers `Vector3[]`; tsc --checkJs
rejects the assignment to `LocalVector3[]` (branded type). The JSDoc
cast makes the intent explicit with no runtime overhead, keeping the
coordinate-space safety contract (PHILOSOPHY #21) intact.

https://claude.ai/code/session_01Hrrh7NVb6i95UaZ4oVLuDn