### PR TITLE
feat: add 3D rotation sector preview (pie-slice fan in viewport)

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -69,6 +69,7 @@ import { QuickDragState }    from '../core/states/QuickDragState.js'
 import { RectSelectState }   from '../core/states/RectSelectState.js'
 import { inferSemanticRelationships } from '../service/SemanticInferencer.js'
 import { SpatialLinkView }            from '../view/SpatialLinkView.js'
+import { RotateSectorPreview }        from '../view/RotateSectorPreview.js'
 
 // ── Module-level helpers ──────────────────────────────────────────────────────
 
@@ -138,10 +139,11 @@ export class AppController {
    * @param {import('../view/OutlinerView.js').OutlinerView} outlinerView
    */
   constructor(sceneView, uiView, gizmoView = null, outlinerView = null) {
-    this._sceneView    = sceneView
-    this._uiView       = uiView
-    this._gizmoView    = gizmoView
-    this._outlinerView = outlinerView
+    this._sceneView          = sceneView
+    this._uiView             = uiView
+    this._gizmoView          = gizmoView
+    this._outlinerView       = outlinerView
+    this._rotateSectorPreview = new RotateSectorPreview(sceneView.scene)
 
     // ── Application service (owns SceneModel aggregate root) ─────────────
     this._service = new SceneService(sceneView.scene)
@@ -4706,6 +4708,7 @@ export class AppController {
       this._rotate.needsStartAngle   = false
     }
 
+    this._refreshSectorPreview()
     this._controls.enabled = false
     this._updateRotateStatus()
     if (window.matchMedia('(pointer: coarse)').matches) this._updateMobileToolbar()
@@ -4751,6 +4754,7 @@ export class AppController {
     this._rotate.segStartPos         = null
     this._rotate.segStartPivot       = null
     this._rotate.needsStartAngle     = false
+    this._rotateSectorPreview.hide()
     this._gizmoView?.setRotationArc(null)
     this._opState.send('CONFIRM')
     this._controls.enabled          = true
@@ -4784,6 +4788,7 @@ export class AppController {
     this._rotate.segStartPos         = null
     this._rotate.segStartPivot       = null
     this._rotate.needsStartAngle     = false
+    this._rotateSectorPreview.hide()
     this._gizmoView?.setRotationArc(null)
     this._opState.send('CANCEL')
     this._controls.enabled          = true
@@ -4823,6 +4828,7 @@ export class AppController {
     } else {
       this._hideAxisGuide()
     }
+    this._refreshSectorPreview()
     this._applyRotate()
     this._updateRotateStatus()
     if (window.matchMedia('(pointer: coarse)').matches) this._updateMobileToolbar()
@@ -4902,6 +4908,31 @@ export class AppController {
     }, deltaQ)
     this._updateRotateStatus()
     this._gizmoView?.setRotationArc(angle, this._rotate.axis)
+    this._rotateSectorPreview.updateAngle(angle)
+  }
+
+  /**
+   * (Re)creates the 3D sector preview at the pivot with the current axis orientation.
+   * Called at rotate start and on every axis toggle.
+   */
+  _refreshSectorPreview() {
+    const obj = this._activeObj
+    if (!obj) return
+
+    let center, radius
+    if (obj instanceof Solid) {
+      center = (this._rotate.segStartPivot ?? obj._position).clone()
+      // Radius: max corner distance from pivot; floor at 0.5 to stay visible on tiny solids
+      const raw = Math.max(...obj.corners.map(c => c.distanceTo(center)))
+      radius = Math.max(raw, 0.5) * 1.1
+    } else if (obj instanceof CoordinateFrame) {
+      center = (this._service.worldPoseOf(obj.id)?.position ?? obj.translation).clone()
+      radius = 0.8
+    } else {
+      return
+    }
+
+    this._rotateSectorPreview.show(center, radius, this._rotate.axis, this._camera)
   }
 
   /**

--- a/src/view/RotateSectorPreview.js
+++ b/src/view/RotateSectorPreview.js
@@ -1,0 +1,116 @@
+import * as THREE from 'three'
+
+const AXIS_COLOR = { x: 0xe05555, y: 0x50c060, z: 0x4d80e6 }
+const FREE_COLOR = 0xaabbff
+
+/**
+ * Transient 3D sector (pie-slice) rendered in the viewport during R-key rotation.
+ *
+ * Lives entirely in the view layer — no domain state.
+ * Lifecycle: show() → updateAngle() (per pointer move) → hide() on confirm/cancel.
+ */
+export class RotateSectorPreview {
+  /** @param {import('three').Scene} scene */
+  constructor(scene) {
+    this._scene  = scene
+    this._group  = null
+    this._mesh   = null
+    this._mat    = null
+    this._radius = 1
+  }
+
+  /**
+   * Creates the sector mesh at the pivot and adds it to the scene.
+   * Safe to call repeatedly — tears down any previous sector first.
+   *
+   * @param {import('three').Vector3}   center - Pivot point in world space
+   * @param {number}                    radius - Outer radius in world units
+   * @param {'x'|'y'|'z'|null}         axis   - Constrained axis, or null for free (camera-facing)
+   * @param {import('three').Camera}    camera - Required when axis is null (free rotation)
+   */
+  show(center, radius, axis, camera) {
+    this.hide()
+
+    this._radius = Math.max(radius, 0.25)
+
+    this._mat = new THREE.MeshBasicMaterial({
+      color:               axis ? (AXIS_COLOR[axis] ?? FREE_COLOR) : FREE_COLOR,
+      side:                THREE.DoubleSide,
+      transparent:         true,
+      opacity:             0.25,
+      depthWrite:          false,
+      depthTest:           true,
+      polygonOffset:       true,
+      polygonOffsetFactor: -1,
+      polygonOffsetUnits:  -4,
+    })
+
+    // Start with an invisible zero-angle sector; updateAngle() gives it shape
+    this._mesh = new THREE.Mesh(
+      new THREE.RingGeometry(0, this._radius, 2, 1, 0, 0),
+      this._mat,
+    )
+
+    this._group = new THREE.Group()
+    this._group.position.copy(center)
+    this._group.quaternion.copy(this._ringOrientation(axis, camera))
+    this._group.add(this._mesh)
+    this._scene.add(this._group)
+  }
+
+  /**
+   * Rebuilds the sector geometry to match the given cumulative rotation angle.
+   * Positive = counter-clockwise fan from 0; negative = clockwise fan toward 0.
+   * @param {number} angle - Radians
+   */
+  updateAngle(angle) {
+    if (!this._mesh) return
+    this._mesh.geometry.dispose()
+
+    const abs   = Math.abs(angle)
+    const start = angle < 0 ? angle : 0
+    const segs  = Math.max(3, Math.ceil(abs * 16))
+    this._mesh.geometry = new THREE.RingGeometry(0, this._radius, segs, 1, start, abs)
+  }
+
+  /** Removes the sector from the scene and releases GPU resources. */
+  hide() {
+    if (!this._group) return
+    this._scene.remove(this._group)
+    this._mesh?.geometry.dispose()
+    this._mat?.dispose()
+    this._group = null
+    this._mesh  = null
+    this._mat   = null
+  }
+
+  // ── Internals ──────────────────────────────────────────────────────────────
+
+  /**
+   * Returns the quaternion that orients the ring's +Z normal along the rotation axis.
+   * THREE.RingGeometry lies in the XY plane by default (normal = +Z).
+   *
+   * @param {'x'|'y'|'z'|null}       axis
+   * @param {import('three').Camera}  camera
+   * @returns {import('three').Quaternion}
+   */
+  _ringOrientation(axis, camera) {
+    const q = new THREE.Quaternion()
+    if (axis === 'x') {
+      // Ring in YZ plane: rotate around world Y by +90°
+      q.setFromAxisAngle(new THREE.Vector3(0, 1, 0), Math.PI / 2)
+    } else if (axis === 'y') {
+      // Ring in XZ plane: rotate around world X by −90°
+      q.setFromAxisAngle(new THREE.Vector3(1, 0, 0), -Math.PI / 2)
+    } else if (axis !== 'z' && camera) {
+      // Free rotation (screen-plane): ring faces the viewer.
+      // The rotation axis in AppController is getWorldDirection().negate(),
+      // so we orient the ring normal the same way (toward viewer).
+      const fwd = new THREE.Vector3()
+      camera.getWorldDirection(fwd)
+      q.setFromUnitVectors(new THREE.Vector3(0, 0, 1), fwd.negate())
+    }
+    // axis === 'z': ring is already in XY plane — identity quaternion (default)
+    return q
+  }
+}


### PR DESCRIPTION
Adds a transient RingGeometry mesh that appears directly at the Solid or CF
pivot during R-key rotation, sweeping to show the cumulative angle.  Complements
the existing 2D gizmo arc by grounding the visual feedback in world space.

- New RotateSectorPreview view class (show / updateAngle / hide lifecycle)
- Ring orientation driven by rotation axis: YZ (X), XZ (Y), XY (Z), screen-facing (free)
- _refreshSectorPreview() helper recreates the ring on rotate start and on axis toggle
- hide() called in both _confirmRotate and _cancelRotate for full resource cleanup

https://claude.ai/code/session_01RFSQ5FYR7taSi2QVoB3pxR