### PR TITLE
refactor(state-pattern): Phase 5 — migrate _sketch.drawing, _objDragging, _rectSel.active to FSM

### DIFF
--- a/docs/STATE_TRANSITIONS.md
+++ b/docs/STATE_TRANSITIONS.md
@@ -995,11 +995,10 @@ convention used in the project's robotics integration context.
 ### Edit Mode — Operation States (`_editOpState`)
 
 **Status**: Implemented — `AppController._editOpState` (`new StateMachine(EO_IDLE, [...])`)
-**Handler classes**: `src/core/states/EndpointDragState.js`
-**State constants**: `EO_IDLE`, `EO_1D_DRAG` in `src/core/editorStates.js`
+**Handler classes**: `src/core/states/EndpointDragState.js`, `src/core/states/SketchDrawState.js`
+**State constants**: `EO_IDLE`, `EO_1D_DRAG`, `EO_2D_SKETCH_DRAW` in `src/core/editorStates.js`
 
 Parallel FSM to `_opState`, scoped to operations within Edit Mode.
-Structured to accept future edit-mode operations (vertex grab, face-normal move, etc.).
 
 ```json
 {
@@ -1013,6 +1012,14 @@ Structured to accept future edit-mode operations (vertex grab, face-normal move,
         "orbitEnabled": false,
         "cursor": "grabbing",
         "handler": "EndpointDragState"
+      }
+    },
+    "EO_2D_SKETCH_DRAW": {
+      "outputs": {
+        "editDragActive": true,
+        "orbitEnabled": false,
+        "cursor": "crosshair",
+        "handler": "SketchDrawState"
       }
     }
   },
@@ -1048,7 +1055,48 @@ Structured to accept future edit-mode operations (vertex grab, face-normal move,
         "EndpointDragState.cancel": "call() → restore original corners",
         "controls.enabled": true
       }
+    },
+    {
+      "from": "EO_IDLE",
+      "to": "EO_2D_SKETCH_DRAW",
+      "event": "pointerDown_onGroundPlane",
+      "guard": [["editSubstate === '2d-sketch'", "groundPlane ray-hit succeeded"]],
+      "actions": {
+        "SketchDrawState.enter": "call() → sets sketch.p1/p2, disables controls",
+        "controls.enabled": false
+      }
+    },
+    {
+      "from": "EO_2D_SKETCH_DRAW",
+      "to": "EO_IDLE",
+      "event": "pointerUp",
+      "guard": [["activeDragPointerId === e.pointerId"]],
+      "actions": {
+        "SketchDrawState.confirm": "call() → obj.setRect() if rect large enough",
+        "controls.enabled": true
+      }
+    },
+    {
+      "from": "EO_2D_SKETCH_DRAW",
+      "to": "EO_IDLE",
+      "event": "cancelEditMode",
+      "guard": [],
+      "actions": {
+        "SketchDrawState.cancel": "call() → clears sketch.p1/p2",
+        "controls.enabled": true
+      }
     }
   ]
 }
 ```
+
+### Object Mode — Quick Drag and Rectangle Selection (`_opState` extensions)
+
+`S_QUICK_DRAG` and `S_RECT_SELECT` are appended to the same `_opState` machine (source of truth: `AppController._opState`).
+
+| State | Entry event | Confirm event | Cancel event | Handler class |
+|---|---|---|---|---|
+| `S_QUICK_DRAG` | `BEGIN_QUICK_DRAG` on pointerdown hitting an object (mouse only) | `CONFIRM` on pointerup | `CANCEL` on mode exit | `QuickDragState` |
+| `S_RECT_SELECT` | `BEGIN_RECT_SELECT` on pointerdown on empty space (mouse only) | `CONFIRM` on pointerup | `CANCEL` on second touch / mode exit | `RectSelectState` |
+
+**Handler files**: `src/core/states/QuickDragState.js`, `src/core/states/RectSelectState.js`

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -60,9 +60,13 @@ import {
   S_OBJECT_IDLE, S_GRAB_ACTIVE, S_ROTATE_ACTIVE,
   S_FACE_EXTRUDE, S_MEASURE_PLACING, S_LINK_MODE,
   S_FRAME_PLACEMENT, S_MOUNT_PICKING,
-  EO_IDLE, EO_1D_DRAG,
+  S_QUICK_DRAG, S_RECT_SELECT,
+  EO_IDLE, EO_1D_DRAG, EO_2D_SKETCH_DRAW,
 } from '../core/editorStates.js'
 import { EndpointDragState } from '../core/states/EndpointDragState.js'
