### PR TITLE
Fix rotate angle flip at 232.5° and remove gizmo arc

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -600,6 +600,10 @@ export class AppController {
       needsStartAngle:      false,
       /** Per-segment start angle; equals startAngle on PC (single drag). */
       segmentStartAngle:    0,
+      /** Angle from pivot to cursor at the previous frame; used for incremental accumulation. */
+      prevCurrentAngle:     0,
+      /** Accumulated signed rotation (radians) for the current drag segment. */
+      accumulatedAngle:     0,
       /** Per-segment quaternion for CoordinateFrame; equals startRot on PC. */
       segmentStartRot:      new THREE.Quaternion(),
       // ADR-040 Solid rotate state (replaces startCorners/segmentStartCorners/bodyRot fields)
@@ -4698,6 +4702,8 @@ export class AppController {
       this._rotate.needsStartAngle   = true
       this._rotate.startAngle        = 0
       this._rotate.segmentStartAngle = 0
+      this._rotate.prevCurrentAngle  = 0
+      this._rotate.accumulatedAngle  = 0
     } else {
       // PC: startAngle from current mouse position
       this._rotate.startAngle = Math.atan2(
@@ -4705,6 +4711,8 @@ export class AppController {
         this._mouse.x - projected.x,
       )
       this._rotate.segmentStartAngle = this._rotate.startAngle
+      this._rotate.prevCurrentAngle  = this._rotate.startAngle
+      this._rotate.accumulatedAngle  = 0
       this._rotate.needsStartAngle   = false
     }
 
@@ -4755,7 +4763,6 @@ export class AppController {
     this._rotate.segStartPivot       = null
     this._rotate.needsStartAngle     = false
     this._rotateSectorPreview.hide()
-    this._gizmoView?.setRotationArc(null)
     this._opState.send('CONFIRM')
     this._controls.enabled          = true
     this._refreshObjectModeStatus()
@@ -4789,7 +4796,6 @@ export class AppController {
     this._rotate.segStartPivot       = null
     this._rotate.needsStartAngle     = false
     this._rotateSectorPreview.hide()
-    this._gizmoView?.setRotationArc(null)
     this._opState.send('CANCEL')
     this._controls.enabled          = true
     this._hideAxisGuide()
@@ -4861,11 +4867,20 @@ export class AppController {
       )
       // Mobile: defer start angle to first canvas touch so there's no jump.
       if (this._rotate.needsStartAngle) {
-        this._rotate.segmentStartAngle = currentAngle
-        this._rotate.needsStartAngle   = false
+        this._rotate.prevCurrentAngle = currentAngle
+        this._rotate.accumulatedAngle = 0
+        this._rotate.needsStartAngle  = false
         return
       }
-      angle = currentAngle - this._rotate.segmentStartAngle
+      // Incremental accumulation: normalize each per-frame delta to [-π, π] so
+      // crossing the atan2 branch-cut (directly left of pivot) never causes a
+      // sudden ±360° jump.
+      let delta = currentAngle - this._rotate.prevCurrentAngle
+      if (delta > Math.PI)  delta -= 2 * Math.PI
+      if (delta < -Math.PI) delta += 2 * Math.PI
+      this._rotate.accumulatedAngle += delta
+      this._rotate.prevCurrentAngle  = currentAngle
+      angle = this._rotate.accumulatedAngle
       // Ctrl: snap to stepSize degree increments
       if (this._ctrlHeld) {
         const stepRad = this._rotate.stepSize * (Math.PI / 180)
@@ -4907,7 +4922,6 @@ export class AppController {
       pivot: this._rotate.segStartPivot ?? obj._position.clone(),
     }, deltaQ)
     this._updateRotateStatus()
-    this._gizmoView?.setRotationArc(angle, this._rotate.axis)
     this._rotateSectorPreview.updateAngle(angle)
   }
 

--- a/src/view/GizmoView.js
+++ b/src/view/GizmoView.js
@@ -32,7 +32,6 @@ export class GizmoView {
     this._lastKey      = null   // axis key of last snap, for toggle-back
     this._prevPosition = null   // camera position before last snap
     this._prevUp       = null   // camera.up before last snap
-    this._rotationArc  = null   // { sweepAngle: number, axis: string|null } during rotate
 
     this._canvas = document.createElement('canvas')
     this._canvas.width  = SIZE
@@ -61,16 +60,6 @@ export class GizmoView {
   /** Adjusts the right offset to avoid overlapping the N panel */
   setRightOffset(px) {
     this._canvas.style.right = `${px}px`
-  }
-
-  /**
-   * Shows a rotation arc preview on the gizmo canvas while rotating.
-   * @param {number|null} sweepAngle - total rotation in radians (null to hide)
-   * @param {'x'|'y'|'z'|null} axis - constrained axis, or null for free rotation
-   */
-  setRotationArc(sweepAngle, axis) {
-    this._rotationArc = sweepAngle != null ? { sweepAngle, axis } : null
-    this.update()
   }
 
   // ── Projection ─────────────────────────────────────────────────────────────
@@ -102,72 +91,6 @@ export class GizmoView {
     const axes = this._projectAxes()
 
     ctx.clearRect(0, 0, SIZE, SIZE)
-
-    // Draw rotation arc preview behind axis lines when rotate is active
-    if (this._rotationArc && Math.abs(this._rotationArc.sweepAngle) > 1e-4) {
-      const { sweepAngle, axis } = this._rotationArc
-      const axisEntry = axis ? AXES.find(a => a.label === axis.toUpperCase()) : null
-      const color     = axisEntry ? axisEntry.color : '#aabbff'
-      const radius    = ARM_LEN * 0.75
-      const sAngle    = -Math.PI / 2   // 12 o'clock as reference start direction
-      const eAngle    = sAngle + sweepAngle
-      const ccw       = sweepAngle < 0
-
-      ctx.save()
-
-      // Pie fill (semi-transparent)
-      ctx.beginPath()
-      ctx.moveTo(HALF, HALF)
-      ctx.arc(HALF, HALF, radius, sAngle, eAngle, ccw)
-      ctx.closePath()
-      ctx.globalAlpha = 0.22
-      ctx.fillStyle   = color
-      ctx.fill()
-
-      // Arc edge stroke
-      ctx.globalAlpha = 0.85
-      ctx.beginPath()
-      ctx.arc(HALF, HALF, radius, sAngle, eAngle, ccw)
-      ctx.strokeStyle = color
-      ctx.lineWidth   = 1.5
-      ctx.stroke()
-
-      // Start radial tick (dashed, from center to arc start)
-      ctx.globalAlpha = 0.45
-      ctx.setLineDash([3, 3])
-      ctx.beginPath()
-      ctx.moveTo(HALF, HALF)
-      ctx.lineTo(HALF + radius * Math.cos(sAngle), HALF + radius * Math.sin(sAngle))
-      ctx.strokeStyle = color
-      ctx.lineWidth   = 1
-      ctx.stroke()
-
-      // End radial tick (solid, current angle)
-      ctx.globalAlpha = 1.0
-      ctx.setLineDash([])
-      ctx.beginPath()
-      ctx.moveTo(HALF, HALF)
-      ctx.lineTo(HALF + radius * Math.cos(eAngle), HALF + radius * Math.sin(eAngle))
-      ctx.strokeStyle = color
-      ctx.lineWidth   = 1.5
-      ctx.stroke()
-
-      // Angle label with dark background for readability over axis lines
-      const deg   = sweepAngle * 180 / Math.PI
-      const label = (deg >= 0 ? '+' : '') + deg.toFixed(1) + '°'
-      ctx.font = 'bold 10px sans-serif'
-      ctx.textAlign    = 'center'
-      ctx.textBaseline = 'middle'
-      const tw = ctx.measureText(label).width
-      ctx.globalAlpha = 0.75
-      ctx.fillStyle   = '#0d0d1a'
-      ctx.fillRect(HALF - tw / 2 - 2, HALF - 7, tw + 4, 14)
-      ctx.globalAlpha = 1.0
-      ctx.fillStyle   = '#ffffff'
-      ctx.fillText(label, HALF, HALF)
-
-      ctx.restore()
-    }
 
     // Build a flat render list (positive + negative for each axis)
     const items = []


### PR DESCRIPTION
Bugfix: R-key rotation jumped ±360° when cursor crossed the atan2 ±π
branch-cut (directly left of pivot). Root cause: `angle = currentAngle -
segmentStartAngle` used the raw atan2 difference, which flips by 2π at
the discontinuity. Fixed by accumulating incremental per-frame deltas
(each normalized to [-π, π]) so full rotations beyond ±180° work without
any jump.

Also removes the rotation arc overlay from the world orientation gizmo
(GizmoView) per user request — `setRotationArc()`, `_rotationArc` state,
and all arc-drawing code are deleted; call sites in AppController removed.

https://claude.ai/code/session_01WmSUDMHMqFpHPRGA7Q9kYE