### PR TITLE
feat: 偶然×意図のアハ体験を強化する5つのUXアップグレード

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -67,9 +67,10 @@ import { EndpointDragState } from '../core/states/EndpointDragState.js'
 import { SketchDrawState }   from '../core/states/SketchDrawState.js'
 import { QuickDragState }    from '../core/states/QuickDragState.js'
 import { RectSelectState }   from '../core/states/RectSelectState.js'
-import { inferSemanticRelationships } from '../service/SemanticInferencer.js'
-import { SpatialLinkView }            from '../view/SpatialLinkView.js'
+import { inferSemanticRelationships, computeApproachWarmth } from '../service/SemanticInferencer.js'
+import { SpatialLinkView, LINK_TYPE_COLORS } from '../view/SpatialLinkView.js'
 import { RotateSectorPreview }        from '../view/RotateSectorPreview.js'
+import { RippleEffect }               from '../view/RippleEffect.js'
 
 // ── Module-level helpers ──────────────────────────────────────────────────────
 
@@ -498,6 +499,8 @@ export class AppController {
     this._quickDragHandler     = new QuickDragState()
     /** @type {import('../view/SpatialLinkView.js').SpatialLinkView|null} Ghost link during drag suggestion */
     this._ghostLinkView        = null
+    /** @type {import('../view/RippleEffect.js').RippleEffect[]} Active link-acceptance ripple animations */
+    this._activeRipples        = []
     this._rectSelHandler       = new RectSelectState()
 
     // ── Face extrude state (Edit Mode · 3D, E key) ─────────────────────────
@@ -561,6 +564,10 @@ export class AppController {
       stacking:        false,
       /** Last delta applied via _applyGrabDeltaToAll; used for live coordinate display. */
       lastDelta:       new THREE.Vector3(),
+      /** True when a live semantic suggestion is showing during G-key grab (ADR-041 Phase 3). */
+      isSuggesting:    false,
+      /** The suggestion currently displayed, or null. @type {object|null} */
+      currentSuggestion: null,
     }
 
     /** Unsubscribe function for the active import.progress WS listener, or null */
@@ -2668,6 +2675,15 @@ export class AppController {
     this._commandStack.push(createSpatialLinkCommand(link, this._service))
     this._uiView.showToast(`Link created: ${option.label}`)
     this._updateNPanel()
+    // Acceptance ceremony: ripple sphere at link midpoint + brief line flash.
+    const srcPos = this._dragSuggestionCentroid(sourceId)
+    const tgtPos = this._dragSuggestionCentroid(targetId)
+    if (srcPos && tgtPos) {
+      const midpoint = srcPos.clone().lerp(tgtPos, 0.5)
+      const color    = LINK_TYPE_COLORS[option.semanticType] ?? 0x888888
+      this._activeRipples.push(new RippleEffect(this._sceneView.scene, midpoint, color))
+    }
+    this._service._linkViews.get(link.id)?.triggerFlash?.()
   }
 
   /**
@@ -3873,6 +3889,9 @@ export class AppController {
     if (this._opState.is(S_MOUNT_PICKING))    this._cancelMountPicking()
     if (this._opState.is(S_QUICK_DRAG)) {
       this._quickDragHandler.cancel(this._quickDragCtx)
+      for (const obj of this._scene.objects.values()) {
+        if (obj instanceof Solid) obj.meshView?.setApproachWarmth(0)
+      }
       this._opState.send('CANCEL')
       this._service.setLinkDragging(new Set(), false)
       this._service.updateLinkSelectionHighlight(this._selectedIds)
@@ -4452,8 +4471,10 @@ export class AppController {
     this._grab.centroid.copy(grabCenter)
     this._grab.pivot.copy(this._grab.centroid)
     this._grab.lastDelta.set(0, 0, 0)
-    this._grab.pivotLabel = 'Centroid'
-    this._grab.autoSnap   = false
+    this._grab.pivotLabel      = 'Centroid'
+    this._grab.autoSnap        = false
+    this._grab.isSuggesting    = false
+    this._grab.currentSuggestion = null
 
     // ADR-032 §6: for mounted Annotated* entities, constrain drag to host local XY plane.
     // For unmounted Annotated* entities, constrain to world XY (prevents Z drift).
@@ -4499,6 +4520,16 @@ export class AppController {
   _confirmGrab() {
     if (!this._opState.is(S_GRAB_ACTIVE)) return
     if (this._grab.pivotSelectMode) { this._cancelPivotSelect(); return }
+    // Clear live suggestion ghost before final state is committed (Drag Suggestion Lifecycle).
+    if (this._grab.isSuggesting) {
+      this._grab.isSuggesting      = false
+      this._grab.currentSuggestion = null
+      this._quickDragCtx.hideDragSuggestion()
+    }
+    // Clear approach warmth on all Solids.
+    for (const obj of this._scene.objects.values()) {
+      if (obj instanceof Solid) obj.meshView?.setApproachWarmth(0)
+    }
     this._applyGrab()
 
     // ADR-032 §6: after grab on mounted Annotated* entities, sync local positions
@@ -4545,6 +4576,14 @@ export class AppController {
   _cancelGrab() {
     if (!this._opState.is(S_GRAB_ACTIVE)) return
     if (this._grab.pivotSelectMode) { this._grab.pivotSelectMode = false }
+    if (this._grab.isSuggesting) {
+      this._grab.isSuggesting      = false
+      this._grab.currentSuggestion = null
+      this._quickDragCtx.hideDragSuggestion()
+    }
+    for (const obj of this._scene.objects.values()) {
+      if (obj instanceof Solid) obj.meshView?.setApproachWarmth(0)
+    }
     // Restore all selected objects to their pre-grab positions
     for (const [id, startCorners] of this._grab.allStartCorners) {
       const selObj = this._scene.getObject(id)
@@ -5036,6 +5075,41 @@ export class AppController {
       }
     } else {
       this._grab.stacking = false
+    }
+
+    // Live inference preview during G-key grab (ADR-041 Phase 3 — mirrors QuickDragState sub-state).
+    if (this._selectedIds.size === 1) {
+      const ctx        = this._quickDragCtx
+      const suggestion = ctx.runInference()
+      const key        = suggestion ? `${suggestion.semanticType}|${suggestion.targetId}` : null
+      const prevKey    = this._grab.currentSuggestion
+        ? `${this._grab.currentSuggestion.semanticType}|${this._grab.currentSuggestion.targetId}` : null
+      if (suggestion) {
+        if (!this._grab.isSuggesting || key !== prevKey) {
+          this._grab.isSuggesting      = true
+          this._grab.currentSuggestion = suggestion
+          ctx.showDragSuggestion(suggestion)
+        } else {
+          ctx.updateDragSuggestion(suggestion)
+        }
+      } else if (this._grab.isSuggesting) {
+        this._grab.isSuggesting      = false
+        this._grab.currentSuggestion = null
+        ctx.hideDragSuggestion()
+      }
+    }
+
+    // Approach gradient: warm wireframe of nearby Solids before the snap threshold is reached.
+    const [movedId] = this._selectedIds
+    const movedObj  = this._scene.getObject(movedId)
+    if (movedObj instanceof Solid) {
+      const warmthEntries = computeApproachWarmth(movedObj, this._scene.objects.values())
+      const warmthMap     = new Map(warmthEntries.map(e => [e.targetId, e.warmth]))
+      for (const obj of this._scene.objects.values()) {
+        if (obj instanceof Solid && !this._selectedIds.has(obj.id)) {
+          obj.meshView?.setApproachWarmth(warmthMap.get(obj.id) ?? 0)
+        }
+      }
     }
   }
 
@@ -6571,6 +6645,9 @@ export class AppController {
       this._opState.send('CONFIRM')
       this._service.setLinkDragging(new Set(), false)
       this._service.updateLinkSelectionHighlight(this._selectedIds)
+      for (const obj of this._scene.objects.values()) {
+        if (obj instanceof Solid) obj.meshView?.setApproachWarmth(0)
+      }
       this._runSemanticInference()
     }
   }
@@ -6681,7 +6758,16 @@ export class AppController {
         case 'y': case 'Y': this._setGrabAxis('y'); return
         case 'z': case 'Z': this._setGrabAxis('z'); return
         case 's': case 'S': this._toggleStackMode(); return
-        case 'Enter':        this._confirmGrab();    return
+        case 'Enter':
+          if (this._grab.isSuggesting && this._grab.currentSuggestion) {
+            this._createSpatialLinkDirect(
+              this._grab.currentSuggestion.sourceId,
+              this._grab.currentSuggestion.targetId,
+              this._grab.currentSuggestion,
+            )
+          }
+          this._confirmGrab()
+          return
         case 'Escape':       this._cancelGrab();     return
         case '1': this._setSnapMode('vertex'); return
         case '2': this._setSnapMode('edge');   return
@@ -7013,7 +7099,15 @@ export class AppController {
       this._service._updateWorldPoses()
       for (const obj of this._scene.objects.values()) {
         if (obj instanceof MeasureLine)     obj.meshView.updateLabelPosition()
-        if (obj instanceof AnnotatedPoint)  { obj.meshView.updateLabelPosition(this._sceneView.activeCamera); obj.meshView.tick(t) }
+        if (obj instanceof AnnotatedPoint)  {
+          obj.meshView.updateLabelPosition(this._sceneView.activeCamera)
+          obj.meshView.tick(t)
+          // Bilateral tolerance alarm: update error bridge line toward violated CF.
+          if (obj.meshView._bridgeCfId) {
+            const pose = this._service._worldPoseCache.get(obj.meshView._bridgeCfId)
+            if (pose) obj.meshView.updateBridgeLine(this._sceneView.scene, pose.position)
+          }
+        }
         if (obj instanceof AnnotatedLine)   { obj.meshView.updateLabelPosition(this._sceneView.activeCamera); obj.meshView.tick(t) }
         if (obj instanceof AnnotatedRegion) { obj.meshView.updateLabelPosition(this._sceneView.activeCamera); obj.meshView.tick(t) }
         if (obj instanceof CoordinateFrame) {
@@ -7046,6 +7140,14 @@ export class AppController {
           obj.meshView.updateScale(this._camera, this._sceneView.renderer, maxWS)
           obj.meshView.updateLabelPosition(this._sceneView.activeCamera)
         }
+      }
+      // Tick and prune completed link-acceptance ripple animations.
+      if (this._activeRipples.length > 0) {
+        this._activeRipples = this._activeRipples.filter(r => {
+          const done = r.tick(t)
+          if (done) r.dispose()
+          return !done
+        })
       }
     }
     loop()

--- a/src/service/SceneService.js
+++ b/src/service/SceneService.js
@@ -1513,7 +1513,9 @@ export class SceneService extends EventEmitter {
         tension = Math.max(0, (currentDist / view.restDistance) - 1) / 0.5
       }
 
-      view.update(src, tgt, dashOffset, tension)
+      const severity = link.semanticType === 'bounded_by'
+        ? (link.properties?.severity ?? 0) : 0
+      view.update(src, tgt, dashOffset, tension, severity)
     }
 
     this._evaluateClearanceLinks()
@@ -1530,9 +1532,15 @@ export class SceneService extends EventEmitter {
     // Aggregate contains-link targets so multiple links to the same Solid compose correctly.
     const containsTargetIds   = new Set()
     const violatedContainsIds = new Set()
+    // Bilateral: also track source Regions that have violated contains-links.
+    const containsSourceIds         = new Set()
+    const violatedContainsSourceIds = new Set()
     // Aggregate tact-time-link targets so Hub visual state is OR-composed across multiple routes.
     const tactTimeHubIds     = new Set()
     const violatedTactHubIds = new Set()
+    // Bilateral: also track source Routes that have violated tact-time links.
+    const tactTimeRouteIds     = new Set()
+    const violatedTactRouteIds = new Set()
     // Aggregate tolerance-references targets (Anchor → CF) for OR-composed Anchor visual state.
     const toleranceAnchorIds        = new Set()
     const violatedToleranceAnchorIds = new Set()
@@ -1560,6 +1568,10 @@ export class SceneService extends EventEmitter {
           ? `⚠️ 安全距離不足: ${minDist.toFixed(0)}mm (要求: ${limit}mm)`
           : ''
         link.properties.currentClearance = minDist
+        // Severity: 0 at 2× clearance, 0.5 at 1.5×, 1.0 at threshold and beyond (one-frame lag is intentional).
+        link.properties.severity = link.violated
+          ? 1.0
+          : (limit > 0 ? Math.max(0, 1 - (minDist / limit - 1)) : 0)
 
         this._linkViews.get(link.id)?.setViolated?.(link.violated)
 
@@ -1585,6 +1597,9 @@ export class SceneService extends EventEmitter {
           containsTargetIds.add(link.targetId)
           if (link.violated) violatedContainsIds.add(link.targetId)
         }
+        // Bilateral: track Zone source for reverse alarm.
+        containsSourceIds.add(link.sourceId)
+        if (link.violated) violatedContainsSourceIds.add(link.sourceId)
 
       } else if (link.semanticType === 'connects' && link.properties?.deadline !== undefined) {
         // Tact-time evaluation: Route (AnnotatedLine) → Hub (AnnotatedPoint).
@@ -1615,6 +1630,9 @@ export class SceneService extends EventEmitter {
 
         tactTimeHubIds.add(link.targetId)
         if (link.violated) violatedTactHubIds.add(link.targetId)
+        // Bilateral: track Route source for reverse alarm.
+        tactTimeRouteIds.add(link.sourceId)
+        if (link.violated) violatedTactRouteIds.add(link.sourceId)
 
       } else if (link.semanticType === 'references' && link.properties?.tolerance !== undefined) {
         // ADR-043 Phase 4: Anchor tolerance check — Anchor (AnnotatedPoint) → CoordinateFrame.
@@ -1645,6 +1663,9 @@ export class SceneService extends EventEmitter {
         this._linkViews.get(link.id)?.setViolated?.(link.violated)
 
         toleranceAnchorIds.add(link.sourceId)
+        // Store cfId on the anchor view so it can draw the error bridge line.
+        const anchorObj = this._model.getObject(link.sourceId)
+        if (anchorObj) anchorObj._toleranceCfId = link.violated ? link.targetId : null
         if (link.violated) violatedToleranceAnchorIds.add(link.sourceId)
 
         // Track all tolerances that reference this CF (for conflict detection).
@@ -1674,17 +1695,28 @@ export class SceneService extends EventEmitter {
       const obj = this._model.getObject(id)
       obj?.meshView?.setConstraintViolated?.(violatedContainsIds.has(id))
     }
+    // Bilateral: propagate violation state to Zone sources of contains links.
+    for (const id of containsSourceIds) {
+      const obj = this._model.getObject(id)
+      obj?.meshView?.setContainsViolated?.(violatedContainsSourceIds.has(id))
+    }
 
     // Propagate tact-time violation state to Hub targets of connects links.
     for (const id of tactTimeHubIds) {
       const obj = this._model.getObject(id)
       obj?.meshView?.setTactTimeViolated?.(violatedTactHubIds.has(id))
     }
+    // Bilateral: propagate tact-time violation state to Route sources of connects links.
+    for (const id of tactTimeRouteIds) {
+      const obj = this._model.getObject(id)
+      obj?.meshView?.setTactViolated?.(violatedTactRouteIds.has(id))
+    }
 
     // Propagate tolerance violation state to Anchor sources of references links (ADR-043 Phase 4).
     for (const id of toleranceAnchorIds) {
       const obj = this._model.getObject(id)
-      obj?.meshView?.setToleranceViolated?.(violatedToleranceAnchorIds.has(id))
+      const cfId = obj?._toleranceCfId ?? null
+      obj?.meshView?.setToleranceViolated?.(violatedToleranceAnchorIds.has(id), cfId)
     }
   }
 

--- a/src/service/SemanticInferencer.js
+++ b/src/service/SemanticInferencer.js
@@ -157,3 +157,36 @@ export function inferSemanticRelationships(moved, sceneObjects, existingPairs) {
     .sort((a, b) => b.confidence - a.confidence)
     .slice(0, 3)
 }
+
+/** Outer radius for approach warmth visualization — 3× the contact threshold. */
+const APPROACH_RADIUS = CONTACT_THRESHOLD * 3
+
+/**
+ * Computes continuous warmth values (0..1) for Solid entities near the moved Solid.
+ * Used to show a pre-threshold "getting warmer" effect on wireframes.
+ * Pure computation; no side effects.
+ *
+ * @param {Solid} moved
+ * @param {Iterable<any>} sceneObjects
+ * @returns {Array<{ targetId: string, warmth: number }>}
+ */
+export function computeApproachWarmth(moved, sceneObjects) {
+  if (!(moved instanceof Solid)) return []
+  const mBox = _solidBox(moved)
+  const result = []
+  for (const entity of sceneObjects) {
+    if (entity.id === moved.id || !(entity instanceof Solid)) continue
+    const tBox = _solidBox(entity)
+    // Minimum positive gap across all six axis-aligned face pairs.
+    const gaps = [
+      mBox.min.z - tBox.max.z, tBox.min.z - mBox.max.z,
+      mBox.min.x - tBox.max.x, tBox.min.x - mBox.max.x,
+      mBox.min.y - tBox.max.y, tBox.min.y - mBox.max.y,
+    ].filter(g => g > 0)
+    const minGap = gaps.length ? Math.min(...gaps) : 0
+    if (minGap < APPROACH_RADIUS) {
+      result.push({ targetId: entity.id, warmth: Math.max(0, 1 - minGap / APPROACH_RADIUS) })
+    }
+  }
+  return result
+}

--- a/src/view/AnnotatedLineView.js
+++ b/src/view/AnnotatedLineView.js
@@ -259,15 +259,29 @@ export class AnnotatedLineView {
    * Drives Route particle animation.  Called every frame from AppController.
    * @param {number} t  elapsed seconds (performance.now() / 1000)
    */
+  /**
+   * Called when a tact-time link violation is detected (bilateral alarm).
+   * Reverses particle flow direction and tints particles red.
+   * Sole writer of _particleDirection and particle color (PHILOSOPHY #4).
+   * @param {boolean} violated
+   */
+  setTactViolated(violated) {
+    this._particleDirection = violated ? -1 : 1
+    const color = violated ? 0xEF4444 : this._colorForType(this._placeType)
+    this._partMat.color.setHex(color)
+  }
+
   tick(t) {
     if (!this._line.visible) return
 
     if (this._placeType === 'Route') {
       if (this._segments.length === 0 || this._totalLen === 0) return
 
+      const direction = this._particleDirection ?? 1
       for (const mesh of this._particles) {
         // Each particle travels the full polyline length continuously.
-        const frac = ((mesh._tOffset + t * PARTICLE_SPEED) % 1 + 1) % 1
+        // _particleDirection=-1 reverses flow when tact-time is violated.
+        const frac = ((mesh._tOffset + t * PARTICLE_SPEED * direction) % 1 + 1) % 1
         const targetDist = frac * this._totalLen
 
         let cumLen = 0

--- a/src/view/AnnotatedPointView.js
+++ b/src/view/AnnotatedPointView.js
@@ -154,6 +154,9 @@ export class AnnotatedPointView {
     this._name  = name
     this._tactViolated      = false
     this._toleranceViolated = false
+    this._bridgeLine = null
+    this._bridgeCfId = null
+    this._scene      = null   // set lazily in updateBridgeLine()
 
     // Apply initial place-type visuals
     this._applyPlaceTypeVisuals(placeType)
@@ -346,14 +349,56 @@ export class AnnotatedPointView {
    * When cleared: reverts to place-type color.
    * @param {boolean} violated
    */
-  setToleranceViolated(violated) {
-    if (this._toleranceViolated === violated) return
+  /**
+   * @param {boolean}     violated
+   * @param {string|null} cfId  CF entity ID to draw error bridge toward, or null to clear.
+   */
+  setToleranceViolated(violated, cfId = null) {
+    if (this._toleranceViolated === violated && this._bridgeCfId === cfId) return
     this._toleranceViolated = violated
+    this._bridgeCfId = violated ? cfId : null
     const hex = violated ? 0xEF4444 : this._colorForType(this._placeType)
     this._mat.color.setHex(hex)
     this._ringMat.color.setHex(hex)
     this._crosshairMat.color.setHex(violated ? 0xEF4444 : 0xffffff)
     this.boxHelper.material?.color.setHex(violated ? 0xEF4444 : 0xffffff)
+    // Dispose bridge line when clearing violation.
+    if (!violated && this._bridgeLine) {
+      this._scene.remove(this._bridgeLine)
+      this._bridgeLine.geometry.dispose()
+      this._bridgeLine.material.dispose()
+      this._bridgeLine = null
+    }
+  }
+
+  /**
+   * Updates the error bridge line endpoint to track the CF world position.
+   * Creates the bridge line lazily on first call.
+   * @param {import('three').Scene} scene
+   * @param {import('three').Vector3} cfWorldPos
+   */
+  updateBridgeLine(scene, cfWorldPos) {
+    if (!this._bridgeCfId || !this._toleranceViolated) return
+    const anchorPos = this._mesh.position
+    if (!this._bridgeLine) {
+      const geo = new THREE.BufferGeometry()
+      const mat = new THREE.LineDashedMaterial({
+        color:       0xEF4444,
+        dashSize:    0.08,
+        gapSize:     0.06,
+        transparent: true,
+        opacity:     0.9,
+        depthTest:   false,
+      })
+      this._bridgeLine = new THREE.Line(geo, mat)
+      this._bridgeLine.renderOrder = 3
+      this._scene = scene
+      scene.add(this._bridgeLine)
+    }
+    const pts = [anchorPos.x, anchorPos.y, anchorPos.z, cfWorldPos.x, cfWorldPos.y, cfWorldPos.z]
+    this._bridgeLine.geometry.setAttribute('position', new THREE.Float32BufferAttribute(pts, 3))
+    this._bridgeLine.geometry.attributes.position.needsUpdate = true
+    this._bridgeLine.computeLineDistances()
   }
 
   // ── Edit-mode no-ops ───────────────────────────────────────────────────────
@@ -384,6 +429,12 @@ export class AnnotatedPointView {
     scene.remove(this._sonarRing)
     scene.remove(this._crosshairs)
     scene.remove(this.boxHelper)
+    if (this._bridgeLine) {
+      scene.remove(this._bridgeLine)
+      this._bridgeLine.geometry.dispose()
+      this._bridgeLine.material.dispose()
+      this._bridgeLine = null
+    }
     this._geo.dispose()
     this._mat.dispose()
     this._ringGeo.dispose()

--- a/src/view/AnnotatedRegionView.js
+++ b/src/view/AnnotatedRegionView.js
@@ -294,13 +294,29 @@ export class AnnotatedRegionView {
     // Dual rim ring pulse: two waves at 180° phase offset.
     // Each ring's outer edge expands from 1.0× to 1.10× while fading.
     // Math.pow(1 - phase, 2) gives ease-out fade (slow at start, fast at end).
-    const phase1 = (t % RIM_PULSE_DURATION) / RIM_PULSE_DURATION
+    // _rimPeriod is shortened when a contains-violation is active (bilateral alarm).
+    const rimPeriod = this._rimPeriod ?? RIM_PULSE_DURATION
+    const phase1 = (t % rimPeriod) / rimPeriod
     this._rimRing1.scale.setScalar(1.0 + phase1 * 0.10)
     this._rimMat1.opacity = RIM_OPACITY_MAX * Math.pow(1 - phase1, 2)
 
-    const phase2 = ((t + RIM_PULSE_DURATION * 0.5) % RIM_PULSE_DURATION) / RIM_PULSE_DURATION
+    const phase2 = ((t + rimPeriod * 0.5) % rimPeriod) / rimPeriod
     this._rimRing2.scale.setScalar(1.0 + phase2 * 0.10)
     this._rimMat2.opacity = RIM_OPACITY_MAX * Math.pow(1 - phase2, 2)
+  }
+
+  /**
+   * Called when a contains-link is violated (bilateral alarm).
+   * Turns rim rings and border red and speeds up the pulse.
+   * Sole writer of rim color during violation (PHILOSOPHY #4).
+   * @param {boolean} violated
+   */
+  setContainsViolated(violated) {
+    this._rimPeriod = violated ? 1.0 : RIM_PULSE_DURATION
+    const color = violated ? 0xEF4444 : this._colorForType(this._placeType)
+    this._rimMat1.color.setHex(color)
+    this._rimMat2.color.setHex(color)
+    this._lineMat.color = color
   }
 
   // ── Label update (call once per frame while visible) ──────────────────────

--- a/src/view/MeshView.js
+++ b/src/view/MeshView.js
@@ -328,6 +328,24 @@ export class MeshView {
     this.boxHelper.visible = sel
   }
 
+  /**
+   * Sets the approach warmth tint on wireframe edges (0 = normal, 1 = full amber).
+   * Sole writer of wireframe color/opacity during grab approach (PHILOSOPHY #4).
+   * @param {number} t  0..1
+   */
+  setApproachWarmth(t) {
+    const mat = this.wireframe.material
+    if (t <= 0) {
+      mat.color.setHex(0xffffff)
+      mat.opacity = 0.4
+    } else {
+      const base  = new THREE.Color(0xffffff)
+      const amber = new THREE.Color(0xF59E0B)
+      mat.color.lerpColors(base, amber, t * t)   // ease-in for drama
+      mat.opacity = 0.4 + t * 0.5
+    }
+  }
+
   /** Sets or clears the spatial-constraint violation tint (red emissive). */
   setConstraintViolated(violated) {
     this._constraintViolated = violated

--- a/src/view/RippleEffect.js
+++ b/src/view/RippleEffect.js
@@ -1,0 +1,49 @@
+// @ts-nocheck
+import * as THREE from 'three'
+
+const DURATION = 0.6   // seconds
+
+/**
+ * Transient sphere that expands and fades over DURATION seconds.
+ * Created at the midpoint of a newly accepted SpatialLink to confirm the relationship.
+ *
+ * Lifecycle: constructor adds to scene; tick() returns true when done; caller calls dispose().
+ * (PHILOSOPHY #9 — allocations and deallocations are symmetric)
+ */
+export class RippleEffect {
+  constructor(scene, position, color) {
+    this._scene = scene
+    this._start = performance.now() / 1000
+    const geo = new THREE.SphereGeometry(0.15, 8, 8)
+    const mat = new THREE.MeshBasicMaterial({
+      color,
+      transparent: true,
+      opacity:     0.8,
+      wireframe:   true,
+      depthTest:   false,
+    })
+    this._mesh = new THREE.Mesh(geo, mat)
+    this._mesh.renderOrder = 3
+    this._mesh.position.copy(position)
+    scene.add(this._mesh)
+  }
+
+  /**
+   * Advances the animation. Returns true when the ripple has finished and should be disposed.
+   * @param {number} t  seconds from performance.now() / 1000
+   */
+  tick(t) {
+    const elapsed = t - this._start
+    if (elapsed >= DURATION) return true
+    const progress = elapsed / DURATION
+    this._mesh.scale.setScalar(1 + progress * 3)           // 1× → 4× over DURATION
+    this._mesh.material.opacity = 0.8 * (1 - progress)    // fade to 0
+    return false
+  }
+
+  dispose() {
+    this._scene.remove(this._mesh)
+    this._mesh.geometry.dispose()
+    this._mesh.material.dispose()
+  }
+}

--- a/src/view/SpatialLinkView.js
+++ b/src/view/SpatialLinkView.js
@@ -104,6 +104,9 @@ export class SpatialLinkView {
     // Clearance violation state (bounded_by links only).
     this._violated = false
 
+    // Flash state: non-null while the acceptance flash is playing (seconds timestamp).
+    this._flashStart = null
+
     // Set initial geometry
     this.update(srcPos, tgtPos)
   }
@@ -118,8 +121,9 @@ export class SpatialLinkView {
    * @param {THREE.Vector3} tgtPos
    * @param {number} [dashOffset=0]   Negative value scrolls dashes source→target (marching ants).
    * @param {number} [tension=0]      0..1 — color shift from semantic color toward orange-red.
+   * @param {number} [severity=0]     0..1 — bounded_by proximity gradient; overrides tension and _violated.
    */
-  update(srcPos, tgtPos, dashOffset = 0, tension = 0) {
+  update(srcPos, tgtPos, dashOffset = 0, tension = 0, severity = 0) {
     const pts = [srcPos.x, srcPos.y, srcPos.z, tgtPos.x, tgtPos.y, tgtPos.z]
     this._geo.setAttribute('position', new THREE.Float32BufferAttribute(pts, 3))
     this._geo.attributes.position.needsUpdate = true
@@ -137,8 +141,33 @@ export class SpatialLinkView {
       if (this._arrow) this._arrow.cone.material.color.set(this._baseColor)
     }
 
-    // Alert state overrides tension color when clearance is violated
-    if (this._violated) {
+    // Severity gradient for bounded_by links: semantic → amber → red as limit approaches.
+    // Overrides tension color when severity > 0. Preserves binary _violated for other link types.
+    if (severity > 0) {
+      const safe  = new THREE.Color(this._baseColor)
+      const amber = new THREE.Color(0xFBBF24)
+      const red   = new THREE.Color(0xEF4444)
+      let gradColor
+      if (severity < 0.5) {
+        gradColor = safe.clone().lerp(amber, severity * 2)
+      } else {
+        gradColor = amber.clone().lerp(red, (severity - 0.5) * 2)
+      }
+      this._mat.color.copy(gradColor)
+      if (this._arrow) this._arrow.cone.material.color.copy(gradColor)
+      this._mat.dashSize = 0.35 - severity * 0.20
+      this._mat.gapSize  = 0.18 - severity * 0.10
+      this._mat.opacity  = 0.4 + severity * 0.4
+      // Pulse only at full violation zone (severity ≈ 1)
+      if (severity > 0.8) {
+        const pulse = 0.5 + 0.5 * Math.sin(Date.now() * 0.008)
+        const bright = new THREE.Color(0xFF9999)
+        this._mat.color.lerp(bright, pulse * 0.4)
+        if (this._arrow) this._arrow.cone.material.color.lerp(bright, pulse * 0.4)
+        this._mat.opacity = 0.8 + pulse * 0.2
+      }
+    } else if (this._violated) {
+      // Fallback binary alert for non-bounded_by links (e.g., contains, tact-time)
       const pulse = 0.5 + 0.5 * Math.sin(Date.now() * 0.008)
       const alertRed    = new THREE.Color(0xEF4444)
       const alertBright = new THREE.Color(0xFF9999)
@@ -164,6 +193,26 @@ export class SpatialLinkView {
         this._arrow.setDirection(dir)
       }
     }
+
+    // Acceptance flash: boost opacity 1.0 → normal over 300ms after link creation.
+    if (this._flashStart !== null) {
+      const elapsed = performance.now() / 1000 - this._flashStart
+      if (elapsed < 0.3) {
+        this._mat.opacity = 1.0 - elapsed * 2   // 1.0 → 0.4
+      } else {
+        this._flashStart = null
+      }
+    }
+  }
+
+  // ── Acceptance flash ──────────────────────────────────────────────────────
+
+  /**
+   * Triggers a 300ms opacity flash on the link line to confirm link creation.
+   * Sole writer of _flashStart (PHILOSOPHY #4).
+   */
+  triggerFlash() {
+    this._flashStart = performance.now() / 1000
   }
 
   // ── Clearance violation state ──────────────────────────────────────────────


### PR DESCRIPTION
Upgrade 5 — 制約深刻度グラジエント:
bounded_by リンクの色を二値赤/非赤から連続スペクトル(semantic→amber→red)へ。
SpatialLinkView.update() に severity 引数を追加。SceneService で clearance 2× → 1× → 超過の gradient を計算して毎フレーム伝播。

Upgrade 1 — Gキーグラブ ライブ推論プレビュー:
QuickDrag でのみ動いていたゴーストリンク+「↵ to link」ツールチップを S_GRAB_ACTIVE にも拡張。_grab に isSuggesting / currentSuggestion フィールドを追加。Enter キーでリンク即確定。

Upgrade 4 — リンク確定リプル:
SpatialLink 確定時に midpoint からワイヤーフレーム球が膨張・フェード(600ms)。RippleEffect クラスを新規作成。SpatialLinkView に triggerFlash() を追加(300ms 輝度フラッシュ)。

Upgrade 2 — アプローチグラジエント(磁力感):
grab/QuickDrag 中、移動 Solid が別 Solid に 0.45m 以内に近づくとターゲットの wireframe が amber に変色。SemanticInferencer に computeApproachWarmth() を追加。MeshView に setApproachWarmth() を追加(wireframe color/opacity の単一所有者)。

Upgrade 3 — 制約アラーム双方向化:
- contains 違反: Solid が赤になるだけでなく、Zone のリムリングも赤・高速パルスに
- tact-time 超過: Hub だけでなく Route のパーティクルも逆流・赤色に
- Anchor tolerance 違反: Anchor から CF へ赤ダッシュのブリッジライン表示

https://claude.ai/code/session_01BWSXwZD1Bk9s9hjiKCTdQ6