+import { SketchDrawState }   from '../core/states/SketchDrawState.js'
+import { QuickDragState }    from '../core/states/QuickDragState.js'
+import { RectSelectState }   from '../core/states/RectSelectState.js'
 
 // ── Module-level helpers ──────────────────────────────────────────────────────
 
@@ -302,6 +306,14 @@ export class AppController {
       { from: S_OBJECT_IDLE,    on: 'BEGIN_MOUNT_PICKING',     to: S_MOUNT_PICKING },
       { from: S_MOUNT_PICKING,  on: 'CONFIRM',                 to: S_OBJECT_IDLE },
       { from: S_MOUNT_PICKING,  on: 'CANCEL',                  to: S_OBJECT_IDLE },
+
+      { from: S_OBJECT_IDLE,   on: 'BEGIN_QUICK_DRAG',        to: S_QUICK_DRAG },
+      { from: S_QUICK_DRAG,    on: 'CONFIRM',                  to: S_OBJECT_IDLE },
+      { from: S_QUICK_DRAG,    on: 'CANCEL',                   to: S_OBJECT_IDLE },
+
+      { from: S_OBJECT_IDLE,   on: 'BEGIN_RECT_SELECT',       to: S_RECT_SELECT },
+      { from: S_RECT_SELECT,   on: 'CONFIRM',                  to: S_OBJECT_IDLE },
+      { from: S_RECT_SELECT,   on: 'CANCEL',                   to: S_OBJECT_IDLE },
     ])
 
     // ── Mount picking state (ADR-032 Phase H-6, Mobile) ──────────────────
@@ -369,8 +381,9 @@ export class AppController {
     }
 
     // ── Sketch drawing state (Edit Mode · 2D) ──────────────────────────────
+    // drawing flag removed — EO_2D_SKETCH_DRAW state in _editOpState is the authority.
+    // p1/p2 are kept here (vs. inside SketchDrawState) so _enterExtrudePhase can read them.
     this._sketch = {
-      drawing: false,
       p1: null,  // THREE.Vector3 ground-plane point
       p2: null,  // THREE.Vector3 ground-plane point
     }
