### PR TITLE
feat: rubber-band link visualization — selection highlight + drag animation

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -2570,6 +2570,8 @@ export class AppController {
       this._selectedIds.clear()
       this._selectedIds.add(id)
     }
+    // Rubber-band: highlight links for the newly active entity (or clear on deselect).
+    this._service.updateLinkSelectionHighlight(select && id ? this._selectedIds : new Set())
 
     const obj = this._scene.getObject(id)
     if (obj) obj.meshView.setObjectSelected(select)
@@ -4329,6 +4331,7 @@ export class AppController {
       if (obj) obj.meshView.setObjectSelected(false)
     }
     this._selectedIds.clear()
+    this._service.updateLinkSelectionHighlight(new Set())
   }
 
   /**
@@ -4457,6 +4460,8 @@ export class AppController {
     }
     // All domain guards passed → mutual exclusion + state transition
     if (!this._opState.send('BEGIN_GRAB')) return
+    // Rubber-band: activate marching ants + tension for links connected to dragged entities.
+    this._service.setLinkDragging(this._selectedIds, true)
     this._grab.axis            = null
     this._grab.inputStr        = ''
     this._grab.hasInput        = false
@@ -4568,6 +4573,9 @@ export class AppController {
     this._meshView.clearPivotDisplay()
     this._meshView.clearSnapDisplay()
     this._opState.send('CONFIRM')
+    // Rubber-band: end drag animation; stay highlighted since entity is still selected.
+    this._service.setLinkDragging(new Set(), false)
+    this._service.updateLinkSelectionHighlight(this._selectedIds)
     this._controls.enabled = true
     this._uiView.setCursor('default')
     this._refreshObjectModeStatus()
@@ -4605,6 +4613,9 @@ export class AppController {
     this._grab.stackMode     = false
     this._grab.stacking      = false
     this._opState.send('CANCEL')
+    // Rubber-band: end drag animation; stay highlighted since entity is still selected.
+    this._service.setLinkDragging(new Set(), false)
+    this._service.updateLinkSelectionHighlight(this._selectedIds)
     this._controls.enabled = true
     if (this._activeObj && this._objSelected) this._attachMobileTransform(this._activeObj)
     this._uiView.setCursor('default')

--- a/src/service/SceneService.js
+++ b/src/service/SceneService.js
@@ -115,6 +115,14 @@ export class SceneService extends EventEmitter {
      * @type {Set<string>}
      */
     this._prevCyclicLinkIds = new Set()
+
+    // ── Rubber-band link highlight state ──────────────────────────────────────
+    /** Entity IDs currently selected (not dragging). Drives link opacity. */
+    this._linkSelectedIds = new Set()
+    /** Entity IDs currently being grabbed. Drives marching ants + tension. */
+    this._dragEntityIds   = new Set()
+    /** Accumulates each frame during drag to scroll dash offset. */
+    this._dashTimer       = 0
   }
 
   // ── BFF integration (ADR-015, Phase A) ────────────────────────────────────
