### PR TITLE
feat: Semantic Select — select all fixed-joint-connected assembly parts

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -3475,6 +3475,12 @@ export class AppController {
         }}]
       : []
 
+    // Show "Select Assembly" only when the object has fixed-joint neighbors
+    const hasFixedNeighbors = this._service.getConnectedAssembly(id).size > 1
+    const assemblyItems = hasFixedNeighbors
+      ? [{ label: 'Select Assembly 🔗', onClick: () => this._selectAssembly() }]
+      : []
+
     const items = [
       {
         label: 'Grab',
@@ -3487,6 +3493,7 @@ export class AppController {
       ...mountItems,
       ...unfastenItems,
       ...linkItems,
+      ...assemblyItems,
       ...(canAddFrame ? [{
         label: 'Add interface frame ⊞',
         onClick: () => this._promptAddFrame(id),
@@ -4393,6 +4400,40 @@ export class AppController {
     this._objSelected = true
     this._refreshObjectModeStatus()
     this._updateNPanel()
+  }
+
+  /**
+   * Selects all entities reachable from the active object via fixed-joint SpatialLinks.
+   * BFS traversal through jointType === 'fixed' edges (Semantic Select / assembly select).
+   * Keyboard: Shift+S  Mobile: long-press context menu "Select Assembly"
+   */
+  _selectAssembly() {
+    if (!this._objSelected || !this._activeObj) return
+    if (this._activeObj instanceof SpatialLink) return
+
+    const startId = this._activeObj.id
+    const assemblyIds = this._service.getConnectedAssembly(startId)
+
+    if (assemblyIds.size <= 1) {
+      this._uiView.showToast('No fixed-linked parts found', { type: 'warn' })
+      return
+    }
+
+    this._clearObjectSelection()
+    for (const id of assemblyIds) {
+      const obj = this._scene.getObject(id)
+      if (!obj?.meshView) continue
+      obj.meshView.setObjectSelected(true)
+      this._setChildFramesVisible(obj.id, true)
+      this._selectedIds.add(id)
+    }
+
+    if (this._scene.activeId !== startId) this._service.setActiveObject(startId)
+    this._objSelected = true
+    this._refreshObjectModeStatus()
+    this._updateNPanel()
+    this._updateMobileToolbar()
+    this._uiView.showToast(`${assemblyIds.size} objects selected`)
   }
 
   // ─── Blender-style grab ────────────────────────────────────────────────────
@@ -6733,6 +6774,12 @@ export class AppController {
           return
         }
         this._startSpatialLinkCreation()
+        return
+      }
+      // Shift+S: select all fixed-joint-connected parts (Semantic Select / assembly select)
+      if (e.key === 'S' && e.shiftKey && this._objSelected) {
+        e.preventDefault()
+        this._selectAssembly()
         return
       }
       // Shift+D: duplicate active object and immediately grab (Blender-style)

--- a/src/service/SceneService.js
+++ b/src/service/SceneService.js
@@ -1890,6 +1890,29 @@ export class SceneService extends EventEmitter {
   }
 
   /**
+   * BFS over jointType === 'fixed' links starting from startEntityId.
+   * Returns all reachable entity IDs including the start entity itself.
+   * @param {string} startEntityId
+   * @returns {Set<string>}
+   */
+  getConnectedAssembly(startEntityId) {
+    const visited = new Set([startEntityId])
+    const queue = [startEntityId]
+    while (queue.length > 0) {
+      const currentId = queue.shift()
+      for (const link of this.getLinksOf(currentId)) {
+        if (link.jointType !== 'fixed') continue
+        const neighborId = link.sourceId === currentId ? link.targetId : link.sourceId
+        if (!visited.has(neighborId)) {
+          visited.add(neighborId)
+          queue.push(neighborId)
+        }
+      }
+    }
+    return visited
+  }
+
+  /**
    * Returns true if the given CoordinateFrame id is the SOURCE of any fastened link.
    * Used by AppController to block independent TC movement of constrained frames.
    * @param {string} cfId


### PR DESCRIPTION
SceneService.getConnectedAssembly(startEntityId) — BFS over jointType === 'fixed'
SpatialLinks; returns Set<string> of all reachable entity IDs including the start.

AppController._selectAssembly() — clears the current multi-selection and replaces
it with every entity in the connected assembly, keeping the original entity as
active. Shows a toast with the count; warns when no fixed-joint neighbors exist.

Entry points:
- Desktop: Shift+S keyboard shortcut (object mode, object selected)
- Mobile:  "Select Assembly 🔗" item in the long-press context menu, shown only
           when the long-pressed object has at least one fixed-joint neighbor

https://claude.ai/code/session_01QqpZB45rARNvoaiXwpkY38