### PR TITLE
fix(mobile-toolbar): CF selected toolbar — Delete|Move|Rotate fixed slots

### DIFF
--- a/docs/LAYOUT_DESIGN.md
+++ b/docs/LAYOUT_DESIGN.md
@@ -111,7 +111,7 @@ Empty slots are filled with `{spacer: true}` to prevent layout shifts.
 | faceExtrude.active | ✓ Confirm | ✕ Cancel | — | — | — |
 | **Object Mode** (no selection) | + Add | Edit (disabled) | Delete (disabled) | — | — |
 | **Object Mode** (selection) | + Add | Edit | Delete | — | — |
-| **Object Mode** (Frame selected) | Rotate | Grab | Delete | Add Frame | spacer |
+| **Object Mode** (Frame selected) | Delete | Move | Rotate | — | — |
 | Edit · 2D-Sketch | ← Object | — | — | Extrude (disabled) | — |
 | Edit · 2D-Extrude | ✕ Cancel | — | — | ✓ Confirm | — |
 | Edit · 3D | ← Object | Vertex | Edge | Face | Extrude (disabled*) |

--- a/docs/code_contracts/ui_layout.md
+++ b/docs/code_contracts/ui_layout.md
@@ -13,7 +13,7 @@ Detail file for `docs/CODE_CONTRACTS.md` Section 3.
 |------|--------|--------|--------|--------|--------|
 | Object (generic) | Add | Dup | Edit | Delete | Stack |
 | Object (Solid selected) | Add | Dup | Edit | Delete | Rotate |
-| Object (CoordinateFrame selected) | Rotate | Grab | Delete | Add Frame | *(spacer)* |
+| Object (CoordinateFrame selected) | Delete | Move | Rotate | *(spacer)* | *(spacer)* |
 | Edit 2D sketch | <- Object | *(spacer)* | *(spacer)* | Extrude | — |
 | Edit 2D extrude | Cancel | *(spacer)* | *(spacer)* | Confirm | — |
 | Edit 3D | <- Object | Vertex | Edge | Face | — |
@@ -69,7 +69,7 @@ Dup, Edit, and Stack are disabled for `ImportedMesh`, `MeasureLine`, and `Coordi
 
 **Solid exception**: when a Solid is selected, slot 5 shows Rotate instead of Stack. Stack is still available via the Grab-active toolbar after starting a grab.
 
-**CoordinateFrame exception**: when a CoordinateFrame is selected the entire toolbar switches to a specialised 5-slot layout (Rotate|Grab|Delete|Add Frame|spacer) rather than disabling individual generic slots.
+**CoordinateFrame exception**: when a CoordinateFrame is selected the entire toolbar switches to a specialised 5-slot layout `[Delete | Move | Rotate | spacer | spacer]` rather than disabling individual generic slots. Delete is at slot 0 (left edge, matching the destructive-action anchor rule). Move (translate mode) and Rotate are separate buttons at slots 1–2 with `active` highlight reflecting the current TC mode; clicking an already-active mode is a no-op. Slots 3–4 are reserved for future CF-specific tools (e.g. Fasten).
 
 The Object-mode Stack button pre-sets `_grab.stackMode` before a grab gesture. `_startGrab()` does not reset `stackMode`, so the pre-set is respected. `_confirmGrab()` and `_cancelGrab()` reset it to `false` when the grab ends.
 

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -3621,19 +3621,13 @@ export class AppController {
     if (mode === 'object') {
       const hasObj = this._objSelected
 
-      // CoordinateFrame: TC mode toggle | Done | Delete | Add Frame | spacer
+      // CoordinateFrame: Delete | Move | Rotate | spacer | spacer
       if (hasObj && this._activeObj instanceof CoordinateFrame) {
-        const isRotate = this._tcMode === 'rotate'
         this._uiView.setMobileToolbar([
-          {
-            icon:    isRotate ? ICONS.rotate    : ICONS.translate,
-            label:   isRotate ? 'Rotate'        : 'Move',
-            active:  true,  // always highlight current mode
-            onClick: () => this._toggleTcMode(),
-          },
-          { icon: ICONS.confirm, label: 'Done', onClick: () => this._setObjectSelected(false) },
-          { icon: ICONS.delete, label: 'Delete', onClick: () => this._deleteObject(this._scene.activeId), danger: true },
-          { icon: ICONS.frame,  label: 'Add Frame', onClick: () => this._addObject('frame') },
+          { icon: ICONS.delete,    label: 'Delete', onClick: () => this._deleteObject(this._scene.activeId), danger: true },
+          { icon: ICONS.translate, label: 'Move',   onClick: () => { if (this._tcMode !== 'translate') this._toggleTcMode() }, active: this._tcMode === 'translate' },
+          { icon: ICONS.rotate,    label: 'Rotate', onClick: () => { if (this._tcMode !== 'rotate')    this._toggleTcMode() }, active: this._tcMode === 'rotate' },
+          { spacer: true },
           { spacer: true },
         ])
         return


### PR DESCRIPTION
Replace the single Move/Rotate toggle button with two separate buttons at
fixed semantic positions: Delete at slot 0 (left-edge destructive anchor),
Move (translate) at slot 1, Rotate at slot 2, slots 3–4 reserved (spacer).

Previously the toolbar had a single toggle at slot 0 that changed its icon
and label depending on the current TC mode, giving no visual indication of
the mode not selected. The new layout shows both modes simultaneously with
`active` highlight on the current one — clicking an already-active mode
is a no-op.

Also removes the "Done" button (deselect via tap-empty-space) and "Add Frame"
(accessible through the Add menu), freeing slots for future CF tools.

Updates LAYOUT_DESIGN.md and docs/code_contracts/ui_layout.md to match.

https://claude.ai/code/session_01KGTgY13aWYgK1yYpPyFVbg