### PR TITLE
fix(AnnotatedRegionView): prevent edge/fill separation during drag via THREE.Group architecture

### DIFF
--- a/src/view/AnnotatedRegionView.js
+++ b/src/view/AnnotatedRegionView.js
@@ -1,20 +1,22 @@
 /**
  * AnnotatedRegionView — renderer for AnnotatedRegion domain entities.
  *
+ * Architecture: all visual components are children of a single THREE.Group
+ * positioned at the polygon centroid. This prevents edge/fill separation during
+ * entity movement — each move just updates group.position and rebuilds local
+ * geometry; no per-component world-position bookkeeping is needed.
+ *
  * Renders:
- *  - A Line2 (fat line) as a closed ring connecting all vertices in place-type color
- *  - A translucent fill mesh (ShapeGeometry on Z=0 XY plane)
+ *  - A Line2 (fat line) as a closed ring in place-type color
+ *  - A translucent fill mesh (ShapeGeometry in centroid-local XY plane)
  *  - Vertex dot markers (small spheres) at each vertex
  *  - A BoxHelper for selection highlight
- *  - A rim ring (polygon-shaped ShapeGeometry) that pulses outward from the boundary (Zone only)
+ *  - Two rim rings (Zone only) that pulse outward in 180°-offset phases
  *
  * Animations (called via tick(t) each frame):
- *  - Zone: fill opacity breathes on a 4 s cycle (alive, "owned territory" feel)
- *  - Zone: rim ring expands 1.0×→1.08× and fades 0.40→0 on a 3 s cycle
- *
- * Exposes the same minimal no-op interface as MeasureLineView / ImportedMeshView.
- *
- * Note: no `cuboid` property — AnnotatedRegion is excluded from raycasting.
+ *  - Pending boundary: dashOffset scrolls — "marching ants" flow effect
+ *  - Zone: fill opacity breathes on a ~4 s cycle (faster when selected)
+ *  - Zone: two rim rings pulse with half-cycle phase offset (continuous wave)
  *
  * @see ADR-029, ADR-031
  */
@@ -24,27 +26,36 @@ import { LineGeometry }  from 'three/addons/lines/LineGeometry.js'
 import { LineMaterial }  from 'three/addons/lines/LineMaterial.js'
 import { getPlaceTypeEntry } from '../domain/PlaceTypeRegistry.js'
 
