### PR TITLE
feat: Add 3D floating labels on CoordinateFrames with minimap hover sync

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -125,6 +125,11 @@ export class AppController {
 
     // ── Application service (owns SceneModel aggregate root) ─────────────
     this._service = new SceneService(sceneView.scene)
+    this._service.setViewContext({
+      camera:    sceneView.camera,
+      renderer:  sceneView.renderer,
+      container: document.body,
+    })
 
     // ── Undo / Redo command history (ADR-022) ─────────────────────────────
     this._commandStack = new CommandStack()
@@ -172,6 +177,10 @@ export class AppController {
       if (id === this._scene.activeId && this._scene.selectionMode === 'object') {
         this._refreshObjectModeStatus()
       }
+      // Update floating 3D label if entity has one (CoordinateFrame, AnnotatedPoint)
+      const renamedObj = this._scene.getObject(id)
+      renamedObj?.meshView?.setLabelText?.(nm)
+      renamedObj?.meshView?.setName?.(nm)
       this._updateLinkNetwork()
     })
     this._service.on('activeChanged', id        => outlinerView?.setActive(id))
@@ -6912,6 +6921,14 @@ export class AppController {
 
     // Wire up Node Editor (Phase S-2: topology editing callbacks)
     this._nodeEditorView = new NodeEditorView(document.body, this._service, {
+      onNodeHover: (id) => {
+        const obj = this._scene.getObject(id)
+        obj?.meshView?.setLabelHighlighted?.(true)
+      },
+      onNodeHoverEnd: (id) => {
+        const obj = this._scene.getObject(id)
+        obj?.meshView?.setLabelHighlighted?.(false)
+      },
       onLinkRequested: (sourceId, targetId, x, y) => {
         const source = this._scene.getObject(sourceId)
         const target = this._scene.getObject(targetId)
@@ -7003,6 +7020,7 @@ export class AppController {
             maxWS = sceneRadius > 0 ? sceneRadius * 0.15 : 1.0
           }
           obj.meshView.updateScale(this._camera, this._sceneView.renderer, maxWS)
+          obj.meshView.updateLabelPosition(this._sceneView.activeCamera)
         }
       }
       // Sync CoordinateFrame world poses every frame (ADR-020).

--- a/src/service/SceneService.js
+++ b/src/service/SceneService.js
@@ -123,6 +123,21 @@ export class SceneService extends EventEmitter {
     this._dragEntityIds   = new Set()
     /** Accumulates each frame during drag to scroll dash offset. */
     this._dashTimer       = 0
+    /**
+     * View context for HTML label rendering (camera, renderer, container).
+     * Set by AppController.setViewContext() after construction.
+     * @type {{ camera: import('three').Camera|null, renderer: import('three').WebGLRenderer|null, container: HTMLElement|null }}
+     */
+    this._viewContext = { camera: null, renderer: null, container: null }
+  }
+
+  /**
+   * Provides the camera/renderer/container needed for HTML label projection on
+   * CoordinateFrameView. Called once by AppController after construction.
+   * @param {{ camera: import('three').Camera, renderer: import('three').WebGLRenderer, container: HTMLElement }} ctx
+   */
+  setViewContext(ctx) {
+    this._viewContext = ctx
   }
 
   // ── BFF integration (ADR-015, Phase A) ────────────────────────────────────
@@ -425,7 +440,9 @@ export class SceneService extends EventEmitter {
         entity.initCorners(meshView.getInitialCorners8())
         entities.push(entity)
       } else if (dto.type === 'CoordinateFrame') {
-        const meshView = new CoordinateFrameView(this._threeScene)
+        const { camera: cfCam = null, renderer: cfRnd = null, container: cfCnt = null } = viewContext
+        const meshView = new CoordinateFrameView(this._threeScene, cfCam, cfRnd, cfCnt)
+        meshView.setLabelText(dto.name)
         const frame    = new CoordinateFrame(dto.id, dto.name, dto.parentId, meshView)
         if (dto.translation) {
           frame.translation.set(dto.translation.x, dto.translation.y, dto.translation.z)
@@ -664,8 +681,11 @@ export class SceneService extends EventEmitter {
       const newParentId = remapId(dto.parentId)
       // Skip if parent is not present in the scene (e.g. ImportedMesh that was skipped)
       if (!this._model.getObject(newParentId)) return null
-      const meshView = new CoordinateFrameView(this._threeScene)
-      const frame    = new CoordinateFrame(newId, dto.name ?? 'Frame', newParentId, meshView)
+      const { camera: cfCam = null, renderer: cfRnd = null, container: cfCnt = null } = viewContext
+      const meshView = new CoordinateFrameView(this._threeScene, cfCam, cfRnd, cfCnt)
+      const cfName   = dto.name ?? 'Frame'
+      meshView.setLabelText(cfName)
+      const frame    = new CoordinateFrame(newId, cfName, newParentId, meshView)
       if (dto.translation) {
         frame.translation.set(dto.translation.x, dto.translation.y, dto.translation.z)
       }
@@ -2389,7 +2409,9 @@ export class SceneService extends EventEmitter {
     const id   = `frame_${idx}_${Date.now()}`
     const name = overrideName ?? `Frame.${String(idx).padStart(3, '0')}`
 
-    const meshView = new CoordinateFrameView(this._threeScene)
+    const { camera, renderer, container } = this._viewContext
+    const meshView = new CoordinateFrameView(this._threeScene, camera ?? null, renderer ?? null, container ?? null)
+    meshView.setLabelText(name)
     const frame    = new CoordinateFrame(id, name, parentObjectId, meshView)
     // Assign provenance from current role (ADR-034 §8.1, §8.2)
     frame.declaredBy = RoleService.getRole()

--- a/src/view/CoordinateFrameView.js
+++ b/src/view/CoordinateFrameView.js
@@ -80,9 +80,16 @@ function makeGhostAxisLine(x, y, z, color) {
 // ── Class ──────────────────────────────────────────────────────────────────
 
 export class CoordinateFrameView {
-  /** @param {THREE.Scene} scene */
-  constructor(scene) {
-    this._scene = scene
+  /**
+   * @param {THREE.Scene} scene
+   * @param {THREE.Camera|null}          [camera]    Required for floating label projection.
+   * @param {THREE.WebGLRenderer|null}   [renderer]  Required for floating label projection.
+   * @param {HTMLElement|null}           [container] DOM parent for the label element.
+   */
+  constructor(scene, camera = null, renderer = null, container = null) {
+    this._scene    = scene
+    this._camera   = camera
+    this._renderer = renderer
 
     // ── Origin sphere ──────────────────────────────────────────────────────
     const sphereGeo = new THREE.SphereGeometry(ORIGIN_RADIUS, 8, 8)
@@ -119,6 +126,34 @@ export class CoordinateFrameView {
      * @type {THREE.Group|null}
      */
     this._ghostGroup = null
+
+    // ── Floating HTML label ────────────────────────────────────────────────
+    /** @type {HTMLElement|null} */
+    this._label = null
+    this._labelVisible = false   // tracks desired visibility (showFull/showDimmed/hide)
+
+    if (camera && renderer && container) {
+      this._label = document.createElement('div')
+      Object.assign(this._label.style, {
+        position:        'fixed',
+        pointerEvents:   'none',
+        userSelect:      'none',
+        fontFamily:      'monospace',
+        fontSize:        '10px',
+        lineHeight:      '1',
+        padding:         '2px 6px',
+        borderRadius:    '3px',
+        background:      'rgba(18,22,36,0.82)',
+        color:           '#b8c4d8',
+        borderLeft:      '2px solid #4488ff',
+        whiteSpace:      'nowrap',
+        zIndex:          '50',
+        display:         'none',
+        transition:      'transform 0.12s, background 0.12s, border-color 0.12s',
+        transformOrigin: 'left center',
+      })
+      container.appendChild(this._label)
+    }
   }
 
   // ── Required interface ─────────────────────────────────────────────────────
@@ -142,6 +177,7 @@ export class CoordinateFrameView {
   /** Outliner eye-icon toggle. */
   setVisible(visible) {
     this._group.visible = visible
+    if (!visible) this._setLabelDisplay(false)
   }
 
   // ── Visibility modes ───────────────────────────────────────────────────────
@@ -154,6 +190,7 @@ export class CoordinateFrameView {
   showFull() {
     this._group.visible = true
     this._applyXray(OPACITY_FULL)
+    this._labelVisible = true
   }
 
   /**
@@ -168,11 +205,14 @@ export class CoordinateFrameView {
     this._originSphere.material.color.setHex(0xffffff)
     this._originSphere.scale.setScalar(1.0)
     this._applyXray(OPACITY_DIMMED)
+    this._labelVisible = true
   }
 
   /** Hide completely. Visibility restored by showFull() or showDimmed(). */
   hide() {
     this._group.visible = false
+    this._labelVisible  = false
+    this._setLabelDisplay(false)
   }
 
   /**
@@ -182,6 +222,66 @@ export class CoordinateFrameView {
   setParentSelected(selected) {
     if (selected) this.showFull()
     else this.hide()
+  }
+
+  // ── Floating label ─────────────────────────────────────────────────────────
+
+  /**
+   * Updates the label text (e.g. after rename).
+   * @param {string} name
+   */
+  setLabelText(name) {
+    if (this._label) this._label.textContent = name
+  }
+
+  /**
+   * Highlights the label to signal minimap-node hover sync.
+   * @param {boolean} highlighted
+   */
+  setLabelHighlighted(highlighted) {
+    if (!this._label) return
+    if (highlighted) {
+      Object.assign(this._label.style, {
+        background:   'rgba(249,115,22,0.88)',
+        borderColor:  '#ffcc00',
+        color:        '#fff',
+        transform:    'scale(1.18)',
+      })
+    } else {
+      Object.assign(this._label.style, {
+        background:   'rgba(18,22,36,0.82)',
+        borderColor:  '#4488ff',
+        color:        '#b8c4d8',
+        transform:    'scale(1)',
+      })
+    }
+  }
+
+  /**
+   * Projects the frame origin to screen space and repositions the HTML label.
+   * Must be called once per frame from AppController while the CF is visible.
+   * @param {THREE.Camera} camera  Pass `SceneView.activeCamera` (supports ortho mode).
+   */
+  updateLabelPosition(camera) {
+    if (!this._label || !this._renderer || !this._labelVisible) return
+
+    const ndc    = this._group.position.clone().project(camera)
+    const canvas = this._renderer.domElement
+    const rect   = canvas.getBoundingClientRect()
+
+    if (ndc.z > 1) { this._setLabelDisplay(false); return }
+
+    const sx = (ndc.x  + 1) / 2 * rect.width  + rect.left
+    const sy = (-ndc.y + 1) / 2 * rect.height + rect.top
+
+    this._label.style.left    = `${Math.round(sx + 6)}px`
+    this._label.style.top     = `${Math.round(sy - 16)}px`
+    this._setLabelDisplay(true)
+  }
+
+  /** @param {boolean} show */
+  _setLabelDisplay(show) {
+    if (this._label) this._label.style.display = show ? 'block' : 'none'
   }
 
   // ── Selection highlight ────────────────────────────────────────────────────
@@ -296,6 +396,10 @@ export class CoordinateFrameView {
         if (obj.material) obj.material.dispose()
       })
       this._ghostGroup = null
+    }
+    if (this._label) {
+      this._label.remove()
+      this._label = null
     }
   }
 

--- a/src/view/NodeEditorView.js
+++ b/src/view/NodeEditorView.js
@@ -65,7 +65,7 @@ export class NodeEditorView {
   /**
    * @param {HTMLElement} container
    * @param {import('../service/SceneService.js').SceneService} sceneService
-   * @param {{ onLinkRequested?: Function, onDeleteSpatialLink?: Function }} [callbacks]
+   * @param {{ onLinkRequested?: Function, onDeleteSpatialLink?: Function, onNodeHover?: Function, onNodeHoverEnd?: Function }} [callbacks]
    */
   constructor(container, sceneService, callbacks = {}) {
     this._container     = container
@@ -80,6 +80,9 @@ export class NodeEditorView {
     // Phase S-2 callbacks
     this._onLinkRequested     = callbacks.onLinkRequested     ?? null
     this._onDeleteSpatialLink = callbacks.onDeleteSpatialLink ?? null
+    // Hover-sync callbacks: NodeEditor ↔ 3D label
+    this._onNodeHover     = callbacks.onNodeHover     ?? null
+    this._onNodeHoverEnd  = callbacks.onNodeHoverEnd  ?? null
     this._dragState    = null   // { sourceId, x1, y1, x2, y2 } — active port-to-port drag
     this._selectedEdge = null   // { linkId } — selected spatial edge
 
@@ -444,6 +447,10 @@ export class NodeEditorView {
     g.setAttribute('transform', `translate(${pos.x},${pos.y})`)
     g.style.cursor = 'pointer'
     g.addEventListener('click', () => this._selectNode(id))
+    if (this._onNodeHover) {
+      g.addEventListener('mouseenter', () => this._onNodeHover(id))
+      g.addEventListener('mouseleave', () => this._onNodeHoverEnd?.(id))
+    }
 
     // Shadow
     const shadow = document.createElementNS('http://www.w3.org/2000/svg', 'rect')


### PR DESCRIPTION
CoordinateFrameView now renders a fixed-position HTML label showing the CF
name above its origin sphere in the 3D viewport.  Labels update position every
animation frame via the established manual world→screen projection pattern
(matching MeasureLineView / AnnotatedPointView).

- CoordinateFrameView: optional camera/renderer/container constructor params;
  setLabelText(), updateLabelPosition(camera), setLabelHighlighted() methods;
  label visibility follows showFull/showDimmed/hide; dispose() cleans up DOM.
- SceneService: _viewContext property + setViewContext() called by AppController;
  all three CoordinateFrameView instantiation sites (createCoordinateFrame,
  _deserializeEntities, _reconstructEntity) now pass the view context.
- AppController: calls setViewContext() after constructing SceneService;
  animation loop calls updateLabelPosition(activeCamera) per CF;
  objectRenamed handler calls setLabelText/setName on the view;
  NodeEditorView wired with onNodeHover/onNodeHoverEnd callbacks that toggle
  setLabelHighlighted() on the matching scene entity.
- NodeEditorView: onNodeHover/onNodeHoverEnd callbacks; _drawNodeShape adds
  mouseenter/mouseleave listeners to fire them.

https://claude.ai/code/session_01EMp699V1FXb1MKHWAndQxh