### PR TITLE
feat: drag damping — リンク張力に比例した移動抵抗を実装

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -873,6 +873,8 @@ export class AppController {
           const pt = new THREE.Vector3()
           if (this._raycaster.ray.intersectPlane(this._objDragPlane, pt)) {
             const delta = pt.clone().sub(this._objDragStart)
+            const _qdTension = this._service.getLinkDragTension()
+            if (_qdTension > 0) delta.multiplyScalar(Math.max(0.15, 1.0 - Math.min(_qdTension, 1.0) * 0.85))
             this._service.applyPreviewTranslation(
               this._objDragAllStartCorners,
               this._objDragAllStartPositions,
@@ -5083,6 +5085,8 @@ export class AppController {
     } else {
       this._grab.snapping      = false
       this._grab.snappedTarget = null
+      const _fgTension = this._service.getLinkDragTension()
+      if (_fgTension > 0) delta.multiplyScalar(Math.max(0.15, 1.0 - Math.min(_fgTension, 1.0) * 0.85))
     }
     this._applyGrabDeltaToAll(delta)
   }
@@ -5138,7 +5142,9 @@ export class AppController {
     } else {
       this._grab.snapping      = false
       this._grab.snappedTarget = null
-      this._applyGrabDeltaToAll(axisVec.clone().multiplyScalar(dist))
+      const _acTension = this._service.getLinkDragTension()
+      const _acDist    = _acTension > 0 ? dist * Math.max(0.15, 1.0 - Math.min(_acTension, 1.0) * 0.85) : dist
+      this._applyGrabDeltaToAll(axisVec.clone().multiplyScalar(_acDist))
     }
   }
 

--- a/src/service/SceneService.js
+++ b/src/service/SceneService.js
@@ -1498,6 +1498,29 @@ export class SceneService extends EventEmitter {
   }
 
   /**
+   * Returns the maximum tension across all SpatialLinks connected to dragged entities.
+   * Tension is 0 at rest distance and reaches 1 at 50% stretch beyond rest distance.
+   * Used by AppController to compute drag-damping resistance during free movement.
+   * @returns {number}
+   */
+  getLinkDragTension() {
+    if (this._dragEntityIds.size === 0) return 0
+    let maxTension = 0
+    for (const [id, view] of this._linkViews) {
+      const link = this._model.getLink(id)
+      if (!link) continue
+      if (!this._dragEntityIds.has(link.sourceId) && !this._dragEntityIds.has(link.targetId)) continue
+      const src = this._entityWorldCentroid(link.sourceId)
+      const tgt = this._entityWorldCentroid(link.targetId)
+      if (!src || !tgt) continue
+      const currentDist = src.distanceTo(tgt)
+      const tension = Math.max(0, (currentDist / view.restDistance) - 1) / 0.5
+      if (tension > maxTension) maxTension = tension
+    }
+    return maxTension
+  }
+
+  /**
    * Resolves the world position of a geometry element from an anchor reference.
    * Returns null when the element cannot be found on the given object.
    * @param {{ type: string, elementId: string }} anchorRef


### PR DESCRIPTION
SpatialLink で繋がったエンティティをドラッグすると、リンクが伸びるほど
移動速度が落ちる「ゴム紐」感を実現する。

- SceneService.getLinkDragTension(): ドラッグ中エンティティに繋がる全リンクの
  最大張力 (0=静止距離, 1=50%伸張) を返す。_updateSpatialLinkViews() と
  同じ計算式を共有。

- AppController の 3 箇所でフリードラッグ時に減衰を適用:
  1. _quickDragCtx.applyMove() — マウス直接ドラッグ (QuickDragState)
  2. _applyFreeGrab() の else ブランチ — G キーフリーグラブ
  3. _applyAxisConstrainedGrab() の else ブランチ — 軸拘束グラブ

  減衰係数 = max(0.15, 1.0 - clamp(tension,0,1) × 0.85)
  → 張力ゼロで 100% 追従、張力 1.0 (50%伸張) で 15% まで減速

スナップ (autoSnap / ctrlHeld / gridSnap) 時は減衰なし — スナップ先に
きちんと吸い付くべきため、フリー移動のみ対象とした。

https://claude.ai/code/session_01TFdrVPsYt1QwWxfeXUgJfH