### PR TITLE
Fix Phase 5 React migration regressions (backdrop, picker, status)

### DIFF
--- a/src/components/InfoBar/InfoBar.jsx
+++ b/src/components/InfoBar/InfoBar.jsx
@@ -32,10 +32,7 @@ export function InfoBar() {
       gap: 0,
       overflow: 'hidden',
     }}>
-      {mobile
-        ? <StatusContent parts={statusParts} />
-        : <HintsContent shortcuts={getInfoText(mode, editSubtype)} extraHint={extraHint} />
-      }
+      {!mobile && <HintsContent shortcuts={getInfoText(mode, editSubtype)} extraHint={extraHint} />}
     </div>
   )
 }

--- a/src/components/NPanel/NPanelGeneric.jsx
+++ b/src/components/NPanel/NPanelGeneric.jsx
@@ -192,7 +192,7 @@ function IfcPicker({ onSelect, onClose }) {
       <div style={{
         position: 'fixed',
         top: '40px',
-        right: '200px',
+        right: window.innerWidth < 768 ? '0' : '200px',
         width: '220px',
         maxHeight: '420px',
         background: '#252525',
@@ -330,7 +330,7 @@ function PlaceTypePicker({ geometry, onSelect, onClose }) {
       <div style={{
         position: 'fixed',
         top: '40px',
-        right: '200px',
+        right: window.innerWidth < 768 ? '0' : '200px',
         width: '230px',
         maxHeight: '320px',
         background: '#252525',

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -779,7 +779,7 @@ export class AppController {
       } else {
         if (uiView.nPanelVisible) this._toggleNPanel()
         outlinerView.openDrawer()
-        uiView.showBackdrop(() => outlinerView.closeDrawer())
+        uiView.showBackdrop(() => { outlinerView.closeDrawer(); uiView.hideBackdrop() })
       }
     })
 
@@ -790,7 +790,7 @@ export class AppController {
       }
       this._toggleNPanel()
       if (uiView.nPanelVisible) {
-        uiView.showBackdrop(() => this._toggleNPanel())
+        uiView.showBackdrop(() => { this._toggleNPanel(); uiView.hideBackdrop() })
       } else {
         uiView.hideBackdrop()
       }


### PR DESCRIPTION
- AppController: backdrop callbacks now call hideBackdrop() after closing
  the outliner/NPanel drawer, so the dark overlay is removed immediately
  instead of persisting until the next toggle (fixes #1 backdrop stuck,
  #3 blue flash, #6 3D viewport blocked after outliner close)
- NPanelGeneric: IfcPicker and PlaceTypePicker use right:0 on mobile
  (< 768px) instead of right:200px — the fixed+220/230px width placed
  the left edge off-screen on narrow viewports, making pickers invisible
  (fixes #2 map attribute icons, #5 IFC category selection)
- InfoBar: remove StatusContent on mobile — CanvasStatusPill already
  renders status above the toolbar; duplicate bottom-bar display removed
  (fixes #4 status duplication); 26px spacer bar is preserved for
  MobileToolbar positioning

https://claude.ai/code/session_018Ev5Yxkz55bpeG98wq175g