### PR TITLE
fix(mobile-toolbar): enforce semantic slot rule — Cancel always left, Confirm always right

### DIFF
--- a/docs/CODE_CONTRACTS.md
+++ b/docs/CODE_CONTRACTS.md
@@ -110,7 +110,7 @@ Detail: `docs/code_contracts/ui_layout.md`
 
 | Rule | Core Takeaway |
 |------|--------------|
-| Mobile Toolbar Stability | Fixed slot counts per mode; use `disabled` + `{spacer: true}` to prevent layout shifts. Solid selected: slot 5 = Rotate (replaces Stack; Stack still accessible via Grab toolbar) |
+| Mobile Toolbar Stability | Fixed slot counts per mode; use `disabled` + `{spacer: true}` to prevent layout shifts. Solid selected: slot 5 = Rotate (replaces Stack; Stack still accessible via Grab toolbar). Semantic slot rule for transient operation bars: slot 1 = Cancel/Back, slot 4 = Confirm — fixed regardless of which operation is active. |
 | Mobile Touch Gesture Model | Touch: tap=select, one-finger-drag=orbit, long-press=context menu; no rect selection or _objDragging |
 | Long-Press Context Menu | `showContextMenu()` with Grab/Dup/Rename/Delete; items filtered by entity type |
 | Long-Press for Non-Draggable Entities | CF/MeasureLine/Annotated* early-return must set long-press timer for touch BEFORE returning; without this CF "Link to..." is unreachable on mobile |

--- a/docs/LAYOUT_DESIGN.md
+++ b/docs/LAYOUT_DESIGN.md
@@ -107,13 +107,13 @@ Empty slots are filled with `{spacer: true}` to prevent layout shifts.
 
 | App State | Slot 1 | Slot 2 | Slot 3 | Slot 4 | Slot 5 |
 |-----------|--------|--------|--------|--------|--------|
-| grab.active | ✓ Confirm | Stack | ✕ Cancel | — | — |
+| grab.active | ✕ Cancel | Stack | — | ✓ Confirm | — |
 | faceExtrude.active | ✓ Confirm | ✕ Cancel | — | — | — |
 | **Object Mode** (no selection) | + Add | Edit (disabled) | Delete (disabled) | — | — |
 | **Object Mode** (selection) | + Add | Edit | Delete | — | — |
 | **Object Mode** (Frame selected) | Rotate | Grab | Delete | Add Frame | spacer |
-| Edit · 2D-Sketch | ← Object | Extrude (disabled) | — | — | — |
-| Edit · 2D-Extrude | ✓ Confirm | ✕ Cancel | — | — | — |
+| Edit · 2D-Sketch | ← Object | — | — | Extrude (disabled) | — |
+| Edit · 2D-Extrude | ✕ Cancel | — | — | ✓ Confirm | — |
 | Edit · 3D | ← Object | Vertex | Edge | Face | Extrude (disabled*) |
 
 `*` Extrude is enabled when a face is included in editSelection.

--- a/docs/adr/ADR-024-mobile-toolbar-architecture.md
+++ b/docs/adr/ADR-024-mobile-toolbar-architecture.md
@@ -55,12 +55,16 @@ identical dimensions occupying layout space without being tappable.
 Object mode (generic):      [ Add | Dup | Edit | Delete | Stack ]
 Object mode (Solid):        [ Add | Dup | Edit | Delete | Rotate ]
 Object mode (CoordFrame):   [ Rotate | Grab | Delete | Add Frame | (spacer) ]
-Edit 2D sketch:             [ <- Object | Extrude | (spacer) | (spacer) ]
-Edit 2D extrude:            [ Confirm | Cancel | (spacer) | (spacer) ]
+Edit 2D sketch:             [ <- Object | (spacer) | (spacer) | Extrude ]
+Edit 2D extrude:            [ Cancel | (spacer) | (spacer) | Confirm ]
 Edit 3D:                    [ <- Object | Vertex | Edge | Face ]
-Grab active:                [ Confirm | Stack | Cancel | (spacer) ]
-Rotate active:              [ Confirm | (spacer) | Cancel | (spacer) ]
+Grab active:                [ Cancel | Stack | (spacer) | Confirm ]
+Rotate active:              [ Cancel | (spacer) | (spacer) | Confirm ]
 ```
+
+**Semantic slot rule for transient operation bars**: slot 1 is always Cancel/Back
+(retreat), slot 4 is always Confirm (advance). Slots 2–3 are contextual tools.
+This mapping is fixed regardless of which operation is active, enabling muscle memory.
 
 **Solid exception**: when a Solid is selected, slot 5 shows Rotate instead of Stack.
 Stack mode is still accessible via the Grab-active toolbar after starting a grab.
@@ -124,7 +128,7 @@ mobile; `_setInfoText()` is a no-op on mobile.
 Phase 3 plans to add X/Y/Z axis constraint buttons during Grab active
 (see ROADMAP Phase 3). This will expand Grab active to 5 slots:
 ```
