### PR TITLE
Fix CF label jitter and mobile rotate axis sign inversion

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -4850,6 +4850,19 @@ export class AppController {
       this._camera.getWorldDirection(axisVec).negate()
     }
 
+    // Sign correction for pointer-driven axis-constrained rotation.
+    // Screen CCW (positive atan2 angle) maps to positive rotation only when the
+    // world axis points toward the viewer (camFwd · axisVec < 0). When the axis
+    // points away from the viewer (dot > 0 — e.g. +Y in the ROS frame for a
+    // typical above-right camera position), the apparent arc direction is reversed.
+    // Negating restores right-hand-rule consistency across all axes and camera poses.
+    // Free rotation and keyboard-input angles are already correct and are not touched.
+    if (!this._rotate.hasInput && this._rotate.axis) {
+      const camFwd = new THREE.Vector3()
+      this._camera.getWorldDirection(camFwd)
+      if (camFwd.dot(axisVec) > 0) angle = -angle
+    }
+
     const deltaQ = new THREE.Quaternion().setFromAxisAngle(axisVec, angle)
 
     this._service.applyPreviewRotation(obj, {

--- a/src/view/CoordinateFrameView.js
+++ b/src/view/CoordinateFrameView.js
@@ -136,6 +136,8 @@ export class CoordinateFrameView {
     // caused by per-frame getBoundingClientRect() variation during viewport animations.
     this._lblX = null           // last rendered pixel X (integer)
     this._lblY = null           // last rendered pixel Y (integer)
+    this._lastRawX  = 0        // raw screen X at last write (pre-rounding)
+    this._lastRawY  = 0        // raw screen Y at last write (pre-rounding)
     this._cachedRect   = null   // cached canvas bounding rect
     this._cachedRectW  = 0      // canvas clientWidth at cache time
     this._cachedRectH  = 0      // canvas clientHeight at cache time
@@ -294,12 +296,21 @@ export class CoordinateFrameView {
 
     const sx = (ndc.x  + 1) / 2 * rect.width  + rect.left
     const sy = (-ndc.y + 1) / 2 * rect.height + rect.top
+
+    // Dead-zone filter: suppress writes when camera drifts < 0.5 px in screen space.
+    // OrbitControls inertia and touch-sensor noise cause sub-pixel oscillation that,
+    // without this guard, straddles rounding boundaries and toggles the label position
+    // every frame — visible as jitter even when the scene is visually static.
+    if (this._lblX !== null &&
+        Math.hypot(sx - this._lastRawX, sy - this._lastRawY) < 0.5) {
+      this._setLabelDisplay(true)
+      return
+    }
+    this._lastRawX = sx
+    this._lastRawY = sy
+
     const rx = Math.round(sx + 6)
     const ry = Math.round(sy - 16)
-
-    // Skip the style write when the pixel position has not changed — prevents
-    // the GPU compositor from triggering a redundant recomposition on mobile.
-    if (rx === this._lblX && ry === this._lblY) { this._setLabelDisplay(true); return }
     this._lblX = rx
     this._lblY = ry
     this._label.style.transform = `translate3d(${rx}px,${ry}px,0)`


### PR DESCRIPTION
1. CoordinateFrameView.updateLabelPosition — screen-space dead zone (0.5 px):
   OrbitControls inertia and touch-sensor noise cause sub-pixel camera oscillation
   that straddles integer-rounding boundaries, toggling the label position every
   frame. The existing getBoundingClientRect cache and Math.round guard eliminate
   browser-layer noise but cannot prevent 3D-space drift from surfacing. The dead
   zone compares the new raw screen position against the last written position with
   Math.hypot; if delta < 0.5 px, the DOM write is skipped entirely. The first
   frame always writes (this._lblX === null), after which the hysteresis prevents
   visible toggling for oscillations under 0.5 px amplitude.

2. AppController._applyRotate — camera-axis dot-product sign correction:
   For axis-constrained pointer-driven rotation, screen CCW (positive atan2 angle)
   maps to positive three.js rotation only when the world axis points toward the
   viewer (camFwd · axisVec < 0). In the ROS coordinate frame (+Y is left), a
   typical above-right camera position yields a positive dot for the Y axis, making
   the Y ring appear to rotate in the opposite direction. Negating angle when
   dot > 0 restores right-hand-rule consistency for all three world axes regardless
   of camera pose, without affecting free rotation (no axis) or keyboard input.

https://claude.ai/code/session_01CarrKSfxTWKbTo39wZeBDx