@@ -1394,19 +1402,98 @@ export class SceneService extends EventEmitter {
     const tgt = this._entityWorldCentroid(link.targetId) ?? new Vector3()
     const view = new SpatialLinkView(this._threeScene, src, tgt, link.semanticType)
     this._linkViews.set(link.id, view)
+    // Apply current selection/drag highlight to the newly created view.
+    const highlighted =
+      this._dragEntityIds.has(link.sourceId) ||
+      this._dragEntityIds.has(link.targetId) ||
+      this._linkSelectedIds.has(link.sourceId) ||
+      this._linkSelectedIds.has(link.targetId)
+    view.setHighlighted(highlighted)
   }
 
   /**
    * Updates the line endpoints of every SpatialLinkView to follow entity centroids.
+   * Drives rubber-band animation: marching ants dash scroll + tension color shift.
    * Called once per animation frame at the end of _updateWorldPoses().
    */
   _updateSpatialLinkViews() {
+    const hasDrag = this._dragEntityIds.size > 0
+    if (hasDrag) this._dashTimer += 0.018   // advance marching ants
+
     for (const [id, view] of this._linkViews) {
       const link = this._model.getLink(id)
       if (!link) continue
       const src = this._entityWorldCentroid(link.sourceId)
       const tgt = this._entityWorldCentroid(link.targetId)
-      if (src && tgt) view.update(src, tgt)
+      if (!src || !tgt) continue
+
+      const isDragging = hasDrag && (
+        this._dragEntityIds.has(link.sourceId) ||
+        this._dragEntityIds.has(link.targetId)
+      )
+
+      let dashOffset = 0
+      let tension    = 0
+      if (isDragging) {
+        dashOffset = -this._dashTimer
+        const currentDist = src.distanceTo(tgt)
+        // tension: 0 at rest, ramps to 1 at 50% stretch beyond rest distance
+        tension = Math.max(0, (currentDist / view.restDistance) - 1) / 0.5
+      }
+
+      view.update(src, tgt, dashOffset, tension)
+    }
+  }
+
+  // ── Rubber-band highlight API (called by AppController) ────────────────────
+
+  /**
+   * Updates which entity IDs are "selected" (but not dragging).
+   * Link views connecting these entities are highlighted (full opacity, larger dashes).
+   * @param {Set<string>} entityIds
+   */
+  updateLinkSelectionHighlight(entityIds) {
+    this._linkSelectedIds = new Set(entityIds)
+    this._applyLinkHighlights()
+  }
+
+  /**
+   * Marks entities as actively being grabbed or released.
+   * On drag start: snapshots rest distances for tension computation.
+   * @param {Iterable<string>} entityIds
+   * @param {boolean}          active
+   */
+  setLinkDragging(entityIds, active) {
+    this._dragEntityIds.clear()
+    if (active) {
+      for (const id of entityIds) this._dragEntityIds.add(id)
+      // Snapshot rest distances for all links connected to dragged entities.
+      for (const [linkId, view] of this._linkViews) {
+        const link = this._model.getLink(linkId)
+        if (!link) continue
+        if (this._dragEntityIds.has(link.sourceId) || this._dragEntityIds.has(link.targetId)) {
+          const src = this._entityWorldCentroid(link.sourceId)
+          const tgt = this._entityWorldCentroid(link.targetId)
+          if (src && tgt) view.setRestDistance(src, tgt)
+        }
+      }
+    } else {
+      this._dashTimer = 0
+    }
+    this._applyLinkHighlights()
+  }
+
+  /** Applies highlight / idle opacity to all link views based on current selection/drag state. */
+  _applyLinkHighlights() {
+    for (const [id, view] of this._linkViews) {
+      const link = this._model.getLink(id)
+      if (!link) continue
+      const highlighted =
+        this._dragEntityIds.has(link.sourceId) ||
+        this._dragEntityIds.has(link.targetId) ||
+        this._linkSelectedIds.has(link.sourceId) ||
+        this._linkSelectedIds.has(link.targetId)
+      view.setHighlighted(highlighted)
     }
   }
 

