### PR TITLE
fix: normalize quaternions in _updateFastenedFrames to prevent exponential drift

### DIFF
--- a/src/service/SceneService.js
+++ b/src/service/SceneService.js
@@ -1213,11 +1213,11 @@ export class SceneService extends EventEmitter {
         const pivotY = currentEntry.position.y
         const pivotZ = currentEntry.position.z
         const prevQuat = currentEntry.quaternion.clone()
-        const dq = new Quaternion(wqx, wqy, wqz, wqw).multiply(prevQuat.conjugate())
+        const dq = new Quaternion(wqx, wqy, wqz, wqw).multiply(prevQuat.conjugate()).normalize()
 
         // ADR-040: update primary triple; _rebuildWorldCorners() derives the 8 world corners.
         // pivot = source CF world position; newPos = wpx/wpy/wpz (target world pos of source CF).
-        rootSolid.orientation.premultiply(dq)
+        rootSolid.orientation.premultiply(dq).normalize()
         rootSolid._position.sub(new Vector3(pivotX, pivotY, pivotZ)).applyQuaternion(dq).add(new Vector3(wpx, wpy, wpz))
         rootSolid._rebuildWorldCorners()
         rootSolid.meshView.updateGeometry(rootSolid.corners)


### PR DESCRIPTION
Floating-point multiplication accumulates unit-quaternion error each frame.
Without normalization, |orientation| grows as 1.0000001^N — after ~60 frames
the implied scale factor causes _rebuildWorldCorners() to place vertices at
exponentially large distances, making the Solid appear to "fly off screen".

Two normalize() calls are added:
  1. dq: the per-frame delta quaternion (product of two ~unit quaternions)
  2. rootSolid.orientation: after premultiply, to reset accumulated error

This complements the previous fix (skip local-coordinate back-conversion) so
that repeated rotation of a fastened-source CF neither drifts in position nor
explodes in scale.

https://claude.ai/code/session_013APK47bRqLbttC972weX71