-Grab active (Phase 3):   [ Confirm | X | Y | Z | Cancel ]
+Grab active (Phase 3):   [ Cancel | X | Y | Z | Confirm ]
 ```
 At that point, review whether Object mode still needs to remain at 5 to maintain the
 "never shrink" invariant, or whether 5 becomes the universal fixed count.

--- a/docs/code_contracts/ui_layout.md
+++ b/docs/code_contracts/ui_layout.md
@@ -22,6 +22,47 @@ Detail file for `docs/CODE_CONTRACTS.md` Section 3.
 
 **Semantic slot rule (transient operation bars)**: Slot 1 is always Cancel/Back (retreat). Slot 4 is always Confirm (advance). Slots 2–3 are contextual tools. This fixed semantic mapping enables muscle memory — users always tap the same corner to abandon or commit an operation, regardless of what operation is active.
 
+### Why sequential (pack-left) mapping is forbidden
+
+3D modelling operations demand high visual attention on the canvas preview. When a user's eyes are tracking a grab position or rotation angle, they cannot afford to scan the toolbar to locate Cancel or Confirm. If those buttons shift position because a different operation has one fewer contextual tool, every operation becomes a visual search task.
+
+The forbidden anti-pattern is **sequential mapping**: filling slots left-to-right with only the available buttons, so the slot count drops when fewer actions are relevant. This makes Cancel appear at index 0 in Measure mode but at index 2 in Rotate mode — breaking muscle memory silently.
+
+The correct pattern is **semantic mapping**: slot semantics are fixed for the entire category of transient operation bars, regardless of how many contextual tools the current operation needs. Missing actions become spacers, never position shifts.
+
+### Transient operation bar — 4-slot layout contract
+
+All states that interrupt Object mode (Grab, Rotate, Edit-extrude, Edit-sketch, Measure, Frame-placement, Map) use a **4-slot bar**. The semantic assignment is:
+
+| Index | Role | Visual treatment |
+|-------|------|-----------------|
+| **0** (leftmost) | **Cancel / Back** — always retreat | `danger: true` |
+| **1** | Contextual tool A | `active` reflects toggle state |
+| **2** | Contextual tool B | `active` reflects toggle state |
+| **3** (rightmost) | **Confirm / Advance** — always commit | default style |
+
+When no contextual tool is needed, use `{ spacer: true }` at slots 1 and/or 2. Never omit the slot — omission causes index shift.
+
+```js
+// ❌ forbidden — Cancel moves from index 0 to index 1 when a contextual tool is absent
+this._uiView.setMobileToolbar([
+  { icon: ICONS.confirm, label: 'Confirm', onClick: () => this._confirm() },
+  { icon: ICONS.cancel,  label: 'Cancel',  onClick: () => this._cancel(), danger: true },
+])
+
+// ✓ correct — semantic positions are fixed; absent tools become spacers
+this._uiView.setMobileToolbar([
+  { icon: ICONS.cancel,  label: 'Cancel',  onClick: () => this._cancel(), danger: true }, // [0] always
+  { spacer: true },                                                                         // [1] unused
+  { spacer: true },                                                                         // [2] unused
+  { icon: ICONS.confirm, label: 'Confirm', onClick: () => this._confirm() },               // [3] always
+])
+```
+
+Object mode is a **5-slot home state** with different semantics (Add / Dup / Edit / Delete / Rotate-or-Stack) — it does not follow the 4-slot transient rule.
+
+**Future Phase 3** (axis-constraint buttons during Grab) will expand the Grab bar to 5 slots: `[ Cancel | X | Y | Z | Confirm ]`. The semantic corners (Cancel = leftmost, Confirm = rightmost) are preserved even when slots are added in the middle.
+
 `{ spacer: true }` renders as a `visibility: hidden` div of identical dimensions. It occupies layout space without being tappable.
 
 Dup, Edit, and Stack are disabled for `ImportedMesh`, `MeasureLine`, and `CoordinateFrame`. Dup is additionally disabled for `Profile`. Delete remains enabled for all object types. All Object-mode slots maintain consistent disabled states so slot positions never shift.

--- a/docs/code_contracts/ui_layout.md
+++ b/docs/code_contracts/ui_layout.md
@@ -14,11 +14,13 @@ Detail file for `docs/CODE_CONTRACTS.md` Section 3.
 | Object (generic) | Add | Dup | Edit | Delete | Stack |
 | Object (Solid selected) | Add | Dup | Edit | Delete | Rotate |
 | Object (CoordinateFrame selected) | Rotate | Grab | Delete | Add Frame | *(spacer)* |
-| Edit 2D sketch | <- Object | Extrude | *(spacer)* | *(spacer)* | — |
-| Edit 2D extrude | Confirm | Cancel | *(spacer)* | *(spacer)* | — |
+| Edit 2D sketch | <- Object | *(spacer)* | *(spacer)* | Extrude | — |
+| Edit 2D extrude | Cancel | *(spacer)* | *(spacer)* | Confirm | — |
 | Edit 3D | <- Object | Vertex | Edge | Face | — |
-| Grab active | Confirm | Stack | Cancel | *(spacer)* | — |
-| Rotate active | Confirm | *(spacer)* | Cancel | *(spacer)* | — |
+| Grab active | Cancel | Stack | *(spacer)* | Confirm | — |
+| Rotate active | Cancel | *(spacer)* | *(spacer)* | Confirm | — |
+
+**Semantic slot rule (transient operation bars)**: Slot 1 is always Cancel/Back (retreat). Slot 4 is always Confirm (advance). Slots 2–3 are contextual tools. This fixed semantic mapping enables muscle memory — users always tap the same corner to abandon or commit an operation, regardless of what operation is active.
 
 `{ spacer: true }` renders as a `visibility: hidden` div of identical dimensions. It occupies layout space without being tappable.
 

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -3516,20 +3516,20 @@ export class AppController {
 
     if (this._opState.is(S_ROTATE_ACTIVE)) {
       this._uiView.setMobileToolbar([
-        { icon: ICONS.confirm, label: 'Confirm', onClick: () => this._confirmRotate() },
-        { spacer: true },
         { icon: ICONS.cancel,  label: 'Cancel',  onClick: () => this._cancelRotate(), danger: true },
         { spacer: true },
+        { spacer: true },
+        { icon: ICONS.confirm, label: 'Confirm', onClick: () => this._confirmRotate() },
       ])
       return
     }
 
     if (this._opState.is(S_GRAB_ACTIVE)) {
       this._uiView.setMobileToolbar([
-        { icon: ICONS.confirm, label: 'Confirm', onClick: () => this._confirmGrab() },
-        { icon: ICONS.stack,   label: 'Stack',   onClick: () => this._toggleStackMode(), active: this._grab.stackMode },
         { icon: ICONS.cancel,  label: 'Cancel',  onClick: () => this._cancelGrab(), danger: true },
+        { icon: ICONS.stack,   label: 'Stack',   onClick: () => this._toggleStackMode(), active: this._grab.stackMode },
         { spacer: true },
+        { icon: ICONS.confirm, label: 'Confirm', onClick: () => this._confirmGrab() },
       ])
       return
     }
@@ -3623,19 +3623,19 @@ export class AppController {
          Math.abs(this._sketch.p2.y - this._sketch.p1.y) > 0.01)
       this._uiView.setMobileToolbar([
         { icon: ICONS.back,    label: 'Object',  onClick: () => this.setMode('object') },
+        { spacer: true },
+        { spacer: true },
         { icon: ICONS.extrude, label: 'Extrude', onClick: () => this._enterExtrudePhase(), disabled: !hasRect },
-        { spacer: true },
-        { spacer: true },
       ])
       return
     }
 
     if (substate === '2d-extrude') {
       this._uiView.setMobileToolbar([
-        { icon: ICONS.confirm, label: 'Confirm', onClick: () => this._confirmExtrudePhase() },
         { icon: ICONS.cancel,  label: 'Cancel',  onClick: () => this._cancelExtrudePhase(), danger: true },
         { spacer: true },
         { spacer: true },
+        { icon: ICONS.confirm, label: 'Confirm', onClick: () => this._confirmExtrudePhase() },
       ])
       return
     }


### PR DESCRIPTION
Transient operation bars (Grab, Rotate, Edit extrude, Edit sketch) previously
placed Confirm and Cancel at inconsistent positions across states, forcing users
to visually locate buttons on every state transition instead of relying on muscle
memory.

Fixed mapping for all 4-slot operation bars:
  slot 1 = Cancel/Back  (retreat, always leftmost)
  slot 4 = Confirm      (advance, always rightmost)
  slots 2–3 = contextual tools (Stack, etc.)

States changed:
- S_ROTATE_ACTIVE:  [Confirm, sp, Cancel, sp] → [Cancel, sp, sp, Confirm]
- S_GRAB_ACTIVE:    [Confirm, Stack, Cancel, sp] → [Cancel, Stack, sp, Confirm]
- Edit 2d-extrude:  [Confirm, Cancel, sp, sp] → [Cancel, sp, sp, Confirm]
- Edit 2d-sketch:   [Back, Extrude, sp, sp] → [Back, sp, sp, Extrude]

Updated docs: CODE_CONTRACTS, LAYOUT_DESIGN, ADR-024, code_contracts/ui_layout.md

https://claude.ai/code/session_01LRuu22y85L7SPXSBwHowjQ