--- a/src/view/SpatialLinkView.js
+++ b/src/view/SpatialLinkView.js
@@ -61,17 +61,18 @@ export class SpatialLinkView {
    */
   constructor(scene, srcPos, tgtPos, semanticType) {
     this._scene = scene
-
-    const color = LINK_TYPE_COLORS[semanticType] ?? 0x888888
+    this._baseColor = LINK_TYPE_COLORS[semanticType] ?? 0x888888
 
     // ── Dashed line ────────────────────────────────────────────────────────
     this._geo = new THREE.BufferGeometry()
     this._mat = new THREE.LineDashedMaterial({
-      color,
-      dashSize:  0.35,
-      gapSize:   0.18,
-      linewidth: 1,
-      depthTest: false,
+      color:       this._baseColor,
+      dashSize:    0.35,
+      gapSize:     0.18,
+      linewidth:   1,
+      depthTest:   false,
+      transparent: true,
+      opacity:     0.4,   // idle: subtle; becomes 1.0 on select/drag
     })
     this._line = new THREE.Line(this._geo, this._mat)
     this._line.renderOrder = 2
@@ -86,7 +87,7 @@ export class SpatialLinkView {
         tmpDir,
         new THREE.Vector3(),
         0.4,    // total length (irrelevant — shaft hidden)
-        color,
+        this._baseColor,
         0.28,   // headLength
         0.13,   // headWidth
       )
@@ -94,6 +95,9 @@ export class SpatialLinkView {
       this._arrow.renderOrder = 2
       scene.add(this._arrow)
     }
+
+    // Rest distance: baseline for tension computation during grab.
+    this._restDistance = Math.max(srcPos.distanceTo(tgtPos), 0.001)
 
     // Set initial geometry
     this.update(srcPos, tgtPos)
@@ -104,14 +108,33 @@ export class SpatialLinkView {
   /**
    * Repositions the line and arrowhead between the two world centroids.
    * Called every animation frame by SceneService._updateSpatialLinkViews().
+   *
    * @param {THREE.Vector3} srcPos
    * @param {THREE.Vector3} tgtPos
+   * @param {number} [dashOffset=0]   Negative value scrolls dashes source→target (marching ants).
+   * @param {number} [tension=0]      0..1 — color shift from semantic color toward orange-red.
    */
-  update(srcPos, tgtPos) {
+  update(srcPos, tgtPos, dashOffset = 0, tension = 0) {
     const pts = [srcPos.x, srcPos.y, srcPos.z, tgtPos.x, tgtPos.y, tgtPos.z]
     this._geo.setAttribute('position', new THREE.Float32BufferAttribute(pts, 3))
     this._geo.attributes.position.needsUpdate = true
     this._line.computeLineDistances()
+
+    // Rubber-band tension: shift color toward orange-red as stretch increases.
+    if (tension > 0) {
+      const t = Math.min(tension, 1) * Math.min(tension, 1)  // ease-in for drama
+      const base    = new THREE.Color(this._baseColor)
+      const hot     = new THREE.Color(0xF97316)               // orange
+      this._mat.color.lerpColors(base, hot, t)
+      if (this._arrow) this._arrow.cone.material.color.lerpColors(base, hot, t)
+    } else {
+      this._mat.color.set(this._baseColor)
+      if (this._arrow) this._arrow.cone.material.color.set(this._baseColor)
+    }
+
+    if (dashOffset !== 0) {
+      this._mat.dashOffset = dashOffset
+    }
 
     if (this._arrow) {
       const dir = new THREE.Vector3().subVectors(tgtPos, srcPos)
@@ -124,6 +147,29 @@ export class SpatialLinkView {
         this._arrow.setDirection(dir)
       }
     }
+  }
+
+  // ── Tension / highlight state ──────────────────────────────────────────────
+
+  /**
+   * Snapshot the current source-target distance as the baseline for tension.
+   * Call at the start of a grab operation that involves this link's entities.
+   */
+  setRestDistance(srcPos, tgtPos) {
+    this._restDistance = Math.max(srcPos.distanceTo(tgtPos), 0.001)
+  }
+
+  /** Baseline distance recorded when drag started. */
+  get restDistance() { return this._restDistance }
+
+  /**
+   * Raises or lowers the line opacity to indicate that the linked entity is
+   * selected (highlighted) or idle.  Also enlarges dashes slightly when active.
+   */
+  setHighlighted(highlighted) {
+    this._mat.opacity  = highlighted ? 1.0 : 0.4
+    this._mat.dashSize = highlighted ? 0.45 : 0.35
+    this._mat.gapSize  = highlighted ? 0.15 : 0.18
   }
 
   // ── Visual state ───────────────────────────────────────────────────────────


### PR DESCRIPTION
SpatialLinkView:
- Lines are now semi-transparent by default (opacity 0.4) — present but subtle
- setHighlighted(bool): jumps to opacity 1.0 + larger dashes when a connected
  entity is selected or being grabbed
- update() extended with dashOffset + tension params
- Tension: color lerps from semantic color → orange as stretch exceeds rest
  distance during grab (ease-in for dramatic effect)
- setRestDistance(): snapshots baseline distance at grab start

SceneService:
- _linkSelectedIds / _dragEntityIds / _dashTimer state added
- updateLinkSelectionHighlight(entityIds): highlights links for selected entities
- setLinkDragging(entityIds, active): activates marching ants + tension; snapshots
  rest distances on drag start, resets timer on drag end
- _applyLinkHighlights(): single source of truth for highlight state across all views
- _createLinkView(): applies current highlight state to newly created link views

AppController:
- _switchActiveObject(): calls updateLinkSelectionHighlight on selection change
- _clearObjectSelection(): calls updateLinkSelectionHighlight(empty) on deselect
- _startGrab(): calls setLinkDragging(selectedIds, true)
- _confirmGrab() / _cancelGrab(): calls setLinkDragging(empty, false) + restores
  selection highlight so links remain bright while entity stays selected

https://claude.ai/code/session_01Pkv22oEvtARTrWH9Dw8Q4k