@@ -387,8 +400,7 @@ export class AppController {
 
     // ── Object mode state ──────────────────────────────────────────────────
     this._objSelected           = false
-    this._objDragging           = false
-    this._objCtrlDrag           = false
+    this._objCtrlDrag           = false  // true during Ctrl+drag rotate within S_QUICK_DRAG
     this._objDragPlane          = new THREE.Plane()
     this._objDragStart          = new THREE.Vector3()
     this._objDragStartCorners   = []
@@ -432,11 +444,18 @@ export class AppController {
     // Mirrors _opState but scoped to Edit Mode. Currently covers 1D endpoint
     // drag; structured for future edit-mode operations (vertex grab, etc.).
     this._editOpState = new StateMachine(EO_IDLE, [
-      { from: EO_IDLE,    on: 'BEGIN_1D_DRAG', to: EO_1D_DRAG },
-      { from: EO_1D_DRAG, on: 'CONFIRM',       to: EO_IDLE },
-      { from: EO_1D_DRAG, on: 'CANCEL',        to: EO_IDLE },
+      { from: EO_IDLE,           on: 'BEGIN_1D_DRAG',    to: EO_1D_DRAG },
+      { from: EO_1D_DRAG,        on: 'CONFIRM',          to: EO_IDLE },
+      { from: EO_1D_DRAG,        on: 'CANCEL',           to: EO_IDLE },
+
+      { from: EO_IDLE,           on: 'BEGIN_2D_SKETCH',  to: EO_2D_SKETCH_DRAW },
+      { from: EO_2D_SKETCH_DRAW, on: 'CONFIRM',          to: EO_IDLE },
+      { from: EO_2D_SKETCH_DRAW, on: 'CANCEL',           to: EO_IDLE },
     ])
-    this._endpointDragHandler = new EndpointDragState()
+    this._endpointDragHandler  = new EndpointDragState()
+    this._sketchDrawHandler    = new SketchDrawState()
+    this._quickDragHandler     = new QuickDragState()
+    this._rectSelHandler       = new RectSelectState()
 
     // ── Face extrude state (Edit Mode · 3D, E key) ─────────────────────────
     // Active state tracked by this._opState (S_FACE_EXTRUDE).
@@ -813,14 +832,79 @@ export class AppController {
   /** Minimal context object passed to Edit Mode operation state handlers. */
   get _editCtx() {
     return {
-      obj:          this._activeObj,
-      camera:       this._camera,
-      mouse:        this._mouse,
-      raycaster:    this._raycaster,
-      controls:     this._controls,
-      commandStack: this._commandStack,
-      scene:        this._scene,
-      sceneService: this._service,
+      obj:                   this._activeObj,
+      camera:                this._camera,
+      mouse:                 this._mouse,
+      raycaster:             this._raycaster,
+      controls:              this._controls,
+      commandStack:          this._commandStack,
+      scene:                 this._scene,
+      sceneService:          this._service,
+      // Extended for SketchDrawState:
+      groundPlane:           this._groundPlane,
+      sketch:                this._sketch,
+      meshView:              this._meshView,
+      uiView:                this._uiView,
+      onMobileToolbarUpdate: () => this._updateMobileToolbar(),
+    }
+  }
+
+  get _quickDragCtx() {
+    return {
+      controls: this._controls,
+      uiView:   this._uiView,
+      applyMove: (e) => {
+        if (this._objCtrlDrag) {
+          const angle = (e.clientX - this._objRotateStartX) * 0.01
+          const quat  = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 0, 1), angle)
+          const obj   = this._activeObj
+          if (obj instanceof Solid && this._objRotateStartOrientation) {
+            obj.rotate(this._objRotateStartOrientation, this._objRotateStartPos, this._objRotateCentroid, quat)
+            obj.meshView.updateGeometry(obj.corners)
+          } else {
+            this._objRotateStartCorners.forEach((c, i) => {
+              this._corners[i].copy(c).sub(this._objRotateCentroid).applyQuaternion(quat).add(this._objRotateCentroid)
+            })
+            this._meshView.updateGeometry(this._corners)
+          }
+          if (this._objSelected) this._meshView.updateBoxHelper()
+        } else {
+          this._raycaster.setFromCamera(this._mouse, this._camera)
+          const pt = new THREE.Vector3()
+          if (this._raycaster.ray.intersectPlane(this._objDragPlane, pt)) {
+            const delta = pt.clone().sub(this._objDragStart)
+            this._service.applyPreviewTranslation(
+              this._objDragAllStartCorners,
+              this._objDragAllStartPositions,
+              delta,
+            )
+            if (this._grab.stackMode) {
+              this._applyStackSnap(this._objDragAllStartPositions, delta)
+              for (const [id] of this._objDragAllStartCorners) {
+                const selObj = this._scene.getObject(id)
+                if (selObj) {
+                  selObj.meshView.updateGeometry(selObj.corners)
+                  selObj.meshView.updateBoxHelper()
+                }
+              }
+            }
+          }
+        }
+      },
+      finish: () => {
+        this._uiView.setCursor(this._hitAnyObject() ? 'pointer' : 'default')
+        this._updateNPanel()
+      },
+    }
+  }
+
+  get _rectSelCtx() {
+    return {
+      controls:      this._controls,
+      rectSel:       this._rectSel,
+      rectSelEl:     this._rectSelEl,
+      updateDisplay: () => this._updateRectSelDisplay(),
+      finalize:      () => this._finalizeRectSelection(),
     }
   }
 
@@ -3832,9 +3916,13 @@ export class AppController {
     if (this._opState.is(S_FACE_EXTRUDE))     this._cancelFaceExtrude()
     if (this._opState.is(S_FRAME_PLACEMENT))  this._cancelFramePickSubMode()
     if (this._opState.is(S_MOUNT_PICKING))    this._cancelMountPicking()
-    if (this._objDragging) {
-      this._objDragging = false
-      this._objCtrlDrag = false
+    if (this._opState.is(S_QUICK_DRAG)) {
+      this._quickDragHandler.cancel(this._quickDragCtx)
+      this._opState.send('CANCEL')
+    }
+    if (this._opState.is(S_RECT_SELECT)) {
+      this._rectSelHandler.cancel(this._rectSelCtx)
+      this._opState.send('CANCEL')
     }
 
     // ── Clear all edit visual state on the current active object ───────────
@@ -3879,7 +3967,6 @@ export class AppController {
       this._detachMobileTransform()  // hide gizmo in Edit mode (no 3D translate there)
       this._clearObjectSelection()
       this._setObjectSelected(false)
-      this._objDragging = false
       if (this._activeObj instanceof Profile) {
         this._enterEditMode2D()
       } else if (this._activeObj instanceof MeasureLine) {
@@ -3892,12 +3979,14 @@ export class AppController {
 
   _cleanupEditSubstate() {
     this._scene.setEditSubstate(null)
-    this._sketch.drawing = false
-    this._sketch.p1 = null
-    this._sketch.p2 = null
     this._extrudePhase.hasInput = false
     this._extrudePhase.inputStr = ''
     this._extrudePhase.height = 0
+    // Cancel any in-progress 2D sketch draw (restores controls, clears p1/p2)
+    if (this._editOpState.is(EO_2D_SKETCH_DRAW)) {
+      this._sketchDrawHandler.cancel(this._editCtx)
+      this._editOpState.send('CANCEL')
+    }
     // Cancel any in-progress endpoint drag (restores original positions)
     if (this._editOpState.is(EO_1D_DRAG)) {
       this._endpointDragHandler.cancel(this._editCtx)
@@ -5539,69 +5628,23 @@ export class AppController {
     }
 
     if (this._scene.selectionMode === 'object') {
-      if (this._rectSel.active) {
-        this._rectSel.currentPx = { x: e.clientX, y: e.clientY }
-        this._updateRectSelDisplay()
+      if (this._opState.is(S_RECT_SELECT)) {
+        this._rectSelHandler.onPointerMove(this._rectSelCtx, e)
         return
       }
-      if (this._objDragging) {
-        if (this._objCtrlDrag) {
-          const angle = (e.clientX - this._objRotateStartX) * 0.01
-          const quat  = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 0, 1), angle)
-          const obj   = this._activeObj
-          if (obj instanceof Solid && this._objRotateStartOrientation) {
-            // ADR-040: use primary triple API — Solid.rotate() updates _position, orientation,
-            // localCorners, and world corners in one snapshot-based call (no direct mutation).
-            obj.rotate(this._objRotateStartOrientation, this._objRotateStartPos, this._objRotateCentroid, quat)
-            obj.meshView.updateGeometry(obj.corners)
-          } else {
-            this._objRotateStartCorners.forEach((c, i) => {
-              this._corners[i].copy(c).sub(this._objRotateCentroid).applyQuaternion(quat).add(this._objRotateCentroid)
-            })
-            this._meshView.updateGeometry(this._corners)
-          }
-          if (this._objSelected) this._meshView.updateBoxHelper()
-        } else {
-          this._raycaster.setFromCamera(this._mouse, this._camera)
-          const pt = new THREE.Vector3()
-          if (this._raycaster.ray.intersectPlane(this._objDragPlane, pt)) {
-            const delta = pt.clone().sub(this._objDragStart)
-            this._service.applyPreviewTranslation(
-              this._objDragAllStartCorners,
-              this._objDragAllStartPositions,
-              delta,
-            )
-            // Stack snap: after XY movement, adjust Z so the object rests on
-            // the highest surface directly below it (same logic as _grab path).
-            if (this._grab.stackMode) {
-              this._applyStackSnap(this._objDragAllStartPositions, delta)
-              // Re-update views after stack snap re-applied domain mutations.
-              for (const [id] of this._objDragAllStartCorners) {
-                const selObj = this._scene.getObject(id)
-                if (selObj) {
-                  selObj.meshView.updateGeometry(selObj.corners)
-                  selObj.meshView.updateBoxHelper()
-                }
-              }
-            }
-          }
-        }
+      if (this._opState.is(S_QUICK_DRAG)) {
+        this._quickDragHandler.onPointerMove(this._quickDragCtx, e)
         this._updateNPanel()
-      } else {
-        this._uiView.setCursor((this._hitAnyObject() || this._hitAnyAnnotation()) ? 'pointer' : 'default')
+        return
       }
+      this._uiView.setCursor((this._hitAnyObject() || this._hitAnyAnnotation()) ? 'pointer' : 'default')
       return
     }
 
     // ── Edit mode · 2D sketch ─────────────────────────────────────────────
     if (this._scene.editSubstate === '2d-sketch') {
-      if (this._sketch.drawing) {
-        const pt = new THREE.Vector3()
-        this._raycaster.setFromCamera(this._mouse, this._camera)
-        if (this._raycaster.ray.intersectPlane(this._groundPlane, pt)) {
-          this._sketch.p2 = pt.clone()
-          this._meshView.showSketchRect(this._sketch.p1, this._sketch.p2)
-        }
+      if (this._editOpState.is(EO_2D_SKETCH_DRAW)) {
+        this._sketchDrawHandler.onPointerMove(this._editCtx)
       }
       return
     }
@@ -5751,9 +5794,9 @@ export class AppController {
     if (this._activeDragPointerId !== null && e.pointerType === 'touch') {
       // Second finger while rect selection is active: cancel rect sel so
       // OrbitControls can handle the two-finger orbit/dolly gesture.
-      if (this._rectSel.active) {
-        this._rectSel.active = false
-        this._rectSelEl.style.display = 'none'
+      if (this._opState.is(S_RECT_SELECT)) {
+        this._rectSelHandler.cancel(this._rectSelCtx)
+        this._opState.send('CANCEL')
         this._activeDragPointerId = null
       }
       return
@@ -6037,14 +6080,13 @@ export class AppController {
 
     // ── Sketch drawing ────────────────────────────────────────────────────
     if (this._scene.editSubstate === '2d-sketch') {
-      const pt = new THREE.Vector3()
-      this._raycaster.setFromCamera(this._mouse, this._camera)
-      if (this._raycaster.ray.intersectPlane(this._groundPlane, pt)) {
-        this._sketch.drawing = true
-        this._sketch.p1 = pt.clone()
-        this._sketch.p2 = pt.clone()
-        this._controls.enabled = false
-        this._activeDragPointerId = e.pointerId
+      if (this._editOpState.send('BEGIN_2D_SKETCH')) {
+        if (this._sketchDrawHandler.enter(this._editCtx)) {
+          this._activeDragPointerId = e.pointerId
+        } else {
+          // Ground plane not hit — roll back FSM immediately
+          this._editOpState.send('CANCEL')
+        }
       }
       return
     }
@@ -6160,12 +6202,8 @@ export class AppController {
           }
         }
 
-        this._objDragging      = true
         // Ctrl+drag (rotate) only works for locally-editable objects (Cuboid).
-        this._objCtrlDrag      = e.ctrlKey && !(obj instanceof ImportedMesh) && !(obj instanceof MeasureLine) && !(obj instanceof CoordinateFrame)
-        this._controls.enabled = false
-        this._activeDragPointerId = e.pointerId
-        this._uiView.setCursor('grabbing')
+        this._objCtrlDrag = e.ctrlKey && !(obj instanceof ImportedMesh) && !(obj instanceof MeasureLine) && !(obj instanceof CoordinateFrame)
 
         const camDir = new THREE.Vector3()
         this._camera.getWorldDirection(camDir)
@@ -6186,6 +6224,11 @@ export class AppController {
             this._objRotateStartCorners = this._corners.map(c => c.clone())
           }
         }
+
+        if (this._opState.send('BEGIN_QUICK_DRAG')) {
+          this._quickDragHandler.enter(this._quickDragCtx)
+          this._activeDragPointerId = e.pointerId
+        }
       } else {
         // No object hit: touch tap → deselect; desktop → start rectangle selection.
         // If TC already claimed this pointer (arrow outside Solid bounds), its own
@@ -6201,10 +6244,10 @@ export class AppController {
         }
         // Do NOT disable _controls here: orbit (right-click / two-finger) uses
         // separate buttons/fingers and must remain available simultaneously.
-        this._rectSel.active    = true
-        this._rectSel.startPx   = { x: e.clientX, y: e.clientY }
-        this._rectSel.currentPx = { x: e.clientX, y: e.clientY }
-        this._activeDragPointerId = e.pointerId
+        if (this._opState.send('BEGIN_RECT_SELECT')) {
+          this._rectSelHandler.enter(this._rectSelCtx, e)
+          this._activeDragPointerId = e.pointerId
+        }
       }
       return
     }
@@ -6381,41 +6424,20 @@ export class AppController {
       if (wasDragging) this._confirmFaceExtrude()
       return
     }
-    if (this._sketch.drawing) {
-      this._sketch.drawing = false
-      this._controls.enabled = true
-      // Save rect to object
-      if (this._sketch.p1 && this._sketch.p2) {
-        const obj = this._activeObj
-        if (obj) {
-          const dx = Math.abs(this._sketch.p2.x - this._sketch.p1.x)
-          const dy = Math.abs(this._sketch.p2.y - this._sketch.p1.y)
-          if (dx > 0.01 || dy > 0.01) {
-            obj.setRect(this._sketch.p1, this._sketch.p2)
-            this._uiView.setStatusRich([
-              { text: 'Sketch', bold: true, color: '#4fc3f7' },
-              { text: 'Press Enter to extrude · Drag to redraw', color: '#888' },
-            ])
-            this._updateMobileToolbar()
-          }
-        }
-      }
+    if (this._editOpState.is(EO_2D_SKETCH_DRAW) && wasDragging) {
+      this._sketchDrawHandler.confirm(this._editCtx)
+      this._editOpState.send('CONFIRM')
       return
     }
-    if (this._rectSel.active) {
-      this._rectSel.active = false
-      this._rectSelEl.style.display = 'none'
-      this._controls.enabled = true
-      this._finalizeRectSelection()
+    if (this._opState.is(S_RECT_SELECT) && wasDragging) {
+      this._rectSelHandler.confirm(this._rectSelCtx)
+      this._opState.send('CONFIRM')
       return
     }
-    if (this._objDragging) {
-      this._objDragging  = false
-      this._objCtrlDrag  = false
-      this._controls.enabled = true
-      this._activeDragPointerId = null
-      this._uiView.setCursor(this._hitAnyObject() ? 'pointer' : 'default')
-      this._updateNPanel()
+    if (this._opState.is(S_QUICK_DRAG) && wasDragging) {
+      this._objCtrlDrag = false
+      this._quickDragHandler.confirm(this._quickDragCtx)
+      this._opState.send('CONFIRM')
     }
   }
 

--- a/src/core/editorStates.js
+++ b/src/core/editorStates.js
@@ -17,6 +17,8 @@ export const S_MEASURE_PLACING  = 'S_MEASURE_PLACING'
 export const S_LINK_MODE        = 'S_LINK_MODE'
 export const S_FRAME_PLACEMENT  = 'S_FRAME_PLACEMENT'
 export const S_MOUNT_PICKING    = 'S_MOUNT_PICKING'
+export const S_QUICK_DRAG       = 'S_QUICK_DRAG'    // direct mouse-drag on selected object
+export const S_RECT_SELECT      = 'S_RECT_SELECT'   // rubber-band rectangle selection
 
 // ── Edit Mode substates (SceneModel._editSubstate) ───────────────────────────
 export const ES_3D         = '3d'
@@ -26,9 +28,9 @@ export const ES_1D         = '1d'
 
 // ── Edit Mode operation FSM (AppController._editOpState) ─────────────────────
 // Parallel to _opState but scoped to operations within Edit Mode.
-// Currently covers 1D endpoint drag; structured for future Edit ops (vertex grab, etc.).
-export const EO_IDLE    = 'EO_IDLE'    // no edit operation in progress
-export const EO_1D_DRAG = 'EO_1D_DRAG' // endpoint drag (MeasureLine 1D Edit Mode)
+export const EO_IDLE          = 'EO_IDLE'          // no edit operation in progress
+export const EO_1D_DRAG       = 'EO_1D_DRAG'       // endpoint drag (MeasureLine 1D Edit Mode)
+export const EO_2D_SKETCH_DRAW = 'EO_2D_SKETCH_DRAW' // rectangle sketch drag (Profile 2D Edit Mode)
 
 // ── Map Mode draw states (_mapMode.drawState) ────────────────────────────────
 export const DS_IDLE    = 'idle'

--- a/src/core/states/QuickDragState.js
+++ b/src/core/states/QuickDragState.js
@@ -1,0 +1,41 @@
+/**
+ * Object Mode operation handler for direct mouse-drag on a selected object.
+ * Covers both plain translate-drag and Ctrl+drag (in-plane rotation).
+ *
+ * Lifecycle:
+ *   enter()       — pointerdown on object; disables OrbitControls and sets cursor
+ *   onPointerMove — pointermove; delegates move/rotate computation to ctx.applyMove
+ *   confirm()     — pointerup; re-enables controls and finalises via ctx.finish
+ *   cancel()      — mode exit; re-enables controls
+ *
+ * Called by AppController when _opState is S_QUICK_DRAG.
+ * All drag-plane and snapshot state stays on AppController; this class is a thin
+ * lifecycle coordinator that enforces the FSM boundary.
+ *
+ * ctx shape:
+ *   controls, uiView, applyMove(e), finish()
+ */
+export class QuickDragState {
+  /** @param {object} ctx */
+  enter(ctx) {
+    ctx.controls.enabled = false
+    ctx.uiView.setCursor('grabbing')
+  }
+
+  /** @param {object} ctx  @param {PointerEvent} e */
+  onPointerMove(ctx, e) {
+    ctx.applyMove(e)
+  }
+
+  /** @param {object} ctx */
+  confirm(ctx) {
+    ctx.controls.enabled = true
+    ctx.finish()
+  }
+
+  /** @param {object} ctx */
+  cancel(ctx) {
+    ctx.controls.enabled = true
+    ctx.uiView.setCursor('default')
+  }
+}

--- a/src/core/states/RectSelectState.js
+++ b/src/core/states/RectSelectState.js
@@ -1,0 +1,42 @@
+/**
+ * Object Mode operation handler for rubber-band rectangle selection.
+ *
+ * Lifecycle:
+ *   enter()       — pointerdown on empty space; records start pixel position
+ *   onPointerMove — pointermove; updates current pixel and refreshes overlay
+ *   confirm()     — pointerup; hides overlay and finalises selection
+ *   cancel()      — second finger on touch / mode exit; hides overlay and aborts
+ *
+ * Called by AppController when _opState is S_RECT_SELECT.
+ * The rectSel data object and the overlay element remain on AppController;
+ * this class drives the lifecycle via ctx callbacks.
+ *
+ * ctx shape:
+ *   controls, rectSel, rectSelEl, updateDisplay(), finalize()
+ */
+export class RectSelectState {
+  /** @param {object} ctx  @param {PointerEvent} e */
+  enter(ctx, e) {
+    ctx.rectSel.startPx   = { x: e.clientX, y: e.clientY }
+    ctx.rectSel.currentPx = { x: e.clientX, y: e.clientY }
+  }
+
+  /** @param {object} ctx  @param {PointerEvent} e */
+  onPointerMove(ctx, e) {
+    ctx.rectSel.currentPx = { x: e.clientX, y: e.clientY }
+    ctx.updateDisplay()
+  }
+
+  /** @param {object} ctx */
+  confirm(ctx) {
+    ctx.rectSelEl.style.display = 'none'
+    ctx.controls.enabled        = true
+    ctx.finalize()
+  }
+
+  /** @param {object} ctx */
+  cancel(ctx) {
+    ctx.rectSelEl.style.display = 'none'
+    ctx.controls.enabled        = true
+  }
+}

--- a/src/core/states/SketchDrawState.js
+++ b/src/core/states/SketchDrawState.js
@@ -1,0 +1,75 @@
+/**
+ * Edit Mode operation handler for 2D sketch rectangle drawing (Profile Edit Mode).
+ *
+ * Lifecycle matches the three-phase contract from ADR-039:
+ *
+ *   enter()       — pointerdown on ground plane; records p1/p2 start point
+ *   onPointerMove — pointermove; updates p2 and sketch rect preview
+ *   confirm()     — pointerup; calls obj.setRect() if rect is large enough,
+ *                   leaves p1/p2 intact for _enterExtrudePhase
+ *   cancel()      — mode exit / cleanup; clears p1/p2
+ *
+ * Called by AppController when _editOpState is EO_2D_SKETCH_DRAW.
+ *
+ * ctx shape (superset of _editCtx):
+ *   obj, camera, mouse, raycaster, controls, groundPlane, sketch, meshView, uiView,
+ *   onMobileToolbarUpdate
+ */
+import * as THREE from 'three'
+
+export class SketchDrawState {
+  /**
+   * @param {object} ctx
+   * @returns {boolean} false if the ground plane was not hit (enter should be aborted)
+   */
+  enter(ctx) {
+    const { mouse, raycaster, camera, groundPlane, controls, sketch } = ctx
+    raycaster.setFromCamera(mouse, camera)
+    const pt = new THREE.Vector3()
+    if (!raycaster.ray.intersectPlane(groundPlane, pt)) return false
+    sketch.p1      = pt.clone()
+    sketch.p2      = pt.clone()
+    controls.enabled = false
+    return true
+  }
+
+  /** @param {object} ctx */
+  onPointerMove(ctx) {
+    const { mouse, raycaster, camera, groundPlane, sketch, meshView } = ctx
+    raycaster.setFromCamera(mouse, camera)
+    const pt = new THREE.Vector3()
+    if (raycaster.ray.intersectPlane(groundPlane, pt)) {
+      sketch.p2 = pt.clone()
+      meshView.showSketchRect(sketch.p1, sketch.p2)
+    }
+  }
+
+  /**
+   * Finalises the sketch rect on the domain object if large enough.
+   * Leaves sketch.p1 / sketch.p2 populated so _enterExtrudePhase can use them.
+   * @param {object} ctx
+   */
+  confirm(ctx) {
+    const { obj, controls, uiView, sketch, onMobileToolbarUpdate } = ctx
+    controls.enabled = true
+    if (!sketch.p1 || !sketch.p2) return
+    const dx = Math.abs(sketch.p2.x - sketch.p1.x)
+    const dy = Math.abs(sketch.p2.y - sketch.p1.y)
+    if (dx > 0.01 || dy > 0.01) {
+      obj.setRect(sketch.p1, sketch.p2)
+      uiView.setStatusRich([
+        { text: 'Sketch', bold: true, color: '#4fc3f7' },
+        { text: 'Press Enter to extrude · Drag to redraw', color: '#888' },
+      ])
+      onMobileToolbarUpdate()
+    }
+  }
+
+  /** @param {object} ctx */
+  cancel(ctx) {
+    const { controls, sketch } = ctx
+    controls.enabled = true
+    sketch.p1 = null
+    sketch.p2 = null
+  }
+}


### PR DESCRIPTION
Eliminates three boolean flag groups from AppController in favour of proper
StateMachine states (ADR-039 follow-up):

• EO_2D_SKETCH_DRAW (_editOpState) — replaces _sketch.drawing.
  SketchDrawState.js owns the enter/onPointerMove/confirm/cancel lifecycle.
  sketch.p1/p2 remain on AppController for _enterExtrudePhase access.

• S_QUICK_DRAG (_opState) — replaces _objDragging + _objCtrlDrag guard.
  QuickDragState.js provides the thin lifecycle boundary; drag-plane
  snapshots and applyMove computation stay in AppController via ctx callbacks
  (_quickDragCtx getter).

• S_RECT_SELECT (_opState) — replaces _rectSel.active.
  RectSelectState.js drives enter/onPointerMove/confirm/cancel; rectSel data
  and overlay element stay on AppController (_rectSelCtx getter).

_editCtx extended with groundPlane, sketch, meshView, uiView,
onMobileToolbarUpdate for SketchDrawState access.
_opState transition table extended with BEGIN_QUICK_DRAG / BEGIN_RECT_SELECT.
_editOpState transition table extended with BEGIN_2D_SKETCH.
_cleanupEditSubstate and setMode() cancel paths updated.
docs/STATE_TRANSITIONS.md §Edit Mode FSM and §Object Mode extensions updated.

https://claude.ai/code/session_01LGUUcupXKiNvhY1L5yVCc7