-const DEFAULT_COLOR    = 0x888888
-const FILL_OPACITY     = 0.40          // confirmed default (mid-range)
-const FILL_OPACITY_MIN = 0.15          // breathing animation lower bound (ADR-031 §8)
-const FILL_OPACITY_MAX = 0.65          // breathing animation upper bound (ADR-031 §8)
-const RIM_OPACITY_MAX  = 0.40          // rim ring start opacity (ADR-031 §8)
-const SELECTED_WIDTH   = 4
-const UNSELECTED_WIDTH = 2
-const CONFIRMED_OPACITY = 1.00
-const PENDING_OPACITY   = 0.90
+const DEFAULT_COLOR      = 0x888888
+const FILL_OPACITY       = 0.40          // confirmed default (mid-range)
+const FILL_OPACITY_MIN   = 0.15          // breathing animation lower bound (ADR-031 §8)
+const FILL_OPACITY_MAX   = 0.65          // breathing animation upper bound (ADR-031 §8)
+const RIM_OPACITY_MAX    = 0.40          // rim ring start opacity (ADR-031 §8)
+const SELECTED_WIDTH     = 4
+const UNSELECTED_WIDTH   = 2
+const CONFIRMED_OPACITY  = 1.00
+const PENDING_OPACITY    = 0.90
+const RIM_PULSE_DURATION = 3.0           // seconds per rim ring cycle
 
 export class AnnotatedRegionView {
   /**
-   * @param {THREE.Scene}   scene
-   * @param {THREE.Vector3[]} points  ordered ring positions (N ≥ 3, implicitly closed)
-   * @param {string|null}   placeType  'Zone' | null
-   * @param {THREE.WebGLRenderer} renderer  needed for Line2 resolution
+   * @param {THREE.Scene}         scene
+   * @param {THREE.Vector3[]}     points     ordered ring positions (N ≥ 3, implicitly closed)
+   * @param {string|null}         placeType  'Zone' | null
+   * @param {THREE.WebGLRenderer} renderer   needed for Line2 resolution
    */
   constructor(scene, points, placeType, renderer) {
-    this._scene    = scene
-    this._renderer = renderer
-    this._placeType = placeType
+    this._scene      = scene
+    this._renderer   = renderer
+    this._placeType  = placeType
+    this._isSelected = false
+    this._isPending  = false
+
+    // Parent group — its world position = polygon centroid.  Every child uses
+    // centroid-relative local coordinates so group.position is the single
+    // authority for world placement; no component can drift independently.
+    this._group = new THREE.Group()
+    scene.add(this._group)
 
     // ── Line2 (closed ring) ────────────────────────────────────────────────
     this._lineGeo = new LineGeometry()
@@ -59,12 +70,11 @@ export class AnnotatedRegionView {
     this._lineMat.resolution.set(window.innerWidth, window.innerHeight)
     this._line = new Line2(this._lineGeo, this._lineMat)
     this._line.renderOrder = 2
-    scene.add(this._line)
+    this._group.add(this._line)
 
-    // ── Fill mesh ──────────────────────────────────────────────────────────
-    // Use an empty BufferGeometry as placeholder — THREE.Mesh(null, ...) throws
-    // in r172 because updateMorphTargets() accesses geometry.morphAttributes.
-    // _setPoints() replaces this with a ShapeGeometry and disposes the placeholder.
+    // ── Fill mesh (placeholder — replaced in _setPoints) ───────────────────
+    // THREE.Mesh(null, mat) throws in r172 because updateMorphTargets() reads
+    // geometry.morphAttributes; use empty BufferGeometry as safe placeholder.
     this._fillGeo = new THREE.BufferGeometry()
     this._fillMat = new THREE.MeshBasicMaterial({
       color:       this._colorForType(placeType),
@@ -75,38 +85,45 @@ export class AnnotatedRegionView {
     })
     this._fillMesh = new THREE.Mesh(this._fillGeo, this._fillMat)
     this._fillMesh.renderOrder = 1
-    scene.add(this._fillMesh)
+    this._group.add(this._fillMesh)
 
     // ── Vertex dots ────────────────────────────────────────────────────────
     this._dotGeo = new THREE.SphereGeometry(0.07, 6, 6)
     this._dotMat = new THREE.MeshBasicMaterial({
-      color:    this._colorForType(placeType),
+      color:     this._colorForType(placeType),
       depthTest: false,
     })
     /** @type {THREE.Mesh[]} */
     this._dots = []
 
-    // ── Rim ring (Zone animation — ADR-031 §8) ─────────────────────────────
-    // Pulses outward from the polygon boundary: scale 1.0×→1.08×, opacity 0.40→0
-    // on a 3 s cycle.  The ring geometry is rebuilt in _setPoints() as a
-    // polygon-shaped ShapeGeometry (with hole) so the ring tracks the actual
-    // Zone shape rather than an approximating circle.
-    // Empty BufferGeometry placeholder — same reason as _fillGeo above.
+    // ── Rim rings (Zone only, dual-wave pulse) ─────────────────────────────
+    // Two rings share one geometry but have independent materials so their
+    // opacities can be animated at 180° phase offset for a continuous double-
+    // wave effect.  Placeholder geometry — replaced in _setPoints.
     this._rimGeo  = new THREE.BufferGeometry()
-    this._rimMat  = new THREE.MeshBasicMaterial({
+    this._rimMat1 = new THREE.MeshBasicMaterial({
       color:       this._colorForType(placeType),
       depthTest:   false,
       transparent: true,
       opacity:     0,
       side:        THREE.DoubleSide,
     })
-    this._rimRing = new THREE.Mesh(this._rimGeo, this._rimMat)
-    this._rimRing.renderOrder = 1
-    scene.add(this._rimRing)
+    this._rimRing1 = new THREE.Mesh(this._rimGeo, this._rimMat1)
+    this._rimRing1.renderOrder = 1
+    this._rimRing1.visible = (placeType === 'Zone')
+    this._group.add(this._rimRing1)
+
+    this._rimMat2 = this._rimMat1.clone()
+    this._rimRing2 = new THREE.Mesh(this._rimGeo, this._rimMat2)
+    this._rimRing2.renderOrder = 1
+    this._rimRing2.visible = (placeType === 'Zone')
+    this._group.add(this._rimRing2)
 
     // ── BoxHelper ──────────────────────────────────────────────────────────
+    // _helperObj is a child of the group (inherits centroid transform).
+    // BoxHelper itself is added to the root scene so it always renders.
     this._helperObj = new THREE.Object3D()
-    scene.add(this._helperObj)
+    this._group.add(this._helperObj)
     this.boxHelper = new THREE.BoxHelper(this._helperObj, 0xffffff)
     this.boxHelper.visible = false
     scene.add(this.boxHelper)
@@ -118,55 +135,56 @@ export class AnnotatedRegionView {
   // ── Geometry ───────────────────────────────────────────────────────────────
 
   /**
-   * Sets (or replaces) all vertex positions.
-   * @param {THREE.Vector3[]} points
+   * Rebuilds all geometry in centroid-local space and repositions the group.
+   * Called on construction and on every entity.move() during drag.
+   * @param {THREE.Vector3[]} points  world-space vertex positions
    */
   _setPoints(points) {
-    // Remove old dots
-    for (const d of this._dots) this._scene.remove(d)
+    for (const d of this._dots) this._group.remove(d)
     this._dots = []
 
     if (!points || points.length < 3) return
 
-    // Closed ring: repeat first point at end for Line2
-    const flat = []
-    for (const p of points) { flat.push(p.x, p.y, p.z) }
-    // Close the ring
-    flat.push(points[0].x, points[0].y, points[0].z)
-    this._lineGeo.setPositions(flat)
-    this._line.computeLineDistances()
-
-    // Fill: ShapeGeometry using XY coordinates (polygon is in Z=0 plane)
-    if (this._fillGeo) {
-      this._fillGeo.dispose()
-      this._fillGeo = null
-    }
-    const shape = new THREE.Shape(points.map(p => new THREE.Vector2(p.x, p.y)))
-    this._fillGeo = new THREE.ShapeGeometry(shape)
-    // ShapeGeometry is in XY plane (Z=0), which matches the ground plane (ROS Z-up)
-    this._fillMesh.geometry = this._fillGeo
-
-    // Vertex dots
-    for (const p of points) {
-      const dot = new THREE.Mesh(this._dotGeo, this._dotMat)
-      dot.position.copy(p)
-      dot.renderOrder = 2
-      this._scene.add(dot)
-      this._dots.push(dot)
-    }
-
-    // Rim ring: polygon-shaped ring that matches the Zone outline.
-    // Build in local space with centroid at origin so scale.setScalar() expands
-    // the ring along the actual polygon shape (not a circle).
+    // Compute centroid → group world position (single authority for placement).
+    // Using the average of polygon vertices is acceptable here because this is
+    // a display offset, not a solver/physics computation (PHILOSOPHY #24 note:
+    // this value does NOT feed back into any per-frame calculation).
     const centroid = new THREE.Vector3()
     for (const p of points) centroid.add(p)
     centroid.divideScalar(points.length)
+    this._group.position.copy(centroid)
 
+    // All geometry in centroid-relative local space.
+    const localPts = points.map(p => new THREE.Vector3().subVectors(p, centroid))
+
+    // Closed ring for Line2 (repeat first point)
+    const flat = []
+    for (const lp of localPts) { flat.push(lp.x, lp.y, lp.z) }
+    flat.push(localPts[0].x, localPts[0].y, localPts[0].z)
+    this._lineGeo.setPositions(flat)
+    this._line.computeLineDistances()
+
+    // Fill: ShapeGeometry in local XY plane
+    if (this._fillGeo) { this._fillGeo.dispose(); this._fillGeo = null }
+    const fillShape = new THREE.Shape(localPts.map(lp => new THREE.Vector2(lp.x, lp.y)))
+    this._fillGeo = new THREE.ShapeGeometry(fillShape)
+    this._fillMesh.geometry = this._fillGeo
+
+    // Vertex dots at local positions
+    for (const lp of localPts) {
+      const dot = new THREE.Mesh(this._dotGeo, this._dotMat)
+      dot.position.copy(lp)
+      dot.renderOrder = 2
+      this._group.add(dot)
+      this._dots.push(dot)
+    }
+
+    // Rim rings: polygon-shaped ShapeGeometry with inner hole at 92% toward
+    // centroid to form a thin ring matching the Zone boundary shape.
+    // Both rings share the same geometry; scale animation in tick() expands
+    // each ring outward from local origin (= centroid in world space).
     if (this._rimGeo) { this._rimGeo.dispose(); this._rimGeo = null }
-
-    // Outer boundary = polygon vertices; inner boundary = vertices shrunk 92% toward
-    // centroid to form a thin ring matching the Zone shape.
-    const relPts = points.map(p => new THREE.Vector2(p.x - centroid.x, p.y - centroid.y))
+    const relPts = localPts.map(lp => new THREE.Vector2(lp.x, lp.y))
     const outerShape = new THREE.Shape()
     outerShape.moveTo(relPts[0].x, relPts[0].y)
     for (let i = 1; i < relPts.length; i++) outerShape.lineTo(relPts[i].x, relPts[i].y)
@@ -177,25 +195,29 @@ export class AnnotatedRegionView {
     innerHole.closePath()
     outerShape.holes.push(innerHole)
     this._rimGeo = new THREE.ShapeGeometry(outerShape)
-    this._rimRing.position.set(centroid.x, centroid.y, 0)
-    this._rimRing.scale.setScalar(1)
-    this._rimRing.geometry = this._rimGeo
+    this._rimRing1.geometry = this._rimGeo
+    this._rimRing1.position.set(0, 0, 0)
+    this._rimRing1.scale.setScalar(1)
+    this._rimRing2.geometry = this._rimGeo
+    this._rimRing2.position.set(0, 0, 0)
+    this._rimRing2.scale.setScalar(1)
 
-    this._updateBoxHelper(points)
+    this._updateBoxHelper(localPts)
   }
 
   /**
-   * Refreshes BoxHelper bounding volume from current vertex positions.
-   * @param {THREE.Vector3[]} points
+   * Refreshes BoxHelper bounding volume from centroid-local vertex positions.
+   * @param {THREE.Vector3[]} localPts  centroid-relative positions
    */
-  _updateBoxHelper(points) {
-    if (!points || points.length === 0) return
+  _updateBoxHelper(localPts) {
+    if (!localPts || localPts.length === 0) return
     const bMin = new THREE.Vector3( Infinity,  Infinity,  Infinity)
     const bMax = new THREE.Vector3(-Infinity, -Infinity, -Infinity)
-    for (const p of points) { bMin.min(p); bMax.max(p) }
+    for (const lp of localPts) { bMin.min(lp); bMax.max(lp) }
     const center = bMin.clone().add(bMax).multiplyScalar(0.5)
     bMin.z -= 0.05; bMax.z += 0.05
     const size = bMax.clone().sub(bMin)
+    // _helperObj is in group-local space; center is already local.
     this._helperObj.position.copy(center)
     this._helperObj.scale.set(size.x || 0.1, size.y || 0.1, size.z || 0.1)
     if (this.boxHelper.visible) this.boxHelper.update()
@@ -210,28 +232,44 @@ export class AnnotatedRegionView {
   // ── Per-frame animation ────────────────────────────────────────────────────
 
   /**
-   * Drives Zone fill breathing + rim ring animation.  Called every frame.
+   * Drives pending-line scroll, Zone fill breathing, and dual rim ring pulse.
+   * Called every frame from the AppController animation loop.
    * @param {number} t  elapsed seconds (performance.now() / 1000)
    */
   tick(t) {
-    if (!this._fillMesh.visible || this._placeType !== 'Zone') return
+    if (!this._group.visible) return
 
-    // Fill breath: opacity oscillates between MIN and MAX on a 4 s period.
-    const breath = (Math.sin(t * Math.PI * 0.5) + 1) * 0.5  // 0 → 1, 4 s period
-    this._fillMat.opacity = FILL_OPACITY_MIN + breath * (FILL_OPACITY_MAX - FILL_OPACITY_MIN)
-
-    // Rim ring pulse: scale 1.0×→1.08×, opacity 0.40→0, 3 s cycle (ADR-031 §8).
-    if (this._rimGeo) {
-      const phase = (t % 3.0) / 3.0  // 0 → 1 every 3 s
-      this._rimRing.scale.setScalar(1.0 + phase * 0.08)
-      this._rimMat.opacity = RIM_OPACITY_MAX * (1 - phase)
+    // Pending boundary: scroll dashOffset for "marching ants" flow.
+    // dashOffset is a shader uniform — no needsUpdate required.
+    if (this._isPending && this._lineMat.dashed) {
+      this._lineMat.dashOffset = -(t * 2.0)
     }
+
+    if (this._placeType !== 'Zone') return
+
+    // Fill breathing: slightly faster and brighter when selected
+    const freq   = this._isSelected ? Math.PI * 1.2 : Math.PI * 0.5
+    const breath = (Math.sin(t * freq) + 1) * 0.5
+    const lo     = this._isSelected ? FILL_OPACITY_MIN + 0.08 : FILL_OPACITY_MIN
+    const hi     = this._isSelected ? FILL_OPACITY_MAX         : FILL_OPACITY_MAX
+    this._fillMat.opacity = lo + breath * (hi - lo)
+
+    // Dual rim ring pulse: two waves at 180° phase offset.
+    // Each ring's outer edge expands from 1.0× to 1.10× while fading.
+    // Math.pow(1 - phase, 2) gives ease-out fade (slow at start, fast at end).
+    const phase1 = (t % RIM_PULSE_DURATION) / RIM_PULSE_DURATION
+    this._rimRing1.scale.setScalar(1.0 + phase1 * 0.10)
+    this._rimMat1.opacity = RIM_OPACITY_MAX * Math.pow(1 - phase1, 2)
+
+    const phase2 = ((t + RIM_PULSE_DURATION * 0.5) % RIM_PULSE_DURATION) / RIM_PULSE_DURATION
+    this._rimRing2.scale.setScalar(1.0 + phase2 * 0.10)
+    this._rimMat2.opacity = RIM_OPACITY_MAX * Math.pow(1 - phase2, 2)
   }
 
   // ── Move support ───────────────────────────────────────────────────────────
 
   /**
-   * Refreshes geometry after entity.move().
+   * Refreshes geometry after entity.move() during drag or after undo/redo.
    * @param {THREE.Vector3[]} corners
    */
   updateGeometry(corners) {
@@ -256,44 +294,46 @@ export class AnnotatedRegionView {
     this._lineMat.color.setHex(hex)
     this._fillMat.color.setHex(hex)
     this._dotMat.color.setHex(hex)
-    this._rimMat.color.setHex(hex)
+    this._rimMat1.color.setHex(hex)
+    this._rimMat2.color.setHex(hex)
     this.boxHelper.material?.color.setHex(hex)
-    // Reset fill opacity to default when place type changes
     this._fillMat.opacity = FILL_OPACITY
-    // rimRing is only active for Zone; sync visibility with the new type
-    this._rimRing.visible = this._fillMesh.visible && placeType === 'Zone'
+    const isZone = placeType === 'Zone'
+    this._rimRing1.visible = isZone
+    this._rimRing2.visible = isZone
   }
 
   /**
-   * Switches the boundary ring to dashed (pending) or solid (drawing/confirmed) style.
+   * Switches the boundary ring to dashed-scrolling (pending) or solid (confirmed).
    * @param {boolean} pending
    */
   setPending(pending) {
+    this._isPending        = pending
     this._lineMat.dashed   = pending
     this._lineMat.dashSize = pending ? 0.40 : 1000
     this._lineMat.gapSize  = pending ? 0.20 : 0
     this._lineMat.opacity  = pending ? PENDING_OPACITY : CONFIRMED_OPACITY
+    if (!pending) this._lineMat.dashOffset = 0
     this._lineMat.needsUpdate = true
   }
 
   // ── Visual state ───────────────────────────────────────────────────────────
 
   setVisible(visible) {
-    this._line.visible     = visible
-    this._fillMesh.visible = visible
-    this._rimRing.visible  = visible && this._placeType === 'Zone'
-    for (const d of this._dots) d.visible = visible
+    this._group.visible = visible
     if (!visible) this.boxHelper.visible = false
   }
 
   setObjectSelected(sel) {
-    this.boxHelper.visible = sel
+    this._isSelected        = sel
+    this.boxHelper.visible  = sel
     this._lineMat.linewidth = sel ? SELECTED_WIDTH : UNSELECTED_WIDTH
-    if (sel) this.boxHelper.update()
+    if (sel)  this.boxHelper.update()
+    if (!sel) this._fillMat.opacity = FILL_OPACITY
   }
 
   /** True when the region is shown in the scene (false when soft-deleted). */
-  get visible() { return this._line.visible }
+  get visible() { return this._group.visible }
 
   // ── Edit-mode no-ops ───────────────────────────────────────────────────────
 
@@ -318,18 +358,15 @@ export class AnnotatedRegionView {
    * @param {THREE.Scene} scene
    */
   dispose(scene) {
-    scene.remove(this._line)
-    scene.remove(this._fillMesh)
-    scene.remove(this._rimRing)
-    scene.remove(this._helperObj)
+    scene.remove(this._group)   // removes group + all its children
     scene.remove(this.boxHelper)
-    for (const d of this._dots) scene.remove(d)
     this._lineGeo.dispose()
     this._lineMat.dispose()
     if (this._fillGeo) this._fillGeo.dispose()
     this._fillMat.dispose()
-    if (this._rimGeo) this._rimGeo.dispose()
-    this._rimMat.dispose()
+    if (this._rimGeo) this._rimGeo.dispose()  // shared by rimRing1 + rimRing2
+    this._rimMat1.dispose()
+    this._rimMat2.dispose()
     this._dotGeo.dispose()
     this._dotMat.dispose()
     this._dots = []


### PR DESCRIPTION
Root cause: Line2, fill mesh, and vertex dots used world-space geometry with no
mesh.position offset, while the rim ring used centroid-relative local geometry
with position=centroid. These two coordinate origins are logically equivalent at
rest, but when the rim ring's scale is animated by tick() between _setPoints()
rebuilds during drag, the per-frame scale state competes with the position reset —
creating a frame where the scaled ring appears displaced from the boundary line.

Fix: wrap all visual components (line, fill, dots, rim rings, helperObj) in a
single THREE.Group positioned at the polygon centroid. All geometry is now built
in centroid-relative local space; group.position is the sole authority for world
placement. Moving the entity calls _setPoints() once, which updates group.position
and rebuilds geometry — no component can drift independently.

Visual upgrades included:
- Dual rim rings (Zone): two waves at 180° phase offset with Math.pow ease-out
  fade replace the single ring, giving a continuous double-wave pulse effect
- Pending boundary: dashOffset scrolls each tick() frame — "marching ants" flow
  animation while the user is still drawing the region boundary
- Selected state: breathing animation runs faster (π×1.2 vs π×0.5 freq) and
  fill opacity floor rises by +0.08 to give tactile selection feedback

https://claude.ai/code/session_01UkXRX9NBcP7UZWKnAPHo1i