### PR TITLE
Fix toolbar slot position jitter and Z-axis gizmo toggle

### DIFF
--- a/src/view/GizmoView.js
+++ b/src/view/GizmoView.js
@@ -29,6 +29,9 @@ export class GizmoView {
     this._camera   = camera
     this._controls = controls
     this._hovered  = null  // e.g. 'X+', 'Y-'
+    this._lastKey      = null   // axis key of last snap, for toggle-back
+    this._prevPosition = null   // camera position before last snap
+    this._prevUp       = null   // camera.up before last snap
 
     this._canvas = document.createElement('canvas')
     this._canvas.width  = SIZE
@@ -170,6 +173,24 @@ export class GizmoView {
     const target = this._controls.target.clone()
     const dist   = this._camera.position.distanceTo(target)
 
+    // Toggle: clicking the same axis key a second time restores the previous perspective view
+    if (key === this._lastKey && this._prevPosition) {
+      this._camera.position.copy(this._prevPosition)
+      this._camera.up.copy(this._prevUp)
+      this._camera.lookAt(target)
+      this._controls.update()
+      this.update()
+      this._lastKey      = null
+      this._prevPosition = null
+      this._prevUp       = null
+      return
+    }
+
+    // Save current camera state so the toggle can restore it
+    this._prevPosition = this._camera.position.clone()
+    this._prevUp       = this._camera.up.clone()
+    this._lastKey      = key
+
     // Direction from origin for each axis view
     const viewDirs = {
       'X+': new THREE.Vector3( 1,  0,  0),
@@ -185,9 +206,14 @@ export class GizmoView {
     // Snap camera position along that axis direction from the orbit target
     this._camera.position.copy(target).addScaledVector(dir, dist)
 
-    // Fix up-vector: top/bottom views (Z+/Z-) use +X as screen-up; others keep +Z up
-    if (key === 'Z+' || key === 'Z-') {
-      this._camera.up.set(1, 0, 0)  // X (forward) points up on screen in top/bottom view
+    // Fix up-vector: top/bottom views (Z+/Z-) use +X as screen-up; others keep +Z up.
+    // Z+ uses a tiny Y offset to prevent gimbal lock (camera look dir parallel to up vec).
+    if (key === 'Z+') {
+      this._camera.position.y += 1e-4  // epsilon prevents gimbal lock in OrbitControls
+      this._camera.up.set(1, 0, 0)
+    } else if (key === 'Z-') {
+      this._camera.position.y += 1e-4
+      this._camera.up.set(1, 0, 0)
     } else {
       this._camera.up.set(0, 0, 1)  // ROS convention: +Z is up for all horizontal views
     }

--- a/src/view/UIView.js
+++ b/src/view/UIView.js
@@ -3414,10 +3414,9 @@ export class UIView {
       if (spacer) {
         const placeholder = document.createElement('div')
         Object.assign(placeholder.style, {
-          minWidth:   '52px',
+          flex:       '1 0 0',
           minHeight:  '48px',
           visibility: 'hidden',
-          flexShrink: '1',
         })
         this._mobileToolbarEl.appendChild(placeholder)
         return
@@ -3432,8 +3431,8 @@ export class UIView {
         alignItems:       'center',
         justifyContent:   'center',
         gap:              '3px',
-        padding:          '6px 12px',
-        minWidth:         '52px',
+        padding:          '6px 4px',
+        flex:             '1 0 0',
         minHeight:        '48px',
         background:       bg,
         border:           `1px solid ${border}`,
@@ -3445,7 +3444,7 @@ export class UIView {
         userSelect:       'none',
         WebkitUserSelect: 'none',
         transition:       'background 0.15s, border-color 0.15s',
-        flexShrink:       '1',
+        overflow:         'hidden',
       })
       if (!indicator) btn.style.cursor = disabled ? 'default' : 'pointer'
 
@@ -3464,11 +3463,16 @@ export class UIView {
       const labelEl = document.createElement('span')
       labelEl.textContent = label
       Object.assign(labelEl.style, {
-        fontSize:      '9px',
-        fontWeight:    '500',
+        fontSize:     '9px',
+        fontWeight:   '500',
         letterSpacing: '0.04em',
         textTransform: 'uppercase',
         opacity:       (disabled && !indicator) ? '0.35' : '0.7',
+        width:         '100%',
+        textAlign:     'center',
+        overflow:      'hidden',
+        textOverflow:  'ellipsis',
+        whiteSpace:    'nowrap',
       })
 
       btn.appendChild(iconEl)


### PR DESCRIPTION
Toolbar: replace minWidth+flexShrink:1 with flex:1 0 0 on every slot
(buttons and spacers alike). All slots now share available width equally,
so position is identical across modes regardless of label text length.
Reduced horizontal padding 12px→4px; added label overflow:hidden +
text-overflow:ellipsis so long labels (e.g. "Add Frame") never widen
their slot.

Gizmo: add toggle-back-to-perspective for all axis balls. Saves camera
position+up before each snap; a second click on the same axis restores
the saved state. Adds a 1e-4 Y epsilon to Z+/Z- positions to prevent
gimbal lock (look-direction parallel to camera.up) in OrbitControls.

https://claude.ai/code/session_01L3rtmNDS8oQY2yfgxydS6Q