### PR TITLE
fix: resolve Phase 5 regressions in 3D viewport and React UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,9 +14,11 @@
         background: #000;
         overflow: hidden;
       }
+      * {
+        -webkit-tap-highlight-color: transparent;
+      }
       canvas {
         display: block;
-        -webkit-tap-highlight-color: transparent;
       }
     </style>
   </head>
@@ -54,7 +56,7 @@
     <!-- React UI overlay — rendered on top of the Three.js canvas.
          pointer-events:none on the root so canvas interaction passes through by default;
          individual React components set pointer-events:auto where needed. -->
-    <div id="react-ui-root" style="position:fixed;inset:0;pointer-events:none;z-index:10"></div>
+    <div id="react-ui-root" style="position:fixed;inset:0;pointer-events:none;z-index:100"></div>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/src/components/AddMenu/AddMenu.jsx
+++ b/src/components/AddMenu/AddMenu.jsx
@@ -43,6 +43,7 @@ export function AddMenu() {
         minWidth: '140px',
         overflow: 'hidden',
         zIndex: 300,
+        pointerEvents: 'auto',
       }}
     >
       <div style={{

--- a/src/components/ContextMenu/ContextMenu.jsx
+++ b/src/components/ContextMenu/ContextMenu.jsx
@@ -45,6 +45,7 @@ export function ContextMenu() {
         zIndex: 400,
         paddingTop: '4px',
         paddingBottom: '4px',
+        pointerEvents: 'auto',
       }}
     >
       {contextMenu.items.map((item, i) => (

--- a/src/components/LinkTypePicker/LinkTypePicker.jsx
+++ b/src/components/LinkTypePicker/LinkTypePicker.jsx
@@ -53,6 +53,7 @@ export function LinkTypePicker() {
         boxShadow: '0 8px 24px rgba(0,0,0,0.6)',
         overflow: 'hidden',
         zIndex: 200,
+        pointerEvents: 'auto',
       }}
     >
       <div style={{

--- a/src/components/MapToolbar/MapToolbar.jsx
+++ b/src/components/MapToolbar/MapToolbar.jsx
@@ -67,6 +67,7 @@ export function MapToolbar() {
         boxShadow: '0 4px 16px rgba(0,0,0,0.6)',
         userSelect: 'none', minWidth: '44px',
         fontFamily: 'system-ui, -apple-system, sans-serif',
+        pointerEvents: 'auto',
       }}
     >
       {/* Tool buttons — always rendered, never removed to prevent layout shift */}

--- a/src/components/Modal/ModalLayer.jsx
+++ b/src/components/Modal/ModalLayer.jsx
@@ -26,6 +26,7 @@ function Overlay({ onCancel, children }) {
         alignItems: 'center',
         justifyContent: 'center',
         zIndex: 500,
+        pointerEvents: 'auto',
       }}
     >
       <div
@@ -160,6 +161,7 @@ function ImportModal({ modal, onClose }) {
         alignItems: 'center',
         justifyContent: 'center',
         zIndex: 10000,
+        pointerEvents: 'auto',
       }}
     >
       <div

--- a/src/components/Onboarding/Onboarding.jsx
+++ b/src/components/Onboarding/Onboarding.jsx
@@ -55,6 +55,7 @@ export function Onboarding() {
         color: '#e8e8e8',
         userSelect: 'none',
         WebkitUserSelect: 'none',
+        pointerEvents: 'auto',
       }}
     >
       {HINTS.map(({ svg, text }) => (

--- a/src/components/Outliner/Outliner.jsx
+++ b/src/components/Outliner/Outliner.jsx
@@ -288,6 +288,7 @@ export function Outliner() {
       display: 'flex',
       flexDirection: 'column',
       userSelect: 'none',
+      pointerEvents: 'auto',
       transform: translate,
       transition: isMobile ? 'transform 0.25s ease' : '',
     }}>

--- a/src/components/SemanticSuggestion/SemanticSuggestion.jsx
+++ b/src/components/SemanticSuggestion/SemanticSuggestion.jsx
@@ -62,6 +62,7 @@ export function SemanticSuggestion() {
       boxShadow: '0 6px 24px rgba(0,0,0,0.5)',
       zIndex: 9998,
       fontSize: '12px',
+      pointerEvents: 'auto',
     }}>
       <span style={{
         width: '8px',

--- a/src/main.js
+++ b/src/main.js
@@ -37,6 +37,7 @@ const sceneView    = new SceneView()
 const uiView       = new UIViewBridge(new UIView())
 const gizmoView    = new GizmoView(sceneView.camera, sceneView.controls)
 const outlinerView = new OutlinerBridge()
+outlinerView.enableReact()
 const controller   = new AppController(sceneView, uiView, gizmoView, outlinerView)
 
 // Hand UI sections to React — hides the corresponding UIView native elements.
@@ -53,6 +54,5 @@ uiView.enableReactLinkTypePicker()
 uiView.enableReactSemanticSuggestion()
 uiView.enableReactImportUI()
 uiView.enableReactOnboarding()
-outlinerView.enableReact()
 
 controller.start()


### PR DESCRIPTION
1. CF label z-index: raise #react-ui-root from z:10 to z:100 so CF labels
   (position:fixed z:50 on document.body) no longer float above context
   menu and other React overlays.

2. Touch blue flash: apply -webkit-tap-highlight-color:transparent globally
   instead of canvas-only.

3. Outliner timing: call outlinerView.enableReact() before new AppController()
   so the initial solid created in the constructor reaches the React store.

4. pointer-events inheritance: #react-ui-root has pointer-events:none for
   canvas passthrough; CSS inherits this to children. Add pointerEvents:'auto'
   to all interactive Phase 3/4 React components that were missing it:
   AddMenu, ContextMenu, MapToolbar, Outliner, LinkTypePicker,
   SemanticSuggestion, Onboarding, ModalLayer (both backdrop variants).

https://claude.ai/code/session_01EJQoj3GcFSd1Au24RXaP8f