### PR TITLE
fix: preserve axis-constraint position when switching grab axis

### DIFF
--- a/docs/CODE_CONTRACTS.md
+++ b/docs/CODE_CONTRACTS.md
@@ -101,7 +101,7 @@ Detail: `docs/code_contracts/interaction.md`
 | Gesture-Based Interaction Priority | Auto-start face extrude on touch tap in Edit 3D; gesture-only, no toolbar button |
 | Interaction Confirmation Lifecycle | FaceExtrude confirms on `pointerup`; Grab on touch confirms via toolbar only, never in `pointerup` |
 | Mobile Rotate Interaction Lifecycle | Rotate button calls `_startRotate(true)`; each canvas touch re-anchors `segmentStart*`; `_onPointerUp` keeps rotate active; confirm via toolbar only |
-| Grab State: allStartCorners vs segmentStartCorners | `allStartCorners` = undo anchor (never update mid-grab); `segmentStartCorners` = per-drag delta (re-snapshot on re-touch) |
+| Grab State: allStartCorners vs segmentStartCorners | `allStartCorners` = undo anchor (never update mid-grab); `segmentStartCorners` = per-drag delta (re-snapshot on re-touch OR on axis-constraint switch in `_setGrabAxis()`). Re-snapshot triggers: (1) touch `pointerdown` in `S_GRAB_ACTIVE`; (2) `_setGrabAxis()` axis change — preserves accumulated offset from the previous constraint. `startMouse` is also reset on axis switch so the new delta starts at zero. |
 | Global Event vs. UI Event Delegation | First guard in `_onPointerDown`: `if (e.target !== renderer.domElement) return` |
 | OrbitControls Disable Strategy | Use `matchMedia('(pointer: coarse)')` not `innerWidth < 768`; disable only for single-finger-consuming ops |
 

--- a/docs/STATE_TRANSITIONS.md
+++ b/docs/STATE_TRANSITIONS.md
@@ -230,6 +230,9 @@ GRAB ACTIVE (grab.active = true)
     |
     |── mouse move → _applyGrab()
     |── X/Y/Z key → _setGrabAxis(axis)  (axis lock)
+    |       re-snapshots segmentStartCorners/segmentStartPositions to current positions
+    |       and resets startMouse — preserves accumulated offset from previous constraint
+    |       (e.g. X→Y keeps the X movement; switching back to free grab also resets startPoint)
     |── V key → PIVOT SELECT MODE (grab.pivotSelectMode = true)
     |       |── mouse move → _updatePivotHover()
     |       |── left click → _confirmPivotSelect() → GRAB ACTIVE

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -4973,6 +4973,28 @@ export class AppController {
     this._grab.axis     = (this._grab.axis === axis) ? null : axis
     this._grab.inputStr = ''
     this._grab.hasInput = false
+    // Re-snapshot current positions as the new segment start so accumulated
+    // movement from the previous axis constraint is preserved (e.g. X→Y keeps
+    // the X offset). Mirrors the touch re-grab pattern (pointerdown in S_GRAB_ACTIVE).
+    this._grab.segmentStartCorners = new Map()
+    this._grab.segmentStartPositions = new Map()
+    for (const id of this._selectedIds) {
+      const selObj = this._scene.getObject(id)
+      if (selObj) {
+        this._grab.segmentStartCorners.set(id, _grabHandlesOf(selObj).map(c => c.clone()))
+        if (selObj instanceof Solid) this._grab.segmentStartPositions.set(id, selObj._position.clone())
+      }
+    }
+    this._grab.startMouse.copy(this._mouse)
+    if (!this._grab.axis) {
+      // Switching back to free grab: reset the 3D drag-plane anchor to the current
+      // mouse position so the free-grab delta starts at zero.
+      this._raycaster.setFromCamera(this._mouse, this._camera)
+      const _pt = new THREE.Vector3()
+      if (this._raycaster.ray.intersectPlane(this._grab.dragPlane, _pt)) {
+        this._grab.startPoint.copy(_pt)
+      }
+    }
     this._applyGrab()
     this._updateGrabStatus()
     if (this._grab.axis) {


### PR DESCRIPTION
When switching axis constraints during Grab (e.g. X→Y), re-snapshot
segmentStartCorners/segmentStartPositions and startMouse to the current
object positions. Previously, switching axes recalculated the delta from
the original grab-start anchor, silently discarding any movement made
under the previous constraint.

When toggling back to free grab (axis=null), also reset startPoint to
the current ray-plane intersection so free-grab delta starts at zero.

Mirrors the existing touch re-grab snapshot pattern (S_GRAB_ACTIVE
pointerdown path, line ~6039).