### PR TITLE
feat: add centroid/midpoint labels to Zone and Route annotations

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -1806,11 +1806,15 @@ export class AppController {
         this._service.setPlaceType(obj.id, placeType)
         created = true
       } else if (geometry === 'line' && pendingPoints.length >= 2) {
-        const obj = this._service.createAnnotatedLine(pendingPoints, name, renderer)
+        const obj = this._service.createAnnotatedLine(pendingPoints, name, {
+          camera: this._camera, renderer, container: document.body,
+        })
         this._service.setPlaceType(obj.id, placeType)
         created = true
       } else if (geometry === 'region' && pendingPoints.length >= 3) {
-        const obj = this._service.createAnnotatedRegion(pendingPoints, name, renderer)
+        const obj = this._service.createAnnotatedRegion(pendingPoints, name, {
+          camera: this._camera, renderer, container: document.body,
+        })
         this._service.setPlaceType(obj.id, placeType)
         created = true
       }
@@ -6918,8 +6922,8 @@ export class AppController {
       for (const obj of this._scene.objects.values()) {
         if (obj instanceof MeasureLine)     obj.meshView.updateLabelPosition()
         if (obj instanceof AnnotatedPoint)  { obj.meshView.updateLabelPosition(this._sceneView.activeCamera); obj.meshView.tick(t) }
-        if (obj instanceof AnnotatedLine)   obj.meshView.tick(t)
-        if (obj instanceof AnnotatedRegion) obj.meshView.tick(t)
+        if (obj instanceof AnnotatedLine)   { obj.meshView.updateLabelPosition(this._sceneView.activeCamera); obj.meshView.tick(t) }
+        if (obj instanceof AnnotatedRegion) { obj.meshView.updateLabelPosition(this._sceneView.activeCamera); obj.meshView.tick(t) }
         if (obj instanceof CoordinateFrame) {
           // Cap the frame's world size so it never visually dwarfs its parent.
           // Compute the parent object's bounding radius (max distance from centroid

--- a/src/service/SceneService.js
+++ b/src/service/SceneService.js
@@ -456,18 +456,18 @@ export class SceneService extends EventEmitter {
         }
         entities.push(frame)
       } else if (dto.type === 'AnnotatedLine') {
-        const { renderer = null } = viewContext
+        const { camera = null, renderer = null, container = document.body } = viewContext
         const points  = dto.vertices.map(v => new Vector3(v.x, v.y, v.z))
-        const meshView = new AnnotatedLineView(this._threeScene, points, dto.placeType ?? null, renderer)
+        const meshView = new AnnotatedLineView(this._threeScene, points, dto.placeType ?? null, renderer, camera, container, dto.name ?? '')
         const entity   = AnnotatedLine.fromPoints(dto.id, dto.name, points, meshView)
         entity.description = dto.description ?? ''
         entity.placeType   = dto.placeType   ?? null
         if (entity.placeType) meshView.setPlaceType(entity.placeType)
         entities.push(entity)
       } else if (dto.type === 'AnnotatedRegion') {
-        const { renderer = null } = viewContext
+        const { camera = null, renderer = null, container = document.body } = viewContext
         const points  = dto.vertices.map(v => new Vector3(v.x, v.y, v.z))
-        const meshView = new AnnotatedRegionView(this._threeScene, points, dto.placeType ?? null, renderer)
+        const meshView = new AnnotatedRegionView(this._threeScene, points, dto.placeType ?? null, renderer, camera, container, dto.name ?? '')
         const entity   = AnnotatedRegion.fromPoints(dto.id, dto.name, points, meshView)
         entity.description = dto.description ?? ''
         entity.placeType   = dto.placeType   ?? null
@@ -699,10 +699,11 @@ export class SceneService extends EventEmitter {
     }
 
     if (dto.type === 'AnnotatedLine') {
-      const { renderer = null } = viewContext
+      const { camera = null, renderer = null, container = document.body } = viewContext
+      const lineName = dto.name ?? 'Line'
       const points   = dto.vertices.map(v => new Vector3(v.x, v.y, v.z))
-      const meshView = new AnnotatedLineView(this._threeScene, points, dto.placeType ?? null, renderer)
-      const entity   = AnnotatedLine.fromPoints(newId, dto.name ?? 'Line', points, meshView)
+      const meshView = new AnnotatedLineView(this._threeScene, points, dto.placeType ?? null, renderer, camera, container, lineName)
+      const entity   = AnnotatedLine.fromPoints(newId, lineName, points, meshView)
       entity.description = dto.description ?? ''
       entity.placeType   = dto.placeType   ?? null
       if (entity.placeType) meshView.setPlaceType(entity.placeType)
@@ -710,10 +711,11 @@ export class SceneService extends EventEmitter {
     }
 
     if (dto.type === 'AnnotatedRegion') {
-      const { renderer = null } = viewContext
+      const { camera = null, renderer = null, container = document.body } = viewContext
+      const regionName = dto.name ?? 'Region'
       const points   = dto.vertices.map(v => new Vector3(v.x, v.y, v.z))
-      const meshView = new AnnotatedRegionView(this._threeScene, points, dto.placeType ?? null, renderer)
-      const entity   = AnnotatedRegion.fromPoints(newId, dto.name ?? 'Region', points, meshView)
+      const meshView = new AnnotatedRegionView(this._threeScene, points, dto.placeType ?? null, renderer, camera, container, regionName)
+      const entity   = AnnotatedRegion.fromPoints(newId, regionName, points, meshView)
       entity.description = dto.description ?? ''
       entity.placeType   = dto.placeType   ?? null
       if (entity.placeType) meshView.setPlaceType(entity.placeType)
@@ -1832,13 +1834,15 @@ export class SceneService extends EventEmitter {
    * Emits: 'objectAdded'
    * @param {import('three').Vector3[]} points  N ≥ 2 ordered points
    * @param {string} [name]
-   * @param {import('three').WebGLRenderer} [renderer]
+   * @param {{ camera?: import('three').Camera, renderer?: import('three').WebGLRenderer, container?: HTMLElement }} [viewContext]
    * @returns {AnnotatedLine}
    */
-  createAnnotatedLine(points, name, renderer) {
+  createAnnotatedLine(points, name, viewContext = {}) {
     const id      = `annot_line_${Date.now()}`
-    const meshView = new AnnotatedLineView(this._threeScene, points, null, renderer ?? null)
-    const obj     = AnnotatedLine.fromPoints(id, name ?? 'Line', points, meshView)
+    const lineName = name ?? 'Line'
+    const { camera = null, renderer = null, container = document.body } = viewContext
+    const meshView = new AnnotatedLineView(this._threeScene, points, null, renderer, camera, container, lineName)
+    const obj     = AnnotatedLine.fromPoints(id, lineName, points, meshView)
     this._model.addObject(obj)
     this.emit('objectAdded', obj)
     return obj
@@ -1850,13 +1854,15 @@ export class SceneService extends EventEmitter {
    * Emits: 'objectAdded'
    * @param {import('three').Vector3[]} points  N ≥ 3 points in ring order
    * @param {string} [name]
-   * @param {import('three').WebGLRenderer} [renderer]
+   * @param {{ camera?: import('three').Camera, renderer?: import('three').WebGLRenderer, container?: HTMLElement }} [viewContext]
    * @returns {AnnotatedRegion}
    */
-  createAnnotatedRegion(points, name, renderer) {
+  createAnnotatedRegion(points, name, viewContext = {}) {
     const id      = `annot_region_${Date.now()}`
-    const meshView = new AnnotatedRegionView(this._threeScene, points, null, renderer ?? null)
-    const obj     = AnnotatedRegion.fromPoints(id, name ?? 'Region', points, meshView)
+    const regionName = name ?? 'Region'
+    const { camera = null, renderer = null, container = document.body } = viewContext
+    const meshView = new AnnotatedRegionView(this._threeScene, points, null, renderer, camera, container, regionName)
+    const obj     = AnnotatedRegion.fromPoints(id, regionName, points, meshView)
     this._model.addObject(obj)
     this.emit('objectAdded', obj)
     return obj

--- a/src/view/AnnotatedLineView.js
+++ b/src/view/AnnotatedLineView.js
@@ -43,11 +43,16 @@ export class AnnotatedLineView {
    * @param {THREE.Vector3[]} points  ordered vertex positions (N ≥ 2)
    * @param {string|null}   placeType  'Route' | 'Boundary' | null
    * @param {THREE.WebGLRenderer} renderer  needed for Line2 resolution
+   * @param {THREE.Camera|null}   [camera]   for label projection
+   * @param {HTMLElement|null}    [container] DOM element to append the label to
+   * @param {string}              [name]     entity name shown in label
    */
-  constructor(scene, points, placeType, renderer) {
+  constructor(scene, points, placeType, renderer, camera = null, container = null, name = '') {
     this._scene    = scene
     this._renderer = renderer
+    this._camera   = camera
     this._placeType = placeType
+    this._labelPos  = null
 
     // ── Line2 geometry ─────────────────────────────────────────────────────
     this._lineGeo = new LineGeometry()
@@ -102,6 +107,30 @@ export class AnnotatedLineView {
     this.boxHelper.visible = false
     scene.add(this.boxHelper)
 
+    // ── HTML name label ────────────────────────────────────────────────────
+    this._label = null
+    if (container) {
+      this._label = document.createElement('div')
+      const hexStr = this._colorForType(placeType).toString(16).padStart(6, '0')
+      Object.assign(this._label.style, {
+        position:      'fixed',
+        pointerEvents: 'none',
+        userSelect:    'none',
+        background:    'rgba(20, 20, 20, 0.80)',
+        color:         '#e0e0e0',
+        fontSize:      '11px',
+        fontFamily:    'sans-serif',
+        padding:       '1px 5px',
+        borderRadius:  '3px',
+        whiteSpace:    'nowrap',
+        display:       'none',
+        zIndex:        '50',
+        borderLeft:    `3px solid #${hexStr}`,
+      })
+      this._label.textContent = name
+      container.appendChild(this._label)
+    }
+
     // ── Set initial geometry ───────────────────────────────────────────────
     this._setPoints(points)
   }
@@ -143,6 +172,7 @@ export class AnnotatedLineView {
 
     this._updateBoxHelper(points)
     this._rebuildParticles(points)
+    this._labelPos = this._computeLabelPos(points)
   }
 
   /**
@@ -173,6 +203,30 @@ export class AnnotatedLineView {
       this._scene.add(mesh)
       this._particles.push(mesh)
     }
+  }
+
+  /**
+   * Returns the arc-length midpoint of the polyline for label placement.
+   * @param {THREE.Vector3[]} points
+   * @returns {THREE.Vector3|null}
+   */
+  _computeLabelPos(points) {
+    if (!points || points.length < 2) return null
+    let total = 0
+    for (let i = 0; i < points.length - 1; i++) {
+      total += points[i].distanceTo(points[i + 1])
+    }
+    const half = total * 0.5
+    let cum = 0
+    for (let i = 0; i < points.length - 1; i++) {
+      const segLen = points[i].distanceTo(points[i + 1])
+      if (cum + segLen >= half) {
+        const t = segLen > 0 ? (half - cum) / segLen : 0
+        return points[i].clone().lerp(points[i + 1], t)
+      }
+      cum += segLen
+    }
+    return points[points.length - 1].clone()
   }
 
   /**
@@ -239,6 +293,35 @@ export class AnnotatedLineView {
     }
   }
 
+  // ── Label update (call once per frame while visible) ──────────────────────
+
+  /**
+   * Projects the arc-length midpoint of the polyline to screen and updates label position.
+   * Must be called from the animation loop while visible.
+   * @param {import('three').Camera} [camera]  Active camera (orthographic in Map mode).
+   */
+  updateLabelPosition(camera) {
+    if (!this._label || !this._labelPos) return
+    const cam = camera ?? this._camera
+    if (!cam || !this._renderer || !this._line.visible) return
+    const ndc    = this._labelPos.clone().project(cam)
+    const canvas = this._renderer.domElement
+    const rect   = canvas.getBoundingClientRect()
+    const sx = (ndc.x  + 1) / 2 * rect.width  + rect.left
+    const sy = (-ndc.y + 1) / 2 * rect.height + rect.top
+
+    if (ndc.z > 1) { this._label.style.display = 'none'; return }
+
+    this._label.style.display = 'block'
+    this._label.style.left    = `${Math.round(sx + 4)}px`
+    this._label.style.top     = `${Math.round(sy - 10)}px`
+  }
+
+  /** Updates the label text (e.g. after rename). */
+  setName(name) {
+    if (this._label) this._label.textContent = name
+  }
+
   // ── Move support ───────────────────────────────────────────────────────────
 
   /**
@@ -269,6 +352,10 @@ export class AnnotatedLineView {
     this._dotMat.color.setHex(hex)
     this._partMat.color.setHex(hex)
     this.boxHelper.material?.color.setHex(hex)
+    if (this._label) {
+      const hexStr = hex.toString(16).padStart(6, '0')
+      this._label.style.borderLeft = `3px solid #${hexStr}`
+    }
     // Boundary: confirmed style uses slow-marching dashes (marching-ants animation)
     if (placeType === 'Boundary') {
       this._lineMat.dashed   = true
@@ -304,7 +391,10 @@ export class AnnotatedLineView {
     this._line.visible = visible
     for (const d of this._dots)     d.visible = visible
     for (const p of this._particles) p.visible = visible
-    if (!visible) this.boxHelper.visible = false
+    if (!visible) {
+      this.boxHelper.visible = false
+      if (this._label) this._label.style.display = 'none'
+    }
   }
 
   setObjectSelected(sel) {
@@ -353,5 +443,6 @@ export class AnnotatedLineView {
     this._dots      = []
     this._particles = []
     this._segments  = []
+    if (this._label) this._label.remove()
   }
 }

--- a/src/view/AnnotatedRegionView.js
+++ b/src/view/AnnotatedRegionView.js
@@ -43,10 +43,14 @@ export class AnnotatedRegionView {
    * @param {THREE.Vector3[]}     points     ordered ring positions (N ≥ 3, implicitly closed)
    * @param {string|null}         placeType  'Zone' | null
    * @param {THREE.WebGLRenderer} renderer   needed for Line2 resolution
+   * @param {THREE.Camera|null}   [camera]   for label projection
+   * @param {HTMLElement|null}    [container] DOM element to append the label to
+   * @param {string}              [name]     entity name shown in label
    */
-  constructor(scene, points, placeType, renderer) {
+  constructor(scene, points, placeType, renderer, camera = null, container = null, name = '') {
     this._scene      = scene
     this._renderer   = renderer
+    this._camera     = camera
     this._placeType  = placeType
     this._isSelected = false
     this._isPending  = false
@@ -136,6 +140,30 @@ export class AnnotatedRegionView {
     this.boxHelper = new THREE.BoxHelper(this._helperObj, 0xffffff)
     this.boxHelper.visible = false
     scene.add(this.boxHelper)
+
+    // ── HTML name label ────────────────────────────────────────────────────
+    this._label = null
+    if (container) {
+      this._label = document.createElement('div')
+      const hexStr = this._colorForType(placeType).toString(16).padStart(6, '0')
+      Object.assign(this._label.style, {
+        position:      'fixed',
+        pointerEvents: 'none',
+        userSelect:    'none',
+        background:    'rgba(20, 20, 20, 0.80)',
+        color:         '#e0e0e0',
+        fontSize:      '11px',
+        fontFamily:    'sans-serif',
+        padding:       '1px 5px',
+        borderRadius:  '3px',
+        whiteSpace:    'nowrap',
+        display:       'none',
+        zIndex:        '50',
+        borderLeft:    `3px solid #${hexStr}`,
+      })
+      this._label.textContent = name
+      container.appendChild(this._label)
+    }
 
     // ── Set initial geometry ───────────────────────────────────────────────
     this._setPoints(points)
@@ -275,6 +303,37 @@ export class AnnotatedRegionView {
     this._rimMat2.opacity = RIM_OPACITY_MAX * Math.pow(1 - phase2, 2)
   }
 
+  // ── Label update (call once per frame while visible) ──────────────────────
+
+  /**
+   * Projects the region centroid to screen and updates label position.
+   * Must be called from the animation loop while visible.
+   * @param {import('three').Camera} [camera]  Active camera (orthographic in Map mode).
+   */
+  updateLabelPosition(camera) {
+    if (!this._label) return
+    const cam = camera ?? this._camera
+    if (!cam || !this._renderer || !this._group.visible) return
+    const worldPos = new THREE.Vector3()
+    this._group.getWorldPosition(worldPos)
+    const ndc    = worldPos.project(cam)
+    const canvas = this._renderer.domElement
+    const rect   = canvas.getBoundingClientRect()
+    const sx = (ndc.x  + 1) / 2 * rect.width  + rect.left
+    const sy = (-ndc.y + 1) / 2 * rect.height + rect.top
+
+    if (ndc.z > 1) { this._label.style.display = 'none'; return }
+
+    this._label.style.display = 'block'
+    this._label.style.left    = `${Math.round(sx + 4)}px`
+    this._label.style.top     = `${Math.round(sy - 10)}px`
+  }
+
+  /** Updates the label text (e.g. after rename). */
+  setName(name) {
+    if (this._label) this._label.textContent = name
+  }
+
   // ── Move support ───────────────────────────────────────────────────────────
 
   /**
@@ -310,6 +369,10 @@ export class AnnotatedRegionView {
     const isZone = placeType === 'Zone'
     this._rimRing1.visible = isZone
     this._rimRing2.visible = isZone
+    if (this._label) {
+      const hexStr = hex.toString(16).padStart(6, '0')
+      this._label.style.borderLeft = `3px solid #${hexStr}`
+    }
   }
 
   /**
@@ -330,7 +393,10 @@ export class AnnotatedRegionView {
 
   setVisible(visible) {
     this._group.visible = visible
-    if (!visible) this.boxHelper.visible = false
+    if (!visible) {
+      this.boxHelper.visible = false
+      if (this._label) this._label.style.display = 'none'
+    }
   }
 
   setObjectSelected(sel) {
@@ -379,5 +445,6 @@ export class AnnotatedRegionView {
     this._dotGeo.dispose()
     this._dotMat.dispose()
     this._dots = []
+    if (this._label) this._label.remove()
   }
 }


### PR DESCRIPTION
Zone (AnnotatedRegionView) now shows an HTML name label projected from
the polygon centroid (_group.position).  Route and Boundary
(AnnotatedLineView) now show a label projected from the arc-length
midpoint of the polyline.

Changes:
- AnnotatedRegionView: add camera/container/name constructor params,
  _label DOM element, updateLabelPosition(camera), setName(name);
  setVisible/setPlaceType/dispose updated for label lifecycle.
- AnnotatedLineView: same additions; _computeLabelPos() walks arc
  length to find true midpoint; _labelPos rebuilt on every _setPoints.
- SceneService.createAnnotatedLine/Region: signature changed from
  (points, name, renderer) to (points, name, viewContext={}) to carry
  camera and container — mirrors createAnnotatedPoint API.
  All three deserialization paths updated accordingly.
- AppController: createAnnotatedLine/Region call sites now pass
  {camera, renderer, container}; animation loop calls
  updateLabelPosition(activeCamera) for AnnotatedLine and
  AnnotatedRegion alongside the existing tick() call.

https://claude.ai/code/session_013XZ1qBJhmQTTqQfanyRnKM