### PR TITLE
refactor: extract MapModeController from AppController (Phase 1-A)

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -66,6 +66,10 @@ import { RippleEffect }               from '../view/RippleEffect.js'
 import { MapModeController }          from './map/MapModeController.js'
 import { RotationHandler }            from './handler/RotationHandler.js'
 import { GrabOperationHandler }       from './handler/GrabOperationHandler.js'
+import { MeasurePlacementHandler }    from './handler/MeasurePlacementHandler.js'
+import { LinkCreationHandler }        from './handler/LinkCreationHandler.js'
+import { FaceExtrudeHandler }         from './handler/FaceExtrudeHandler.js'
+import { FramePlacementHandler }      from './handler/FramePlacementHandler.js'
 
 // ── Module-level helpers ──────────────────────────────────────────────────────
 
@@ -272,42 +276,13 @@ export class AppController {
       this._uiView.hideImportProgress()
     })
 
-    // ── Measure placement state ────────────────────────────────────────────
-    // Active while the user is placing a MeasureLine (M key / Add → Measure).
-    // Phase 1: waiting for first click (p1 = null)
-    // Phase 2: p1 set, waiting for second click (preview line shown)
-    // Active state tracked by this._opState (S_MEASURE_PLACING).
-    this._measure = {
-      /** @type {THREE.Vector3|null} fixed first endpoint */
-      p1:           null,
-      /** @type {THREE.Vector3|null} live cursor position (snapped) */
-      p2:           null,
-      /** @type {{label:string, position:THREE.Vector3, type:string, objectId:string, elementId:string}[]} */
-      snapTargets:  [],
-      snapping:     false,
-      /** @type {{label:string, position:THREE.Vector3, type:string, objectId:string, elementId:string}|null} */
-      snappedTarget: null,
-      /** Anchor reference captured when p1 was confirmed (ADR-028).
-       *  @type {{ objectId:string, type:string, elementId:string }|null} */
-      p1Anchor:     null,
-      /** Three.js Line for preview before entity is created */
-      previewLine:  null,
-      /** True while the user is holding a pointer down to snap a point */
-      pressing:     false,
-      /** MeshView used for snap candidate display (may differ from _meshView when active obj is MeasureLine) */
-      snapMeshView: null,
-    }
+    // ── Measure placement handler (delegated to MeasurePlacementHandler) ──
+    this._measureHandler  = new MeasurePlacementHandler(this)
+    this._measure         = this._measureHandler.state
 
-    // ── SpatialLink creation state (ADR-030 Phase 4) ──────────────────────
-    // Active while the user is selecting a target entity after pressing L.
-    // Phase 1: sourceId captured, waiting for target click.
-    // Active state tracked by this._opState (S_LINK_MODE).
-    this._spatialLinkMode = {
-      /** @type {string|null} ID of the source entity */
-      sourceId:         null,
-      /** @type {string|null} ID of the candidate target (pending picker) */
-      pendingTargetId:  null,
-    }
+    // ── SpatialLink creation handler (delegated to LinkCreationHandler) ───
+    this._linkHandler     = new LinkCreationHandler(this)
+    this._spatialLinkMode = this._linkHandler.state
 
     // ── Primary operation FSM (ADR-039) ──────────────────────────────────
     // Single source of truth for which Object Mode operation is currently active.
@@ -448,25 +423,9 @@ export class AppController {
     this._activeRipples        = []
     this._rectSelHandler       = new RectSelectState()
 
-    // ── Face extrude state (Edit Mode · 3D, E key) ─────────────────────────
-    // Active state tracked by this._opState (S_FACE_EXTRUDE).
-    this._faceExtrude = {
-      /** @type {import('../graph/Face.js').Face|null} */
-      face:          null,
-      savedCorners:  [],    // world face corners at drag start (for display / snap)
-      /** @type {import('three').Vector3[]} Body-frame face corners at drag start (for extrudeFace call). ADR-040 */
-      savedLocalFaceCorners: [],
-      normal:        new THREE.Vector3(),  // world face normal (for distance dot product)
-      localNormal:   new THREE.Vector3(),  // body-frame face normal (for extrudeFace call). ADR-040
-      dist:          0,
-      dragPlane:     new THREE.Plane(),
-      startPoint:    new THREE.Vector3(),
-      inputStr:      '',
-      hasInput:      false,
-      snapping:      false,
-      snappedTarget: null,
-      snapTargets:   [],
-    }
+    // ── Face extrude handler (delegated to FaceExtrudeHandler) ──────────────
+    this._faceExtrudeHandler = new FaceExtrudeHandler(this)
+    this._faceExtrude        = this._faceExtrudeHandler.state
 
     // ── Blender-style grab state ───────────────────────────────────────────
     this._grabHandler = new GrabOperationHandler(this)
@@ -510,24 +469,9 @@ export class AppController {
       startY:    0,
     }
 
-    // ── CoordinateFrame placement pick sub-mode (ADR-034 §6) ─────────────────
-    /**
-     * Data for frame placement pick sub-mode.
-     * Active state tracked by this._opState (S_FRAME_PLACEMENT).
-     * @type {{ parentId: string|null }}
-     */
-    this._framePlacementState = { parentId: null }
-    /**
-     * Scene-level Three.js Group showing world-aligned parent axes during pick sub-mode.
-     * Lazily created in _enterFramePickSubMode; reused on subsequent entries.
-     * @type {THREE.Group|null}
-     */
-    this._parentAxesOverlay = null
-    /**
-     * Ghost CoordinateFrame axes following the cursor during pick sub-mode.
-     * @type {THREE.Group|null}
-     */
-    this._frameCursorGhost = null
+    // ── CoordinateFrame placement handler (delegated to FramePlacementHandler) ─
+    this._framePlacementHandler = new FramePlacementHandler(this)
+    this._framePlacementState   = this._framePlacementHandler.state
 
     // ── UI wiring ──────────────────────────────────────────────────────────
     uiView.setCanvas(sceneView.renderer.domElement)
@@ -849,7 +793,7 @@ export class AppController {
         this._activeDragPointerId = null
         this._service.setLinkDragging(new Set(), false)
         this._service.updateLinkSelectionHighlight(this._selectedIds)
-        this._createSpatialLinkDirect(suggestion.sourceId, suggestion.targetId, suggestion)
+        this._linkHandler.createDirect(suggestion.sourceId, suggestion.targetId, suggestion)
       },
     }
   }
@@ -891,7 +835,7 @@ export class AppController {
    */
   _addObject(type = 'box') {
     if (type === 'sketch')  { this._addProfileObject();    return }
-    if (type === 'measure') { this._startMeasurePlacement(); return }
+    if (type === 'measure') { this._measureHandler.start(); return }
     if (type === 'frame')   { this._addCoordinateFrame();  return }
 
     // Exit Edit Mode cleanly before adding, so the previous object's visual state is cleared
@@ -940,969 +884,7 @@ export class AppController {
       return
     }
     if (this._scene.selectionMode === 'edit') this.setMode('object')
-    this._enterFramePickSubMode(parentId)
-  }
-
-  /**
-   * Enters the frame placement pick sub-mode for the given parent entity.
-   * Shows the parent axes ghost and cursor ghost; updates status bar and mobile toolbar.
-   * @param {string} parentId
-   */
-  _enterFramePickSubMode(parentId) {
-    if (!this._opState.send('BEGIN_FRAME_PLACEMENT')) return
-    this._framePlacementState.parentId = parentId
-
-    // Show parent axes overlay at geometry ancestor centroid (ADR-034 §7)
-    const ancestorCentroid = this._geometryAncestorCentroid(parentId)
-    if (ancestorCentroid) {
-      if (!this._parentAxesOverlay) {
-        this._parentAxesOverlay = _makeGhostAxesGroup()
-        this._sceneView.scene.add(this._parentAxesOverlay)
-      }
-      this._parentAxesOverlay.position.copy(ancestorCentroid)
-      this._parentAxesOverlay.quaternion.set(0, 0, 0, 1)
-      this._parentAxesOverlay.visible = true
-    }
-
-    // Cursor ghost axes (hidden until hover)
-    if (!this._frameCursorGhost) {
-      this._frameCursorGhost = _makeFrameAxesGroup()
-      this._sceneView.scene.add(this._frameCursorGhost)
-    }
-    this._frameCursorGhost.visible = false
-
-    const mobile = window.innerWidth < 768
-    if (mobile) {
-      this._uiView.setStatus('Tap to place frame')
-      this._updateMobileToolbar()
-    } else {
-      this._uiView.setStatus('Click to place frame — Esc to cancel')
-      this._uiView.setCursor('crosshair')
-    }
-  }
-
-  /**
-   * Cancels pick sub-mode; hides overlays and restores normal state.
-   */
-  _cancelFramePickSubMode() {
-    if (!this._opState.is(S_FRAME_PLACEMENT)) return
-    this._framePlacementState.parentId = null
-    if (this._parentAxesOverlay) this._parentAxesOverlay.visible = false
-    if (this._frameCursorGhost)  this._frameCursorGhost.visible  = false
-    this._uiView.setCursor('default')
-    this._opState.send('CANCEL')
-    this._refreshObjectModeStatus()
-    this._updateMobileToolbar()
-  }
-
-  /**
-   * Confirms frame placement at the given world position.
-   * Creates the CoordinateFrame, records undo, exits sub-mode.
-   * @param {THREE.Vector3} worldPos
-   */
-  _confirmFramePlacement(worldPos) {
-    if (!this._opState.is(S_FRAME_PLACEMENT)) return
-    const parentId = this._framePlacementState.parentId
-    this._framePlacementState.parentId = null
-    if (this._parentAxesOverlay) this._parentAxesOverlay.visible = false
-    if (this._frameCursorGhost)  this._frameCursorGhost.visible  = false
-    this._uiView.setCursor('default')
-    this._opState.send('CONFIRM')
-    this._refreshObjectModeStatus()
-    this._updateMobileToolbar()
-
-    // User CFs are always parented to the Origin CF of the Solid (ADR-037 §2)
-    const parentObj = this._scene.getObject(parentId)
-    let effectiveParentId = parentId
-    if (parentObj && !(parentObj instanceof CoordinateFrame)) {
-      const originFrame = [...this._scene.objects.values()]
-        .find(o => o instanceof CoordinateFrame && o.parentId === parentId && o.name === 'Origin')
-      if (originFrame) effectiveParentId = originFrame.id
-    }
-
-    const frame = this._service.createCoordinateFrame(effectiveParentId, null, worldPos)
-    if (!frame) return
-
-    const cmd = createCreateCoordinateFrameCommand(
-      frame, this._service,
-      () => {
-        // After undo: restore parent selection if parent still exists
-        const parent = this._scene.getObject(parentId)
-        if (parent) this._switchActiveObject(parentId, true)
-        else { this._objSelected = false; this._selectedIds.clear(); this._refreshObjectModeStatus(); this._updateMobileToolbar() }
-      },
-      (id) => this._switchActiveObject(id, true),
-    )
-    this._commandStack.push(cmd)
-    this._switchActiveObject(frame.id, true)
-  }
-
-  /**
-   * Picks a world position on the parent entity's surface from the current mouse/pointer.
-   * Returns null when the ray misses the entity bounding box.
-   * @returns {THREE.Vector3|null}
-   */
-  _pickFramePlacementPoint() {
-    const { parentId } = this._framePlacementState
-    const parent = this._scene.getObject(parentId)
-    if (!parent) return null
-
-    this._raycaster.setFromCamera(this._mouse, this._camera)
-    const ray = this._raycaster.ray
-    const pt  = new THREE.Vector3()
-
-    // Try raycasting against the parent's cuboid mesh first (Solid)
-    const cuboid = parent.meshView?.cuboid
-    if (cuboid) {
-      const hits = []
-      this._raycaster.intersectObject(cuboid, true, hits)
-      if (hits.length > 0) return hits[0].point.clone()
-    }
-
-    // Fallback: bounding box intersection
-    if (parent.corners?.length > 0) {
-      const box = new THREE.Box3()
-      for (const c of parent.corners) box.expandByPoint(c)
-      if (ray.intersectBox(box, pt)) return pt.clone()
-    }
-
-    // For CoordinateFrame parent: use a plane at the frame world position
-    if (parent instanceof CoordinateFrame) {
-      const wp = this._service.worldPoseOf(parentId)?.position
-      if (wp) {
-        const camDir = new THREE.Vector3()
-        this._camera.getWorldDirection(camDir)
-        const plane = new THREE.Plane().setFromNormalAndCoplanarPoint(camDir, wp)
-        if (ray.intersectPlane(plane, pt)) return pt.clone()
-      }
-    }
-
-    return null
-  }
-
-  // ── STEP import ─────────────────────────────────────────────────────────────
-
-  _triggerStepImport() {
-    const input = document.createElement('input')
-    input.type = 'file'; input.accept = '.stp,.step,.STP,.STEP'
-    input.addEventListener('change', async () => {
-      const file = input.files?.[0]
-      if (!file) return
-
-      const scale = await this._showUnitDialog()
-      if (scale === null) return  // user cancelled
-
-      if (!this._service._bff) {
-        this._uiView.showToast('サーバーに接続されていません', { type: 'warn' })
-        return
-      }
-
-      // Always upload via REST (multipart/form-data) to avoid WS payload size limits.
-      // Pass sessionId so the server can stream import.progress events back over WS.
-      const ws        = this._service.wsChannel
-      const sessionId = ws?.sessionId ?? null
-
-      if (ws) {
-        this._importProgressUnsub = ws.on('import.progress', ({ percent, status }) => {
-          this._uiView.showImportProgress(percent, status)
-        })
-      }
-
-      this._uiView.showImportProgress(0, 'Uploading…')
-      try {
-        await this._service._bff.importStep(file, { scale, sessionId })
-        // Progress overlay is hidden by geometryApplied / geometryError handlers.
-        // If WS is not connected (REST-only mode), hide it now.
-        if (!ws) this._uiView.hideImportProgress()
-      } catch (err) {
-        this._importProgressUnsub?.(); this._importProgressUnsub = null
-        this._uiView.hideImportProgress()
-        this._uiView.showToast('Import failed', { type: 'error' })
-        console.error('[AppController] STEP import error:', err)
-      }
-    })
-    input.click()
-  }
-
-  // ── Save / Load scene ──────────────────────────────────────────────────────
-
-  async _saveScene() {
-    const name = await this._showInputDialog('Save Scene', 'Scene name:', 'Untitled')
-    if (name === null) return
-    const id = await this._service.saveScene(name)
-    if (id) {
-      this._uiView.showToast(`Saved: "${name}"`)
-    } else {
-      this._uiView.showToast('Save failed', { type: 'error' })
-    }
-  }
-
-  async _loadScene() {
-    const scenes = await this._service.listScenes()
-    if (!scenes || scenes.length === 0) {
-      this._uiView.showToast('No saved scenes', { type: 'warn' })
-      return
-    }
-    const id = await this._showSceneListDialog(scenes)
-    if (id === null) return
-    const ok = await this._service.loadScene(id, {
-      camera:    this._camera,
-      renderer:  this._sceneView.renderer,
-      container: document.body,
-    })
-    if (ok) {
-      this._commandStack.clear()
-      this._uiView.showToast('Scene loaded')
-      this._switchActiveObject(null)
-    } else {
-      this._uiView.showToast('Load failed', { type: 'error' })
-    }
-  }
-
-  /** Shows a text-input dialog. Resolves with the trimmed string, or null if cancelled. */
-  _showInputDialog(title, label, placeholder = '') {
-    return new Promise((resolve) => {
-      const overlay = document.createElement('div')
-      overlay.style.cssText = [
-        'position:fixed;inset:0;background:rgba(0,0,0,0.6)',
-        'display:flex;align-items:center;justify-content:center;z-index:9999',
-      ].join(';')
-
-      const dlg = document.createElement('div')
-      dlg.style.cssText = [
-        'background:#1e2a3a;border:1px solid #3a4a5a;border-radius:6px',
-        'padding:20px 24px;min-width:300px;color:#ecf0f1;font-family:monospace',
-        'box-shadow:0 8px 32px rgba(0,0,0,0.6)',
-      ].join(';')
-
-      const titleEl = document.createElement('div')
-      titleEl.textContent = title
-      titleEl.style.cssText = 'font-size:13px;font-weight:bold;margin-bottom:14px;color:#aad4f5'
-      dlg.appendChild(titleEl)
-
-      const lbl = document.createElement('div')
-      lbl.textContent = label
-      lbl.style.cssText = 'font-size:11px;color:#aaa;margin-bottom:6px'
-      dlg.appendChild(lbl)
-
-      const input = document.createElement('input')
-      input.type = 'text'
-      input.value = placeholder
-      input.setAttribute('aria-label', label)
-      input.style.cssText = [
-        'width:100%;box-sizing:border-box;background:#0d1a26;color:#ecf0f1',
-        'border:1px solid #3a4a5a;border-radius:4px;padding:6px 8px',
-        'font-family:monospace;font-size:12px;outline:none',
-      ].join(';')
-      dlg.appendChild(input)
-
-      const btnRow = document.createElement('div')
-      btnRow.style.cssText = 'display:flex;gap:8px;justify-content:flex-end;margin-top:16px'
-
-      const btnCancel = document.createElement('button')
-      btnCancel.textContent = 'Cancel'
-      btnCancel.style.cssText = [
-        'padding:6px 14px;background:#2c3e50;color:#ecf0f1;border:1px solid #3a4a5a',
-        'border-radius:4px;cursor:pointer;font-family:monospace;font-size:12px',
-      ].join(';')
-
-      const btnSave = document.createElement('button')
-      btnSave.textContent = 'Save'
-      btnSave.style.cssText = [
-        'padding:6px 14px;background:#2980b9;color:#fff;border:none',
-        'border-radius:4px;cursor:pointer;font-family:monospace;font-size:12px;font-weight:bold',
-      ].join(';')
-
-      btnRow.appendChild(btnCancel)
-      btnRow.appendChild(btnSave)
-      dlg.appendChild(btnRow)
-      overlay.appendChild(dlg)
-      document.body.appendChild(overlay)
-
-      const close = (result) => { document.body.removeChild(overlay); resolve(result) }
-      btnCancel.addEventListener('click', () => close(null))
-      btnSave.addEventListener('click', () => close(input.value.trim() || placeholder))
-      input.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') close(input.value.trim() || placeholder)
-        if (e.key === 'Escape') close(null)
-      })
-      overlay.addEventListener('click', (e) => { if (e.target === overlay) close(null) })
-      input.focus()
-      input.select()
-    })
-  }
-
-  /**
-   * Shows a list-selection dialog for saved scenes.
-   * Resolves with the selected scene id, or null if cancelled.
-   * @param {{ id: string, name: string, updated_at: string }[]} scenes
-   */
-  _showSceneListDialog(scenes) {
-    return new Promise((resolve) => {
-      const overlay = document.createElement('div')
-      overlay.style.cssText = [
-        'position:fixed;inset:0;background:rgba(0,0,0,0.6)',
-        'display:flex;align-items:center;justify-content:center;z-index:9999',
-      ].join(';')
-
-      const dlg = document.createElement('div')
-      dlg.style.cssText = [
-        'background:#1e2a3a;border:1px solid #3a4a5a;border-radius:6px',
-        'padding:20px 24px;min-width:320px;max-width:480px;color:#ecf0f1;font-family:monospace',
-        'box-shadow:0 8px 32px rgba(0,0,0,0.6)',
-      ].join(';')
-
-      const titleEl = document.createElement('div')
-      titleEl.textContent = 'Load Scene'
-      titleEl.style.cssText = 'font-size:13px;font-weight:bold;margin-bottom:14px;color:#aad4f5'
-      dlg.appendChild(titleEl)
-
-      let selectedId = null
-
-      const list = document.createElement('div')
-      list.setAttribute('role', 'listbox')
-      list.setAttribute('aria-label', 'Saved scenes')
-      list.style.cssText = [
-        'max-height:240px;overflow-y:auto;border:1px solid #3a4a5a;border-radius:4px',
-      ].join(';')
-
-      const selectRow = (row, id) => {
-        list.querySelectorAll('[role="option"]').forEach(r => {
-          r.style.background = ''
-          r.setAttribute('aria-selected', 'false')
-        })
-        row.style.background = '#2980b9'
-        row.setAttribute('aria-selected', 'true')
-        selectedId = id
-      }
-
-      scenes.forEach((scene) => {
-        const row = document.createElement('div')
-        row.setAttribute('role', 'option')
-        row.setAttribute('tabindex', '0')
-        row.setAttribute('aria-selected', 'false')
-        row.style.cssText = [
-          'padding:8px 10px;cursor:pointer;font-size:12px',
-          'border-bottom:1px solid #2a3a4a;display:flex;justify-content:space-between;align-items:center',
-        ].join(';')
-        row.dataset.id = scene.id
-
-        const nameEl = document.createElement('span')
-        nameEl.textContent = scene.name
-        nameEl.style.cssText = 'color:#ecf0f1;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap'
-
-        const dateEl = document.createElement('span')
-        const d = new Date(scene.updated_at)
-        dateEl.textContent = isNaN(d) ? '' : d.toLocaleDateString()
-        dateEl.style.cssText = 'color:#7f8c8d;font-size:10px;margin-left:8px;flex-shrink:0'
-
-        row.appendChild(nameEl)
-        row.appendChild(dateEl)
-
-        row.addEventListener('click', () => selectRow(row, scene.id))
-        row.addEventListener('keydown', (ev) => {
-          if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); selectRow(row, scene.id) }
-        })
-
-        list.appendChild(row)
-      })
-
-      dlg.appendChild(list)
-
-      const btnRow = document.createElement('div')
-      btnRow.style.cssText = 'display:flex;gap:8px;justify-content:flex-end;margin-top:16px'
-
-      const btnCancel = document.createElement('button')
-      btnCancel.textContent = 'Cancel'
-      btnCancel.style.cssText = [
-        'padding:6px 14px;background:#2c3e50;color:#ecf0f1;border:1px solid #3a4a5a',
-        'border-radius:4px;cursor:pointer;font-family:monospace;font-size:12px',
-      ].join(';')
-
-      const btnLoad = document.createElement('button')
-      btnLoad.textContent = 'Load'
-      btnLoad.style.cssText = [
-        'padding:6px 14px;background:#2980b9;color:#fff;border:none',
-        'border-radius:4px;cursor:pointer;font-family:monospace;font-size:12px;font-weight:bold',
-      ].join(';')
-
-      btnRow.appendChild(btnCancel)
-      btnRow.appendChild(btnLoad)
-      dlg.appendChild(btnRow)
-      overlay.appendChild(dlg)
-      document.body.appendChild(overlay)
-
-      const close = (result) => { document.body.removeChild(overlay); resolve(result) }
-      btnCancel.addEventListener('click', () => close(null))
-      btnLoad.addEventListener('click', () => close(selectedId))
-      overlay.addEventListener('click', (e) => { if (e.target === overlay) close(null) })
-    })
-  }
-
-  // ── Unit selection dialog ──────────────────────────────────────────────────
-
-  /** Shows a modal dialog for unit scale selection. Resolves with scale factor or null if cancelled. */
-  _showUnitDialog() {
-    return new Promise((resolve) => {
-      const UNITS = [
-        { label: 'No conversion  (1 : 1)',    value: 1 },
-        { label: 'mm  →  m       (÷ 1000)',   value: 0.001 },
-        { label: 'm   →  mm      (× 1000)',   value: 1000 },
-        { label: 'cm  →  m       (÷ 100)',    value: 0.01 },
-        { label: 'inch →  m      (× 0.0254)', value: 0.0254 },
-        { label: 'inch →  mm     (× 25.4)',   value: 25.4 },
-      ]
-
-      const overlay = document.createElement('div')
-      overlay.style.cssText = [
-        'position:fixed;inset:0;background:rgba(0,0,0,0.6)',
-        'display:flex;align-items:center;justify-content:center;z-index:9999',
-      ].join(';')
-
-      const dlg = document.createElement('div')
-      dlg.style.cssText = [
-        'background:#1e2a3a;border:1px solid #3a4a5a;border-radius:6px',
-        'padding:20px 24px;min-width:320px;color:#ecf0f1;font-family:monospace',
-        'box-shadow:0 8px 32px rgba(0,0,0,0.6)',
-      ].join(';')
-
-      const title = document.createElement('div')
-      title.textContent = 'Import STEP — Unit Conversion'
-      title.style.cssText = 'font-size:13px;font-weight:bold;margin-bottom:14px;color:#aad4f5'
-      dlg.appendChild(title)
-
-      const lbl = document.createElement('div')
-      lbl.textContent = 'Scale'
-      lbl.style.cssText = 'font-size:11px;color:#aaa;margin-bottom:6px'
-      dlg.appendChild(lbl)
-
-      const sel = document.createElement('select')
-      sel.style.cssText = [
-        'width:100%;background:#0d1a26;color:#ecf0f1;border:1px solid #3a4a5a',
-        'border-radius:4px;padding:6px 8px;font-family:monospace;font-size:12px',
-        'cursor:pointer;outline:none',
-      ].join(';')
-      UNITS.forEach((u, i) => {
-        const opt = document.createElement('option')
-        opt.value = i
-        opt.textContent = u.label
-        sel.appendChild(opt)
-      })
-      dlg.appendChild(sel)
-
-      const btnRow = document.createElement('div')
-      btnRow.style.cssText = 'display:flex;gap:8px;justify-content:flex-end;margin-top:16px'
-
-      const btnCancel = document.createElement('button')
-      btnCancel.textContent = 'Cancel'
-      btnCancel.style.cssText = [
-        'padding:6px 14px;background:#2c3e50;color:#ecf0f1;border:1px solid #3a4a5a',
-        'border-radius:4px;cursor:pointer;font-family:monospace;font-size:12px',
-      ].join(';')
-
-      const btnImport = document.createElement('button')
-      btnImport.textContent = 'Import'
-      btnImport.style.cssText = [
-        'padding:6px 14px;background:#e67e22;color:#fff;border:none',
-        'border-radius:4px;cursor:pointer;font-family:monospace;font-size:12px;font-weight:bold',
-      ].join(';')
-
-      btnRow.appendChild(btnCancel)
-      btnRow.appendChild(btnImport)
-      dlg.appendChild(btnRow)
-      overlay.appendChild(dlg)
-      document.body.appendChild(overlay)
-
-      const close = (result) => { document.body.removeChild(overlay); resolve(result) }
-      btnCancel.addEventListener('click', () => close(null))
-      btnImport.addEventListener('click', () => close(UNITS[sel.value].value))
-      overlay.addEventListener('click', (e) => { if (e.target === overlay) close(null) })
-    })
-  }
-
-  // ────────────────────────────────────────────────────────────────────────────
-
-  _addProfileObject() {
-    // Exit current mode cleanly before switching active object
-    if (this._scene.selectionMode === 'edit') this.setMode('object')
-
-    const obj = this._service.createProfile()
-    this._switchActiveObject(obj.id, true)
-    this.setMode('edit')  // enters Edit Mode · 2D
-  }
-
-  /** Enters measure placement mode: click p1, then p2 to create a MeasureLine. */
-  _startMeasurePlacement() {
-    if (this._scene.selectionMode === 'edit') this.setMode('object')
-    this._opState.send('BEGIN_MEASURE')
-    this._measure.p1           = null
-    this._measure.p2           = null
-    this._measure.p1Anchor     = null
-    this._measure.snapTargets  = []
-    this._measure.snapping     = false
-    this._measure.snappedTarget = null
-    // Snap display requires a MeshView with THREE.Points infrastructure.
-    // MeasureLineView and CoordinateFrameView have no snap display infrastructure.
-    // Fall back to any real MeshView-backed object for snap candidate rendering.
-    const activeObj = this._scene.activeObject
-    const _isSnapCapable = o => !(o instanceof MeasureLine) && !(o instanceof CoordinateFrame)
-    this._measure.snapMeshView = (activeObj && _isSnapCapable(activeObj))
-      ? activeObj.meshView
-      : ([...this._scene.objects.values()].find(_isSnapCapable)?.meshView ?? null)
-    // On touch devices, disable orbit so single-finger touch places measure
-    // points instead of orbiting the camera.  Use (pointer: coarse) rather
-    // than innerWidth so that tablets and landscape phones are also covered.
-    if (window.matchMedia('(pointer: coarse)').matches) this._controls.enabled = false
-    this._uiView.setCursor('crosshair')
-    this._updateMeasureStatus()
-    this._updateMobileToolbar()
-  }
-
-  _cancelMeasure() {
-    if (!this._opState.is(S_MEASURE_PLACING)) return
-    this._measure.p1           = null
-    this._measure.p2           = null
-    this._measure.p1Anchor     = null
-    this._measure.snapping     = false
-    this._measure.snappedTarget = null
-    this._measure.snapTargets  = []
-    this._measure.pressing     = false
-    if (this._measure.previewLine) {
-      this._sceneView.scene.remove(this._measure.previewLine)
-      this._measure.previewLine.geometry.dispose()
-      this._measure.previewLine.material.dispose()
-      this._measure.previewLine = null
-    }
-    this._measure.snapMeshView?.clearSnapDisplay()
-    this._measure.snapMeshView = null
-    this._opState.send('CANCEL')
-    if (window.matchMedia('(pointer: coarse)').matches) this._controls.enabled = true
-    this._uiView.setCursor('default')
-    this._refreshObjectModeStatus()
-    this._updateMobileToolbar()
-  }
-
-  /**
-   * Confirms the current snapped cursor position as a measure point.
-   * Phase 1: sets p1. Phase 2: creates the MeasureLine entity.
-   * Called from _onPointerUp so mobile users can hold-to-snap before releasing.
-   */
-  _confirmMeasurePoint() {
-    const pt = this._measurePickPoint()
-    if (!pt) return
-    if (!this._measure.p1) {
-      // Phase 1 → Phase 2: record start point and its anchor (ADR-028)
-      this._measure.p1 = pt.clone()
-      const t = this._measure.snappedTarget
-      this._measure.p1Anchor = (t?.objectId && t?.elementId)
-        ? { objectId: t.objectId, type: t.type, elementId: t.elementId }
-        : null
-      this._updateMeasureStatus()
-    } else {
-      // Phase 2: record end point → create entity
-      const p2 = pt.clone()
-      // Capture anchor refs before clearing state (ADR-028)
-      const t2       = this._measure.snappedTarget
-      const p2Anchor = (t2?.objectId && t2?.elementId)
-        ? { objectId: t2.objectId, type: t2.type, elementId: t2.elementId }
-        : null
-      const p1Anchor = this._measure.p1Anchor
-      if (this._measure.previewLine) {
-        this._sceneView.scene.remove(this._measure.previewLine)
-        this._measure.previewLine.geometry.dispose()
-        this._measure.previewLine.material.dispose()
-        this._measure.previewLine = null
-      }
-      this._measure.snapMeshView?.clearSnapDisplay()
-      this._measure.snapMeshView  = null
-      this._opState.send('CONFIRM')
-      const p1                    = this._measure.p1
-      this._measure.p1            = null
-      this._measure.p2            = null
-      this._measure.p1Anchor      = null
-      this._measure.snapTargets   = []
-      this._measure.snapping      = false
-      this._measure.snappedTarget = null
-      const obj = this._service.createMeasureLine(
-        p1, p2,
-        this._camera,
-        this._sceneView.renderer,
-        document.body,
-        { p1: p1Anchor, p2: p2Anchor },
-      )
-      this._switchActiveObject(obj.id, true)
-      if (window.matchMedia('(pointer: coarse)').matches) this._controls.enabled = true
-      this._uiView.setCursor('default')
-      this._refreshObjectModeStatus()
-      this._updateMobileToolbar()
-    }
-  }
-
-  _updateMeasureStatus() {
-    if (!this._opState.is(S_MEASURE_PLACING)) return
-    if (!this._measure.p1) {
-      this._uiView.setStatusRich([
-        { text: 'Measure', bold: true, color: '#f9a825' },
-        { text: 'Click to set start point', color: '#888' },
-        { text: 'ESC cancel', color: '#444' },
-      ])
-    } else {
-      const parts = [
-        { text: 'Measure', bold: true, color: '#f9a825' },
-        { text: 'Click to set end point', color: '#888' },
-      ]
-      if (this._measure.p2) {
-        const d = this._measure.p1.distanceTo(this._measure.p2)
-        const f = d < 1 ? `${(d * 100).toFixed(1)} cm` : `${d.toFixed(3)} m`
-        parts.push({ text: f, bold: true, color: '#f9a825' })
-      }
-      if (this._measure.snapping && this._measure.snappedTarget) {
-        parts.push({ text: `Snap: ${this._measure.snappedTarget.label}`, color: '#ff9800' })
-      }
-      parts.push({ text: 'ESC cancel', color: '#444' })
-      this._uiView.setStatusRich(parts)
-    }
-  }
-
-  // ── 2D Map Mode — see MapModeController ─────────────────────────────────
-  // All map mode methods live in src/controller/map/MapModeController.js.
-  // AppController holds this._mapModeCtrl; event handlers delegate via
-  // this._mapModeCtrl.onPointerMove/Down/Up/KeyDown/onWheel.
-
-  /**
-   * Finds the nearest V/E/F snap target to the current mouse cursor.
-   * Returns the snapped world position (or ground-plane fallback).
-   * Also updates this._measure.snapping / snappedTarget / snapTargets.
-   */
-  _measurePickPoint() {
-    const mx = (this._mouse.x + 1) / 2 * innerWidth
-    const my = (-this._mouse.y + 1) / 2 * innerHeight
-
-    const targets = collectSnapTargets(this._scene.objects, 'all')
-    this._measure.snapTargets = targets
-
-    const bestTarget = this._pickBestSnapTarget(targets, mx, my)
-
-    if (bestTarget) {
-      this._measure.snapping      = true
-      this._measure.snappedTarget = bestTarget
-      return bestTarget.position.clone()
-    }
-
-    // Fallback: intersect ground plane (Z=0)
-    this._measure.snapping      = false
-    this._measure.snappedTarget = null
-    this._raycaster.setFromCamera(this._mouse, this._camera)
-    const pt = new THREE.Vector3()
-    if (this._raycaster.ray.intersectPlane(this._groundPlane, pt)) return pt
-    return null
-  }
-
-  /** Builds or updates the dashed preview line shown during measure placement phase 2. */
-  _updateMeasurePreview(p1, p2) {
-    const pts = [p1.x, p1.y, p1.z, p2.x, p2.y, p2.z]
-    if (!this._measure.previewLine) {
-      const geo  = new THREE.BufferGeometry()
-      const mat  = new THREE.LineDashedMaterial({
-        color: 0xf9a825, dashSize: 0.15, gapSize: 0.08, depthTest: false,
-      })
-      this._measure.previewLine = new THREE.Line(geo, mat)
-      this._measure.previewLine.renderOrder = 1
-      this._sceneView.scene.add(this._measure.previewLine)
-    }
-    const geo = this._measure.previewLine.geometry
-    geo.setAttribute('position', new THREE.Float32BufferAttribute(pts, 3))
-    geo.attributes.position.needsUpdate = true
-    this._measure.previewLine.computeLineDistances()
-  }
-
-  _deleteObject(id) {
-    const target = this._scene.getObject(id)
-    if (!target) return
-
-    // Origin frames are the body frame — cannot be explicitly deleted (ADR-037)
-    if (target instanceof CoordinateFrame && target.name === 'Origin') {
-      this._uiView.showToast('Origin frame cannot be deleted', { type: 'warn' })
-      return
-    }
-
-    // Frames are always deletable.  Geometry objects require at least one
-    // other geometry object to remain in the scene.
-    if (!(target instanceof CoordinateFrame)) {
-      const geometryCount = [...this._scene.objects.values()]
-        .filter(o => !(o instanceof CoordinateFrame)).length
-      if (geometryCount <= 1) {
-        this._uiView.showToast('Scene must contain at least one object', { type: 'warn' })
-        return
-      }
-    }
-
-    // Provenance check: block delete if frame was declared by a different role (ADR-034 §8.2)
-    if (target instanceof CoordinateFrame && !RoleService.canEdit(target)) {
-      this._uiView.showToast(`This frame was declared by a ${target.declaredBy}. Switch to that role to edit it.`, { type: 'warn' })
-      return
-    }
-
-    // ADR-033 §4: warn when deleting a CoordinateFrame that is referenced by SpatialLinks
-    if (target instanceof CoordinateFrame) {
-      const links = this._service.getLinksOf(id)
-      if (links.length > 0) {
-        const n = links.length
-        this._uiView.showConfirmDialog(
-          `Frame "${target.name}" is referenced by ${n} spatial link${n > 1 ? 's' : ''}.\n` +
-          `Deleting it will leave those links dangling. Delete anyway?`,
-          (confirmed) => {
-            if (confirmed) this._execDeleteObject(id, target)
-          },
-          { title: 'Delete Frame', confirmLabel: 'Delete', danger: true },
-        )
-        return
-      }
-    }
-
-    this._execDeleteObject(id, target)
-  }
-
-  /** Performs the actual soft-delete after all guards have passed. */
-  _execDeleteObject(id, target) {
-    if (!target) target = this._scene.getObject(id)
-    if (!target) return
-
-    // If deleting the active object while in Edit Mode, exit cleanly first
-    // (setMode operates on the active meshView, so must be called before dispose)
-    if (id === this._scene.activeId && this._scene.selectionMode === 'edit') {
-      this.setMode('object')
-    }
-
-    const wasActive = this._scene.activeId === id
-
-    // If deleting the active frame, hide its chain before detaching
-    if (wasActive && target instanceof CoordinateFrame && this._activeFrameChain.size > 0) {
-      this._hideFrameChain()
-    }
-    // If deleting a geometry object with visible child frames, hide them first
-    if (wasActive && !(target instanceof CoordinateFrame)) {
-      this._setChildFramesVisible(id, false)
-    }
-
-    // Determine next active object: prefer geometry objects over frames.
-    const nextId = wasActive
-      ? (
-          // First try another geometry object
-          [...this._scene.objects.entries()].find(
-            ([k, o]) => k !== id && !(o instanceof CoordinateFrame),
-          )?.[0]
-          // Fall back to any object (e.g. another frame)
-          ?? [...this._scene.objects.keys()].find(k => k !== id)
-          ?? null
-        )
-      : null
-
-    // ── Soft-delete for undo support (ADR-022 Phase 3) ────────────────────
-    const childrenRefs = [...this._collectAllDescendantFrames(id)]
-      .map(fid => this._scene.getObject(fid)).filter(Boolean)
-
-    // Detach children first (deepest last, though frames rarely nest >1 deep)
-    for (let i = childrenRefs.length - 1; i >= 0; i--) {
-      this._service.detachObject(childrenRefs[i].id)
-    }
-    this._service.detachObject(id)
-    target.meshView.setVisible(false)
-
-    const cmd = createDeleteCommand(
-      target, childrenRefs, this._service,
-      // onAfterUndo: switch active to the restored entity
-      (restoredId) => this._switchActiveObject(restoredId, true),
-      // onAfterRedo: switch active to next available object
-      (deletedId)  => {
-        const nxt = [...this._scene.objects.entries()]
-          .find(([k, o]) => k !== deletedId && !(o instanceof CoordinateFrame))?.[0]
-          ?? [...this._scene.objects.keys()].find(k => k !== deletedId)
-          ?? null
-        if (nxt) this._switchActiveObject(nxt, true)
-      },
-    )
-    this._commandStack.push(cmd)
-
-    if (wasActive && nextId) {
-      this._switchActiveObject(nextId, true)
-    }
-  }
-
-  /**
-   * Duplicates the active Solid, makes the copy active, and immediately
-   * starts a grab so the user can position it (Blender Shift+D behaviour).
-   * No-ops if there is no active object or it is a Profile.
-   */
-  _duplicateObject() {
-    const id = this._scene.activeId
-    if (!id) return
-    // SpatialLink has no geometry — cannot be duplicated (ADR-030)
-    if (this._activeObj instanceof SpatialLink) {
-      this._uiView.showToast('SpatialLink cannot be duplicated', { type: 'warn' })
-      return
-    }
-    if (this._scene.selectionMode === 'edit') this.setMode('object')
-    const copy = this._service.duplicateSolid(id)
-    if (!copy) return
-    this._selectedIds.clear()
-    this._selectedIds.add(copy.id)
-    this._switchActiveObject(copy.id, true)
-    this._grabHandler.start()
-  }
-
-  // ─── Mobile Axis Guide helpers (replaces TransformControls) ──────────────
-
-  /**
-   * Creates 3D axis guide visuals: a colored line (translate) and a gimbal ring
-   * (rotate).  Both are invisible until _showAxisGuide() is called.
-   * Called once at construction time.
-   */
-  _initMobileAxisGuide() {
-    // Axis line — two endpoints; reused for all axes (position updated by _showAxisGuide)
-    const lineGeom = new THREE.BufferGeometry()
-    lineGeom.setAttribute('position', new THREE.Float32BufferAttribute(new Float32Array(6), 3))
-    const lineMat = new THREE.LineBasicMaterial({ color: 0xffffff, depthTest: false, transparent: true, opacity: 0.85 })
-    this._axisGuideLine = new THREE.Line(lineGeom, lineMat)
-    this._axisGuideLine.visible = false
-    this._axisGuideLine.renderOrder = 999
-    this._sceneView.scene.add(this._axisGuideLine)
-
-    // Gimbal ring — circle in the local XY plane; rotated to match the rotation axis
-    const SEG = 64
-    const pts = new Float32Array((SEG + 1) * 3)
-    for (let i = 0; i <= SEG; i++) {
-      const t = (i / SEG) * Math.PI * 2
-      pts[i * 3] = Math.cos(t); pts[i * 3 + 1] = Math.sin(t); pts[i * 3 + 2] = 0
-    }
-    const ringGeom = new THREE.BufferGeometry()
-    ringGeom.setAttribute('position', new THREE.Float32BufferAttribute(pts, 3))
-    const ringMat = new THREE.LineBasicMaterial({ color: 0xffffff, depthTest: false, transparent: true, opacity: 0.9 })
-    this._axisGuideRing = new THREE.Line(ringGeom, ringMat)
-    this._axisGuideRing.visible = false
-    this._axisGuideRing.renderOrder = 999
-    this._sceneView.scene.add(this._axisGuideRing)
-  }
-
-  /**
-   * Shows the axis guide appropriate for the current operation mode.
-   * @param {'x'|'y'|'z'} axis
-   * @param {THREE.Vector3} center - world position of the guide origin
-   * @param {'translate'|'rotate'} mode
-   */
-  _showAxisGuide(axis, center, mode) {
-    const COLORS = { x: 0xe05252, y: 0x6ab04c, z: 0x4a9eed }
-    const color = COLORS[axis] ?? 0xffffff
-    const camDist = center.distanceTo(this._camera.position)
-    const r = Math.max(0.5, camDist * 0.25)
-
-    if (mode === 'translate') {
-      const dir = axis === 'x' ? new THREE.Vector3(1, 0, 0)
-                : axis === 'y' ? new THREE.Vector3(0, 1, 0)
-                :                new THREE.Vector3(0, 0, 1)
-      const attr = this._axisGuideLine.geometry.attributes.position
-      const p0 = center.clone().addScaledVector(dir, -r * 2.5)
-      const p1 = center.clone().addScaledVector(dir,  r * 2.5)
-      attr.array[0] = p0.x; attr.array[1] = p0.y; attr.array[2] = p0.z
-      attr.array[3] = p1.x; attr.array[4] = p1.y; attr.array[5] = p1.z
-      attr.needsUpdate = true
-      this._axisGuideLine.material.color.setHex(color)
-      this._axisGuideLine.visible = true
-      this._axisGuideRing.visible = false
-    } else {
-      this._axisGuideRing.position.copy(center)
-      this._axisGuideRing.scale.setScalar(r)
-      if (axis === 'x') {
-        this._axisGuideRing.rotation.set(0, Math.PI / 2, 0)
-      } else if (axis === 'y') {
-        this._axisGuideRing.rotation.set(Math.PI / 2, 0, 0)
-      } else {
-        this._axisGuideRing.rotation.set(0, 0, 0)
-      }
-      this._axisGuideRing.material.color.setHex(color)
-      this._axisGuideRing.visible = true
-      this._axisGuideLine.visible = false
-    }
-  }
-
-  /** Hides all axis guide visuals. */
-  _hideAxisGuide() {
-    if (this._axisGuideLine) this._axisGuideLine.visible = false
-    if (this._axisGuideRing) this._axisGuideRing.visible = false
-  }
-
-  /**
-   * Switches the active object without toggling selection.
-   * @param {string} id
-   * @param {boolean} select - whether to set _objSelected = true
-   */
-  _switchActiveObject(id, select = false) {
-    // Deselect / un-highlight previous
-    if (this._scene.activeId && this._scene.activeId !== id) {
-      const prev = this._scene.getObject(this._scene.activeId)
-      if (prev) {
-        prev.meshView.setObjectSelected(false)
-        if (prev instanceof CoordinateFrame) {
-          this._hideFrameChain()
-          // Hide parent axes ghost when leaving a CoordinateFrame selection (ADR-034 §7)
-          prev.meshView.hideParentAxesGhost()
-        } else {
-          this._setChildFramesVisible(this._scene.activeId, false)
-        }
-      }
-    }
-
-    this._service.setActiveObject(id)
-    this._objSelected = select
-    // Keep _selectedIds in sync so grab / pointer-drag work after outliner selection
-    if (select) {
-      this._selectedIds.clear()
-      this._selectedIds.add(id)
-    }
-    // Rubber-band: highlight links for the newly active entity (or clear on deselect).
-    this._service.updateLinkSelectionHighlight(select && id ? this._selectedIds : new Set())
-    // Link network overlay: sync node highlight with 3D selection.
-    this._linkNetworkView?.setSelection(select && id ? this._selectedIds : new Set())
-
-    const obj = this._scene.getObject(id)
-    if (obj) obj.meshView.setObjectSelected(select)
-    if (select) {
-      if (obj instanceof CoordinateFrame) {
-        this._showFrameChain(id)
-        // Show parent axes ghost at geometry ancestor centroid (ADR-034 §7)
-        const ghostPos = this._geometryAncestorCentroid(id)
-        if (ghostPos) obj.meshView.showParentAxesGhost(ghostPos)
-      } else {
-        this._setChildFramesVisible(id, true)
-      }
-    }
-
-    this._refreshObjectModeStatus()
-    this._updateNPanel()
-    this._updateMobileToolbar()
-
-  }
-
-  /**
-   * Walks up the parentId chain from the given CoordinateFrame ID to find the
-   * first non-CoordinateFrame ancestor, then returns its world centroid.
-   * Returns null if no geometry ancestor found or if it has no corners.
-   * @param {string} frameId
-   * @returns {THREE.Vector3|null}
-   */
-  _geometryAncestorCentroid(frameId) {
-    let obj = this._scene.getObject(frameId)
-    while (obj instanceof CoordinateFrame) {
-      obj = this._scene.getObject(obj.parentId)
-    }
-    if (!obj) return null
-    // Use cached world position for CoordinateFrame (never reached here — just corners)
-    const corners = obj.corners
-    if (!corners || corners.length === 0) return null
-    const centroid = new THREE.Vector3()
-    for (const c of corners) centroid.add(c)
-    centroid.divideScalar(corners.length)
-    return centroid
+    this._framePlacementHandler.start(parentId)
   }
 
   _setObjectVisible(id, visible) {
@@ -1945,7 +927,7 @@ export class AppController {
     // During link creation: treat the clicked row as the target entity
     if (this._opState.is(S_LINK_MODE)) {
       if (id !== this._spatialLinkMode.sourceId) {
-        this._showLinkTypePicker(window.innerWidth / 2, window.innerHeight / 2, id)
+        this._linkHandler.showTypePicker(window.innerWidth / 2, window.innerHeight / 2, id)
       }
       return  // don't change active selection while in link mode
     }
@@ -1956,163 +938,6 @@ export class AppController {
       // Clicking the already-active row just re-selects it
       this._setObjectSelected(true)
     }
-  }
-
-  // ── SpatialLink creation flow (ADR-030 Phase 4) ────────────────────────────
-
-  /** Starts the two-phase L-key link creation. Source = currently active entity. */
-  _startSpatialLinkCreation() {
-    this._opState.send('BEGIN_LINK')
-    this._spatialLinkMode.sourceId = this._scene.activeId
-    this._spatialLinkMode.pendingTargetId = null
-    // Show all CFs so the target frame is visible for picking regardless of selection state
-    for (const obj of this._scene.objects.values()) {
-      if (obj instanceof CoordinateFrame && obj.meshView) obj.meshView.showFull()
-    }
-    this._uiView.setStatus('Click target entity  [Esc: cancel]')
-    this._uiView.setCursor('crosshair')
-  }
-
-  /** Cancels link creation mode and restores normal status. */
-  _cancelSpatialLinkCreation() {
-    this._opState.send('CANCEL')
-    this._spatialLinkMode.sourceId = null
-    this._spatialLinkMode.pendingTargetId = null
-    this._restoreCoordinateFrameVisibility()
-    this._uiView.setCursor('default')
-    this._refreshObjectModeStatus()
-  }
-
-  /** Restores CF visibility after link-creation mode: show only CFs whose parent (or self) is the active object. */
-  _restoreCoordinateFrameVisibility() {
-    const activeId = this._activeObj?.id
-    for (const obj of this._scene.objects.values()) {
-      if (!(obj instanceof CoordinateFrame) || !obj.meshView) continue
-      if (obj.id === activeId || obj.parentId === activeId) {
-        obj.meshView.showFull()
-      } else {
-        obj.meshView.hide()
-      }
-    }
-  }
-
-  /**
-   * Opens the link-type picker at (x, y) for the given target entity.
-   * Filters valid link types based on source / target entity type (ADR-032 §2).
-   * @param {number} x  client X
-   * @param {number} y  client Y
-   * @param {string} targetId
-   */
-  _showLinkTypePicker(x, y, targetId) {
-    this._spatialLinkMode.pendingTargetId = targetId
-    const sourceId = this._spatialLinkMode.sourceId
-    const source   = this._scene.getObject(sourceId)
-    const target   = this._scene.getObject(targetId)
-    const linkOptions = _computeLinkOptions(source, target)
-    this._uiView.showLinkTypePicker(x, y, (option) => {
-      if (option.semanticType === 'mounts') {
-        this._confirmMountAnnotation(sourceId, targetId)
-      } else if (option.jointType === 'fixed') {
-        this._confirmFastenFrame(sourceId, targetId, option.semanticType)
-      } else {
-        this._confirmSpatialLink(option)
-      }
-    }, { linkOptions })
-  }
-
-  /**
-   * Shared link creation used by L-key flow and Node Editor (Phase S-2).
-   * Creates SpatialLink + records undo command without touching spatialLinkMode state.
-   * @param {string} sourceId
-   * @param {string} targetId
-   * @param {{ jointType: string|null, semanticType: string, label: string }} option
-   */
-  _createSpatialLinkDirect(sourceId, targetId, option) {
-    const link = this._service.createSpatialLink(sourceId, targetId, option.jointType, option.semanticType, option.properties ?? {})
-    this._commandStack.push(createSpatialLinkCommand(link, this._service))
-    this._uiView.showToast(`Link created: ${option.label}`)
-    this._updateNPanel()
-    // Acceptance ceremony: ripple sphere at link midpoint + brief line flash.
-    const srcPos = this._dragSuggestionCentroid(sourceId)
-    const tgtPos = this._dragSuggestionCentroid(targetId)
-    if (srcPos && tgtPos) {
-      const midpoint = srcPos.clone().lerp(tgtPos, 0.5)
-      const color    = LINK_TYPE_COLORS[option.semanticType] ?? 0x888888
-      this._activeRipples.push(new RippleEffect(this._sceneView.scene, midpoint, color))
-    }
-    this._service._linkViews.get(link.id)?.triggerFlash?.()
-  }
-
-  /**
-   * Creates the SpatialLink from L-key picking flow and records the undo command.
-   * @param {{ jointType: string|null, semanticType: string, label: string }} option
-   */
-  _confirmSpatialLink(option) {
-    const { sourceId, pendingTargetId } = this._spatialLinkMode
-    if (!sourceId || !pendingTargetId) return
-    this._createSpatialLinkDirect(sourceId, pendingTargetId, option)
-    this._cancelSpatialLinkCreation()
-  }
-
-  /**
-   * Mounts an Annotated* entity onto a CoordinateFrame and records the command.
-   * Called from both the L-key flow (PC) and the mobile mount-picking flow.
-   * @param {string} sourceId  Annotated* entity ID
-   * @param {string} targetId  CoordinateFrame entity ID
-   */
-  _confirmMountAnnotation(sourceId, targetId) {
-    const result = this._service.mountAnnotation(sourceId, targetId)
-    if (!result) {
-      this._uiView.showToast('Cannot mount — host frame pose unknown', { type: 'warn' })
-      return
-    }
-    const { link, worldPositionsBefore } = result
-    this._commandStack.push(createMountAnnotationCommand(
-      link, worldPositionsBefore, this._service,
-      () => { this._updateNPanel() },
-      () => { this._updateNPanel() },
-    ))
-    this._uiView.showToast(`Mounted on frame "${this._scene.getObject(targetId)?.name}"`)
-    this._cancelSpatialLinkCreation()
-    if (this._opState.is(S_MOUNT_PICKING)) {
-      this._mountPicking.sourceId = null
-      this._uiView.setCursor('default')
-      this._opState.send('CONFIRM')
-      this._refreshObjectModeStatus()
-    }
-    this._updateNPanel()
-  }
-
-  /**
-   * Fastens a source CoordinateFrame to a target CoordinateFrame and records the command.
-   * Called from the L-key link-type picker when the user selects a fixed joint for CF→CF.
-   * @param {string} sourceId     CoordinateFrame entity ID (slave / constrained frame)
-   * @param {string} targetId     CoordinateFrame entity ID (master / reference frame)
-   * @param {string} [semanticType='fastened']  Semantic annotation for the link
-   */
-  _confirmFastenFrame(sourceId, targetId, semanticType = 'fastened') {
-    const source = this._scene.getObject(sourceId)
-    const target = this._scene.getObject(targetId)
-    if (!(source instanceof CoordinateFrame) || !(target instanceof CoordinateFrame)) {
-      this._uiView.showToast('Select a coordinate frame as source and target', { type: 'warn' })
-      return
-    }
-    // Force-update world poses so cache is fresh even if called between animation ticks
-    this._service._updateWorldPoses()
-    const result = this._service.fastenFrame(sourceId, targetId, semanticType)
-    if (!result) {
-      this._uiView.showToast('Cannot fasten — frame pose unknown', { type: 'warn' })
-      return
-    }
-    const { link, translationBefore, rotationBefore, relativeOffset, relativeQuat } = result
-    this._commandStack.push(createFastenFrameCommand(
-      link, translationBefore, rotationBefore, relativeOffset, relativeQuat, this._service,
-      () => { this._updateNPanel() },
-      () => { this._updateNPanel() },
-    ))
-    this._uiView.showToast(`Fastened to "${this._scene.getObject(targetId)?.name}"`)
-    this._cancelSpatialLinkCreation()
-    this._updateNPanel()
   }
 
   // ── Mount picking flow (Mobile, ADR-032 Phase H-6) ────────────────────────
@@ -2793,7 +1618,7 @@ export class AppController {
     // ADR-032 §9: generic Link to... for Solid / CoordinateFrame
     const linkItems = isSolidOrCF
       ? [{ label: 'Link to... 🔗', onClick: () => {
-          this._startSpatialLinkCreation()
+          this._linkHandler.start()
           // Override the sourceId to the long-pressed object (it may not be active)
           this._spatialLinkMode.sourceId = id
         }}]
@@ -2910,7 +1735,7 @@ export class AppController {
 
     if (this._opState.is(S_MEASURE_PLACING)) {
       this._uiView.setMobileToolbar([
-        { icon: ICONS.cancel, label: 'Cancel', onClick: () => this._cancelMeasure(), danger: true },
+        { icon: ICONS.cancel, label: 'Cancel', onClick: () => this._measureHandler.cancel(), danger: true },
         { spacer: true },
         { spacer: true },
         { spacer: true },
@@ -2921,7 +1746,7 @@ export class AppController {
     // ── Frame placement pick sub-mode (ADR-034 §6) ────────────────────────
     if (this._opState.is(S_FRAME_PLACEMENT)) {
       this._uiView.setMobileToolbar([
-        { icon: ICONS.cancel, label: 'Cancel', onClick: () => this._cancelFramePickSubMode(), danger: true },
+        { icon: ICONS.cancel, label: 'Cancel', onClick: () => this._framePlacementHandler.cancel(), danger: true },
         { spacer: true },
         { spacer: true },
         { spacer: true },
@@ -3241,8 +2066,8 @@ export class AppController {
     // ── Cancel all in-progress operations ──────────────────────────────────
     if (this._opState.is(S_GRAB_ACTIVE))      this._grabHandler.cancel()
     if (this._opState.is(S_ROTATE_ACTIVE))    this._rotateHandler.cancel()
-    if (this._opState.is(S_FACE_EXTRUDE))     this._cancelFaceExtrude()
-    if (this._opState.is(S_FRAME_PLACEMENT))  this._cancelFramePickSubMode()
+    if (this._opState.is(S_FACE_EXTRUDE))     this._faceExtrudeHandler.cancel()
+    if (this._opState.is(S_FRAME_PLACEMENT))  this._framePlacementHandler.cancel()
     if (this._opState.is(S_MOUNT_PICKING))    this._cancelMountPicking()
     if (this._opState.is(S_QUICK_DRAG)) {
       this._quickDragHandler.cancel(this._quickDragCtx)
@@ -3819,32 +2644,7 @@ export class AppController {
 
     // ── Frame placement pick sub-mode hover (ADR-034 §6) ─────────────────
     if (this._opState.is(S_FRAME_PLACEMENT) && e.pointerType !== 'touch') {
-      const pt = this._pickFramePlacementPoint()
-      if (pt && this._frameCursorGhost) {
-        this._frameCursorGhost.position.copy(pt)
-        this._frameCursorGhost.quaternion.set(0, 0, 0, 1)
-        this._frameCursorGhost.visible = true
-        // Scale cursor ghost to consistent screen size
-        const d = this._camera.position.distanceTo(pt)
-        if (d > 0 && this._camera.isPerspectiveCamera) {
-          const tanHalfFov = Math.tan((this._camera.fov * Math.PI) / 360)
-          const screenH    = this._sceneView.renderer.domElement.clientHeight || 1
-          const ws = (60 / screenH) * 2 * d * tanHalfFov
-          this._frameCursorGhost.scale.setScalar(ws / _GHOST_AXIS_LEN)
-        }
-      } else if (this._frameCursorGhost) {
-        this._frameCursorGhost.visible = false
-      }
-      // Scale parent axes overlay too
-      if (this._parentAxesOverlay?.visible) {
-        const dp = this._camera.position.distanceTo(this._parentAxesOverlay.position)
-        if (dp > 0 && this._camera.isPerspectiveCamera) {
-          const tanHalfFov = Math.tan((this._camera.fov * Math.PI) / 360)
-          const screenH    = this._sceneView.renderer.domElement.clientHeight || 1
-          const ws = (80 / screenH) * 2 * dp * tanHalfFov
-          this._parentAxesOverlay.scale.setScalar(ws / _GHOST_AXIS_LEN)
-        }
-      }
+      this._framePlacementHandler.updateCursorGhost()
       return
     }
 
@@ -3853,7 +2653,7 @@ export class AppController {
 
     // ── Measure placement hover ───────────────────────────────────────────
     if (this._opState.is(S_MEASURE_PLACING)) {
-      const pt = this._measurePickPoint()
+      const pt = this._measureHandler.pickPoint()
       if (pt) {
         this._measure.p2 = pt
         // Show snap candidates via snapMeshView (a real MeshView, not MeasureLineView)
@@ -3878,10 +2678,10 @@ export class AppController {
         }
         // Phase 2: draw preview line
         if (this._measure.p1) {
-          this._updateMeasurePreview(this._measure.p1, pt)
+          this._measureHandler.updatePreview(this._measure.p1, pt)
         }
       }
-      this._updateMeasureStatus()
+      this._measureHandler.updateStatus()
       return
     }
 
@@ -3958,8 +2758,8 @@ export class AppController {
       const pt = new THREE.Vector3()
       if (!this._raycaster.ray.intersectPlane(this._faceExtrude.dragPlane, pt)) return
       const rawDist = pt.clone().sub(this._faceExtrude.startPoint).dot(this._faceExtrude.normal)
-      this._faceExtrude.dist = this._trySnapFaceExtrude(rawDist)
-      this._applyFaceExtrude()
+      this._faceExtrude.dist = this._faceExtrudeHandler.trySnap(rawDist)
+      this._faceExtrudeHandler.applyPreview()
       // snap visuals
       const fe = this._faceExtrude
       const mx = (this._mouse.x + 1) / 2 * innerWidth
@@ -3978,7 +2778,7 @@ export class AppController {
         if (nearest) this._meshView.showSnapNearest(nearest.position, nearest.type)
         else         this._meshView.clearSnapNearest()
       }
-      this._updateFaceExtrudeStatus()
+      this._faceExtrudeHandler.updateStatus()
       return
     }
 
@@ -4083,13 +2883,13 @@ export class AppController {
 
     // ── Frame placement pick sub-mode (ADR-034 §6) ────────────────────────
     if (this._opState.is(S_FRAME_PLACEMENT)) {
-      if (e.button === 2) { this._cancelFramePickSubMode(); return }
+      if (e.button === 2) { this._framePlacementHandler.cancel(); return }
       if (e.button === 0 || e.pointerType === 'touch') {
-        const pt = this._pickFramePlacementPoint()
+        const pt = this._framePlacementHandler.pickPoint()
         if (pt) {
-          this._confirmFramePlacement(pt)
+          this._framePlacementHandler.confirm(pt)
         } else {
-          this._cancelFramePickSubMode()
+          this._framePlacementHandler.cancel()
         }
         return
       }
@@ -4127,7 +2927,7 @@ export class AppController {
         if (hit) {
           const hitObj = this._scene.getObject(hit.obj.id)
           if (hitObj instanceof CoordinateFrame) {
-            this._confirmMountAnnotation(this._mountPicking.sourceId, hit.obj.id)
+            this._linkHandler.confirmMount(this._mountPicking.sourceId, hit.obj.id)
           } else if (hitObj instanceof Solid) {
             this._uiView.showToast('Add a frame to this object first', { type: 'warn' })
           } else {
@@ -4143,7 +2943,7 @@ export class AppController {
         if (hit) {
           const hitObj = this._scene.getObject(hit.obj.id)
           if (hitObj instanceof CoordinateFrame) {
-            this._confirmMountAnnotation(this._mountPicking.sourceId, hit.obj.id)
+            this._linkHandler.confirmMount(this._mountPicking.sourceId, hit.obj.id)
           } else if (hitObj instanceof Solid) {
             this._uiView.showToast('Add a frame to this object first', { type: 'warn' })
           } else {
@@ -4159,13 +2959,13 @@ export class AppController {
 
     // ── SpatialLink target selection (ADR-030 Phase 4) ─────────────────────
     if (this._opState.is(S_LINK_MODE)) {
-      if (e.button === 2) { this._cancelSpatialLinkCreation(); return }
+      if (e.button === 2) { this._linkHandler.cancel(); return }
       if (e.button === 0) {
         const hit = this._hitAnyEntityForLink()
         if (hit) {
-          this._showLinkTypePicker(e.clientX, e.clientY, hit.obj.id)
+          this._linkHandler.showTypePicker(e.clientX, e.clientY, hit.obj.id)
         } else {
-          this._cancelSpatialLinkCreation()
+          this._linkHandler.cancel()
         }
         return
       }
@@ -4227,7 +3027,7 @@ export class AppController {
         this._activeDragPointerId = e.pointerId
         return
       }
-      if (e.button === 2) { this._cancelFaceExtrude(); return }
+      if (e.button === 2) { this._faceExtrudeHandler.cancel(); return }
       return
     }
 
@@ -4236,7 +3036,7 @@ export class AppController {
 
     // ── Measure placement clicks ──────────────────────────────────────────
     if (this._opState.is(S_MEASURE_PLACING)) {
-      if (e.button === 2) { this._cancelMeasure(); return }
+      if (e.button === 2) { this._measureHandler.cancel(); return }
       if (e.button === 0) {
         // Hold to snap, release to confirm — handled in _onPointerUp.
         // This lets mobile users slide their finger to the snap target before lifting.
@@ -4473,7 +3273,7 @@ export class AppController {
         !e.shiftKey) {
       const faces = [...this._scene.editSelection].filter(x => x instanceof Face)
       if (faces.length > 0) {
-        this._startFaceExtrude(faces[0])
+        this._faceExtrudeHandler.start(faces[0])
         this._activeDragPointerId = e.pointerId
       }
     }
@@ -4509,7 +3309,7 @@ export class AppController {
       if (this._activeDragPointerId === e.pointerId) {
         this._activeDragPointerId = null
         this._measure.pressing    = false
-        this._confirmMeasurePoint()
+        this._measureHandler.confirmPoint()
       }
       return
     }
@@ -4530,7 +3330,7 @@ export class AppController {
     if (this._opState.is(S_FACE_EXTRUDE)) {
       // Only confirm when a canvas drag was started; prevents double-confirm
       // when the mobile Confirm toolbar button fires both pointerup and click.
-      if (wasDragging) this._confirmFaceExtrude()
+      if (wasDragging) this._faceExtrudeHandler.confirm()
       return
     }
     if (this._editOpState.is(EO_2D_SKETCH_DRAW) && wasDragging) {
@@ -4560,7 +3360,7 @@ export class AppController {
     if (e.key === 'Control') {
       this._ctrlHeld = false
       if (this._opState.is(S_GRAB_ACTIVE) && !this._grabHandler.pivotSelectMode) this._grabHandler.updateStatus()
-      if (this._opState.is(S_FACE_EXTRUDE)) this._updateFaceExtrudeStatus()
+      if (this._opState.is(S_FACE_EXTRUDE)) this._faceExtrudeHandler.updateStatus()
       if (this._opState.is(S_ROTATE_ACTIVE) && !this._rotateHandler.state.hasInput) {
         this._rotateHandler.apply()
         this._rotateHandler.updateStatus()
@@ -4667,7 +3467,7 @@ export class AppController {
         case 's': case 'S': gh.toggleStackMode(); return
         case 'Enter':
           if (gh.isSuggesting && gh.currentSuggestion) {
-            this._createSpatialLinkDirect(
+            this._linkHandler.createDirect(
               gh.currentSuggestion.sourceId,
               gh.currentSuggestion.targetId,
               gh.currentSuggestion,
@@ -4710,19 +3510,19 @@ export class AppController {
 
     // ── Frame placement pick sub-mode keys (ADR-034 §6) ──────────────────
     if (this._opState.is(S_FRAME_PLACEMENT)) {
-      if (e.key === 'Escape') { this._cancelFramePickSubMode(); return }
+      if (e.key === 'Escape') { this._framePlacementHandler.cancel(); return }
       return  // consume all other keys during frame pick
     }
 
     // ── Measure placement keys ─────────────────────────────────────────────
     if (this._opState.is(S_MEASURE_PLACING)) {
-      if (e.key === 'Escape') { this._cancelMeasure(); return }
+      if (e.key === 'Escape') { this._measureHandler.cancel(); return }
       return
     }
 
     // ── SpatialLink creation keys (ADR-030 Phase 4) ────────────────────────
     if (this._opState.is(S_LINK_MODE)) {
-      if (e.key === 'Escape') { this._cancelSpatialLinkCreation(); return }
+      if (e.key === 'Escape') { this._linkHandler.cancel(); return }
       return  // consume all other keys during link mode
     }
 
@@ -4776,26 +3576,26 @@ export class AppController {
 
     // ── Face extrude keys (Edit Mode · 3D) ────────────────────────────────
     if (this._opState.is(S_FACE_EXTRUDE)) {
-      if (e.key === 'Enter')  { e.preventDefault(); this._confirmFaceExtrude(); return }
-      if (e.key === 'Escape') { this._cancelFaceExtrude(); return }
+      if (e.key === 'Enter')  { e.preventDefault(); this._faceExtrudeHandler.confirm(); return }
+      if (e.key === 'Escape') { this._faceExtrudeHandler.cancel(); return }
       if ((e.key >= '0' && e.key <= '9') || e.key === '.') {
         this._faceExtrude.inputStr += e.key
         this._faceExtrude.hasInput  = true
-        this._applyFaceExtrudeFromInput()
-        this._updateFaceExtrudeStatus()
+        this._faceExtrudeHandler.applyFromInput()
+        this._faceExtrudeHandler.updateStatus()
         return
       }
       if (e.key === '-' && this._faceExtrude.inputStr.length === 0) {
         this._faceExtrude.inputStr = '-'
         this._faceExtrude.hasInput = true
-        this._updateFaceExtrudeStatus()
+        this._faceExtrudeHandler.updateStatus()
         return
       }
       if (e.key === 'Backspace') {
         this._faceExtrude.inputStr = this._faceExtrude.inputStr.slice(0, -1)
         this._faceExtrude.hasInput = this._faceExtrude.inputStr.length > 0 && this._faceExtrude.inputStr !== '-'
-        this._applyFaceExtrudeFromInput()
-        this._updateFaceExtrudeStatus()
+        this._faceExtrudeHandler.applyFromInput()
+        this._faceExtrudeHandler.updateStatus()
         return
       }
       return
@@ -4808,7 +3608,7 @@ export class AppController {
       if (e.key === '3') { this._setEditSelectMode('face');   return }
       if ((e.key === 'e' || e.key === 'E') && this._editSelectMode === 'face') {
         const selected = [...this._scene.editSelection].filter(x => x instanceof Face)
-        if (selected.length > 0) this._startFaceExtrude(selected[0])
+        if (selected.length > 0) this._faceExtrudeHandler.start(selected[0])
         return
       }
     }
@@ -4827,7 +3627,7 @@ export class AppController {
     if (this._scene.selectionMode === 'object') {
       // M: start measure placement
       if (e.key === 'm' || e.key === 'M') {
-        this._startMeasurePlacement()
+        this._measureHandler.start()
         return
       }
       // L: start SpatialLink creation (ADR-030 Phase 4)
@@ -4836,7 +3636,7 @@ export class AppController {
           this._uiView.showToast('SpatialLink cannot be used as a link source', { type: 'warn' })
           return
         }
-        this._startSpatialLinkCreation()
+        this._linkHandler.start()
         return
       }
       // Shift+S: select all fixed-joint-connected parts (Semantic Select / assembly select)
@@ -4915,11 +3715,11 @@ export class AppController {
         const linkOptions = _computeLinkOptions(source, target)
         this._uiView.showLinkTypePicker(x, y, (option) => {
           if (option.semanticType === 'mounts') {
-            this._confirmMountAnnotation(sourceId, targetId)
+            this._linkHandler.confirmMount(sourceId, targetId)
           } else if (option.jointType === 'fixed') {
-            this._confirmFastenFrame(sourceId, targetId, option.semanticType)
+            this._linkHandler.confirmFasten(sourceId, targetId, option.semanticType)
           } else {
-            this._createSpatialLinkDirect(sourceId, targetId, option)
+            this._linkHandler.createDirect(sourceId, targetId, option)
           }
         }, { linkOptions })
       },
@@ -5169,51 +3969,4 @@ function _meshBboxCorners(obj) {
     new THREE.Vector3(max.x, max.y, max.z),
     new THREE.Vector3(min.x, max.y, max.z),
   ]
-}
-
-// ── Frame placement helpers (ADR-034 §6, §7) ──────────────────────────────────
-
-const _GHOST_AXIS_LEN = 0.5
-const _GHOST_OPACITY  = 0.35
-const _GHOST_DASH     = 0.08
-const _GHOST_GAP      = 0.05
-
-/** Creates a dimmed dashed axis-lines group (world-aligned — always identity rotation). */
-function _makeGhostAxesGroup() {
-  const group = new THREE.Group()
-  for (const [dx, dy, dz, color] of [
-    [_GHOST_AXIS_LEN, 0, 0, 0xff4444],
-    [0, _GHOST_AXIS_LEN, 0, 0x44cc44],
-    [0, 0, _GHOST_AXIS_LEN, 0x4488ff],
-  ]) {
-    const geo = new THREE.BufferGeometry()
-    geo.setAttribute('position', new THREE.Float32BufferAttribute([0, 0, 0, dx, dy, dz], 3))
-    const mat = new THREE.LineDashedMaterial({
-      color, dashSize: _GHOST_DASH, gapSize: _GHOST_GAP,
-      depthTest: false, transparent: true, opacity: _GHOST_OPACITY,
-    })
-    const line = new THREE.Line(geo, mat)
-    line.renderOrder = 1
-    line.computeLineDistances()
-    group.add(line)
-  }
-  return group
-}
-
-/** Creates a bright solid axis-lines group to show as cursor ghost during frame pick. */
-function _makeFrameAxesGroup() {
-  const group = new THREE.Group()
-  for (const [dx, dy, dz, color] of [
-    [_GHOST_AXIS_LEN, 0, 0, 0xff4444],
-    [0, _GHOST_AXIS_LEN, 0, 0x44cc44],
-    [0, 0, _GHOST_AXIS_LEN, 0x4488ff],
-  ]) {
-    const geo = new THREE.BufferGeometry()
-    geo.setAttribute('position', new THREE.Float32BufferAttribute([0, 0, 0, dx, dy, dz], 3))
-    const mat = new THREE.LineBasicMaterial({ color, depthTest: false, transparent: true, opacity: 0.75 })
-    const line = new THREE.Line(geo, mat)
-    line.renderOrder = 2
-    group.add(line)
-  }
-  return group
 }

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -71,6 +71,7 @@ import { inferSemanticRelationships, computeApproachWarmth } from '../service/Se
 import { SpatialLinkView, LINK_TYPE_COLORS } from '../view/SpatialLinkView.js'
 import { RotateSectorPreview }        from '../view/RotateSectorPreview.js'
 import { RippleEffect }               from '../view/RippleEffect.js'
+import { MapModeController }          from './map/MapModeController.js'
 
 // ── Module-level helpers ──────────────────────────────────────────────────────
 
@@ -367,60 +368,10 @@ export class AppController {
       sourceId: null,
     }
 
-    // ── 2D Map Mode state ─────────────────────────────────────────────────
-    // Entered via the "Map" header button.  Uses an orthographic top-down
-    // camera (SceneView.useOrthoCamera) for distortion-free 2D placement.
-    //
-    // Three-state drawing model (ADR-031 §1):
-    //   idle     → no gesture in progress; tool may or may not be selected
-    //   drawing  → gesture in progress (rubber-band follows cursor)
-    //   pending  → geometry fully defined; static dashed preview; awaiting name + confirm
-    this._mapMode = {
-      /** Whether map mode is currently active */
-      active: false,
-      /** Active drawing tool: 'route'|'boundary'|'zone'|'hub'|'anchor'|null */
-      tool:   null,
-      /** 'idle'|'drawing'|'pending' (ADR-031 §1) */
-      drawState: 'idle',
-      /** @type {THREE.Vector3[]} vertex positions collected during drawing */
-      points: [],
-      /** @type {THREE.Vector3[]|null} frozen geometry entered when going pending */
-      pendingPoints: null,
-      /** Default name for the pending entity (e.g. "Route 1") */
-      pendingName: null,
-      /** @type {THREE.Vector3|null} live cursor world position */
-      cursor: null,
-      /** THREE.Line preview drawn while placing */
-      previewLine: null,
-      /** THREE.Mesh cursor dot */
-      cursorDot:   null,
-      /** Panning state */
-      isPanning:   false,
-      panStart:    null,   // { screenX, screenY, camX, camY }
-      /** Current orthographic frustum height (world units) */
-      frustumSize: 50,
-      /**
-       * Mobile drag start: set on pointerdown for Line/Region/Point tools.
-       * Cleared on pointerup.
-       * @type {{ pt: THREE.Vector3, screenX: number, screenY: number }|null}
-       */
-      mobileDragStart: null,
-      /**
-       * Per-type creation counters for default name generation ("Route 1", "Zone 2" …).
-       */
-      nameCounters: { Route: 0, Boundary: 0, Zone: 0, Hub: 0, Anchor: 0 },
-      /**
-       * Snap indicator ring (PC only) — shown at the snap-candidate world position.
-       * @type {THREE.Mesh|null}
-       */
-      snapRingMesh: null,
-      /**
-       * The world position of the active snap candidate (null when not snapping).
-       * Populated by _mapPickPoint on PC; consumed by _updateMapPreview.
-       * @type {THREE.Vector3|null}
-       */
-      snapCandidate: null,
-    }
+    // ── 2D Map Mode (delegated to MapModeController) ─────────────────────
+    // All map mode state and interaction logic live in MapModeController.
+    // AppController accesses map state via this._mapModeCtrl.isActive / .hasTool.
+    this._mapModeCtrl = new MapModeController(this)
 
     // ── Sketch drawing state (Edit Mode · 2D) ──────────────────────────────
     // drawing flag removed — EO_2D_SKETCH_DRAW state in _editOpState is the authority.
@@ -812,7 +763,7 @@ export class AppController {
     })
 
     // ── Map Mode entry ────────────────────────────────────────────────────
-    uiView.onMapModeClick(() => this._enterMapMode())
+    uiView.onMapModeClick(() => this._mapModeCtrl.enter())
 
     // ── CF Link Network Overlay ───────────────────────────────────────────
     this._linkNetworkView = new LinkNetworkView(id => this._switchActiveObject(id, true))
@@ -1702,517 +1653,10 @@ export class AppController {
     }
   }
 
-  // ── 2D Map Mode ──────────────────────────────────────────────────────────
-
-  /** Returns true when running on a coarse-pointer (touch) device. */
-  _isMapMobile() {
-    return window.matchMedia('(pointer: coarse)').matches
-  }
-
-  /** Enters 2D Map Mode: switches to orthographic top-down camera, shows map toolbar. */
-  _enterMapMode() {
-    if (this._mapMode.active) return
-    if (this._scene.selectionMode === 'edit') this.setMode('object')
-    this._mapMode.active        = true
-    this._mapMode.tool          = null
-    this._mapMode.drawState     = 'idle'
-    this._mapMode.points        = []
-    this._mapMode.pendingPoints = null
-    this._mapMode.pendingName   = null
-    this._mapMode.cursor        = null
-    this._mapMode.mobileDragStart = null
-    this._mapMode.isPanning     = false
-    this._sceneView.useOrthoCamera(true, this._mapMode.frustumSize)
-    this._uiView.setCursor('default')
-    this._uiView.setStatus('Map Mode — select a type on the left to start drawing')
-    this._refreshMapToolbar()
-    this._updateMobileToolbar()
-  }
-
-  /** Exits 2D Map Mode: restores perspective camera, removes map toolbar. */
-  _exitMapMode() {
-    this._mapCancelDrawing()
-    this._mapMode.active      = false
-    this._mapMode.isPanning   = false
-    this._sceneView.useOrthoCamera(false)
-    this._uiView.hideMapToolbar()
-    this._uiView.setCursor('default')
-    this._refreshObjectModeStatus()
-    this._updateMobileToolbar()
-  }
-
-  /**
-   * Returns the geometry kind for a place-type drawing tool.
-   * @param {string} type
-   * @returns {'line'|'region'|'point'}
-   */
-  _geometryForType(type) {
-    if (type === 'zone') return 'region'
-    if (type === 'hub' || type === 'anchor') return 'point'
-    return 'line'
-  }
-
-  /** Returns the place type name capitalised from a tool type string. */
-  _placeTypeForType(type) {
-    return type.charAt(0).toUpperCase() + type.slice(1)
-  }
-
-  /**
-   * Sets the active map drawing tool, resetting to drawing state.
-   * @param {string} type  PlaceType name lowercase: 'route'|'boundary'|'zone'|'hub'|'anchor'
-   */
-  _setMapTool(type) {
-    this._mapCancelDrawing()   // clear any in-progress drawing
-    this._mapMode.tool          = type
-    this._mapMode.drawState     = 'drawing'
-    this._mapMode.points        = []
-    this._mapMode.pendingPoints = null
-    this._mapMode.pendingName   = null
-    this._mapMode.cursor        = null
-    this._uiView.setCursor('crosshair')
-    this._refreshMapToolbar()
-    this._updateMapStatus()
-  }
-
-  /** Cancels the current drawing without creating an entity. */
-  _mapCancelDrawing() {
-    this._clearMapPreview()
-    this._mapMode.tool            = null
-    this._mapMode.drawState       = 'idle'
-    this._mapMode.points          = []
-    this._mapMode.pendingPoints   = null
-    this._mapMode.pendingName     = null
-    this._mapMode.cursor          = null
-    this._mapMode.mobileDragStart = null
-    this._mapMode.snapCandidate   = null
-    this._uiView.setCursor('default')
-    this._refreshMapToolbar()
-    if (this._mapMode.active) {
-      this._uiView.setStatus('Map Mode — select a type on the left to start drawing')
-    }
-  }
-
-  /**
-   * Transitions from drawing → pending state.
-   * Freezes the current geometry, generates a default name, switches the preview to
-   * dashed style, and refreshes the toolbar to show the name input + Confirm button.
-   * @param {THREE.Vector3[]} points  the completed geometry vertices
-   */
-  _enterMapPendingState(points) {
-    if (!this._mapMode.tool) return
-    const placeType = this._placeTypeForType(this._mapMode.tool)
-    const n = ++this._mapMode.nameCounters[placeType]
-    this._mapMode.drawState     = 'pending'
-    this._mapMode.pendingPoints = points.map(p => p.clone())
-    this._mapMode.pendingName   = `${placeType} ${n}`
-    this._mapMode.cursor        = null
-    this._mapMode.snapCandidate = null
-    this._clearMapPreview()
-    this._showPendingPreview()
-    this._refreshMapToolbar()
-    this._uiView.setStatusRich([
-      { text: placeType, bold: true, color: '#80cbc4' },
-      { text: '— enter a name and confirm', color: '#888' },
-      { text: '  ESC = cancel', color: '#444' },
-    ])
-  }
-
-  /**
-   * Confirms the pending entity.
-   * Must only be called while drawState === 'pending'.
-   * Reads the entity name from the toolbar name input (falls back to pendingName).
-   */
-  _mapConfirmDrawing() {
-    const { tool, pendingPoints, pendingName } = this._mapMode
-    if (!tool || !pendingPoints) return
-
-    const geometry  = this._geometryForType(tool)
-    const placeType = this._placeTypeForType(tool)
-    const renderer  = this._sceneView.renderer
-
-    // Read the user-supplied name (or fall back to the auto-generated default)
-    const name = this._uiView.getMapPendingName() ?? pendingName ?? placeType
-
-    // Create entity — state reset always happens in finally, even if creation throws
-    let created = false
-    try {
-      if (geometry === 'point' && pendingPoints.length >= 1) {
-        const obj = this._service.createAnnotatedPoint(pendingPoints[0], name, {
-          camera: this._camera, renderer, container: document.body,
-        })
-        this._service.setPlaceType(obj.id, placeType)
-        created = true
-      } else if (geometry === 'line' && pendingPoints.length >= 2) {
-        const obj = this._service.createAnnotatedLine(pendingPoints, name, {
-          camera: this._camera, renderer, container: document.body,
-        })
-        this._service.setPlaceType(obj.id, placeType)
-        created = true
-      } else if (geometry === 'region' && pendingPoints.length >= 3) {
-        const obj = this._service.createAnnotatedRegion(pendingPoints, name, {
-          camera: this._camera, renderer, container: document.body,
-        })
-        this._service.setPlaceType(obj.id, placeType)
-        created = true
-      }
-    } catch (err) {
-      console.error('[MapMode] entity creation failed:', err)
-    } finally {
-      // Always exit pending state — confirm button must disappear regardless of success
-      this._clearMapPreview()
-      this._mapMode.drawState     = 'drawing'  // ready for another gesture
-      this._mapMode.points        = []
-      this._mapMode.pendingPoints = null
-      this._mapMode.pendingName   = null
-      this._mapMode.cursor        = null
-      this._refreshMapToolbar()
-    }
-
-    if (created) {
-      this._uiView.setStatus(`Map Mode — ${placeType} placed. Draw another or select a different type.`)
-    }
-  }
-
-  /** Removes preview line, cursor dot, and snap ring from the Three.js scene. */
-  _clearMapPreview() {
-    const scene = this._sceneView.scene
-    if (this._mapMode.previewLine) {
-      scene.remove(this._mapMode.previewLine)
-      this._mapMode.previewLine.geometry.dispose()
-      this._mapMode.previewLine.material.dispose()
-      this._mapMode.previewLine = null
-    }
-    if (this._mapMode.cursorDot) {
-      scene.remove(this._mapMode.cursorDot)
-      this._mapMode.cursorDot.geometry.dispose()
-      this._mapMode.cursorDot.material.dispose()
-      this._mapMode.cursorDot = null
-    }
-    if (this._mapMode.snapRingMesh) {
-      scene.remove(this._mapMode.snapRingMesh)
-      this._mapMode.snapRingMesh.geometry.dispose()
-      this._mapMode.snapRingMesh.material.dispose()
-      this._mapMode.snapRingMesh = null
-    }
-    this._mapMode.snapCandidate = null
-  }
-
-  /**
-   * Picks the ground-plane (Z=0) world position under the pointer in Map Mode,
-   * using the orthographic camera for correct distortion-free picking.
-   * Applies grid snapping (1-unit grid) then, on PC only, endpoint snapping.
-   * Also stores the active snap candidate in this._mapMode.snapCandidate.
-   * @param {PointerEvent|MouseEvent} e
-   * @returns {THREE.Vector3}
-   */
-  _mapPickPoint(e) {
-    const ndcX =  (e.clientX / innerWidth)  * 2 - 1
-    const ndcY = -(e.clientY / innerHeight) * 2 + 1
-    this._raycaster.setFromCamera(new THREE.Vector2(ndcX, ndcY), this._sceneView.activeCamera)
-    const pt = new THREE.Vector3()
-    this._raycaster.ray.intersectPlane(this._groundPlane, pt)
-    pt.z = 0
-
-    // Grid snap: round to nearest grid unit (matches GridHelper 20×20 / 20 divisions = 1 unit)
-    const GRID = 1.0
-    pt.x = Math.round(pt.x / GRID) * GRID
-    pt.y = Math.round(pt.y / GRID) * GRID
-
-    // Endpoint snap: PC only — not reliable on touch (ADR-031 §6)
-    if (!this._isMapMobile()) {
-      const { snapped, point } = this._mapSnapToEndpoint(pt, e.clientX, e.clientY)
-      this._mapMode.snapCandidate = snapped
-      return point
-    }
-
-    this._mapMode.snapCandidate = null
-    return pt
-  }
-
-  /**
-   * Snaps a grid-snapped world point to a nearby annotated entity vertex (PC only).
-   * Uses the orthographic camera to measure screen-space distance.
-   * Endpoint snap has higher priority than grid snap.
-   * @param {THREE.Vector3} gridPt  grid-snapped world position
-   * @param {number} screenX  pointer clientX
-   * @param {number} screenY  pointer clientY
-   * @param {number} [snapPx=20]  snap radius in CSS pixels (ADR-031 §6)
-   * @returns {{ snapped: THREE.Vector3|null, point: THREE.Vector3 }}
-   */
-  _mapSnapToEndpoint(gridPt, screenX, screenY, snapPx = 20) {
-    const cam = this._sceneView.activeCamera
-    let bestDist = snapPx
-    let bestPt   = null
-
-    for (const obj of this._scene.objects.values()) {
-      const verts = (obj instanceof AnnotatedLine || obj instanceof AnnotatedRegion || obj instanceof AnnotatedPoint)
-        ? obj.vertices.map(v => v.position)
-        : null
-      if (!verts) continue
-
-      for (const vert of verts) {
-        const sv = this._projectToScreen(vert, cam)
-        const d  = Math.hypot(screenX - sv.x, screenY - sv.y)
-        if (d < bestDist) { bestDist = d; bestPt = vert.clone() }
-      }
-    }
-
-    return bestPt
-      ? { snapped: bestPt, point: bestPt }
-      : { snapped: null,   point: gridPt }
-  }
-
-  /**
-   * Updates the live preview during map drawing (drawing state only).
-   * In pending state use _showPendingPreview() instead.
-   */
-  _updateMapPreview() {
-    const { tool, points, cursor, mobileDragStart, drawState } = this._mapMode
-    if (!tool || drawState !== 'drawing') return
-    if (!cursor) return
-
-    const geometry = this._geometryForType(tool)
-    const entry    = getPlaceTypeEntry(this._placeTypeForType(tool))
-    const color    = entry ? parseInt(entry.color.slice(1), 16) : 0x80cbc4
-
-    // Cursor dot — shown only in drawing state
-    if (!this._mapMode.cursorDot) {
-      const g = new THREE.SphereGeometry(0.08, 8, 8)
-      const m = new THREE.MeshBasicMaterial({ color, depthTest: false })
-      this._mapMode.cursorDot = new THREE.Mesh(g, m)
-      this._mapMode.cursorDot.renderOrder = 3
-      this._sceneView.scene.add(this._mapMode.cursorDot)
-    }
-    this._mapMode.cursorDot.position.copy(cursor)
-    this._mapMode.cursorDot.material.color.setHex(color)
-
-    // Update snap ring visibility (PC only)
-    this._updateSnapRing(this._mapMode.snapCandidate, color)
-
-    // Determine the preview point sequence to render
-    let previewPts = null
-
-    if (geometry === 'region' && mobileDragStart) {
-      // Drag-to-rectangle: show live rectangle from anchor to cursor
-      const p1 = mobileDragStart.pt
-      const p2 = cursor
-      previewPts = [
-        new THREE.Vector3(p1.x, p1.y, 0),
-        new THREE.Vector3(p2.x, p1.y, 0),
-        new THREE.Vector3(p2.x, p2.y, 0),
-        new THREE.Vector3(p1.x, p2.y, 0),
-        new THREE.Vector3(p1.x, p1.y, 0),  // close ring
-      ]
-    } else if (geometry === 'line' && mobileDragStart) {
-      // Mobile line drag: straight line from start to cursor
-      previewPts = [mobileDragStart.pt, cursor]
-    } else if (geometry !== 'point' && points.length > 0) {
-      // PC multi-click preview: confirmed points + live cursor
-      previewPts = [...points, cursor]
-      if (geometry === 'region' && previewPts.length >= 3) previewPts.push(previewPts[0])
-    }
-
-    if (previewPts) {
-      const flat = []
-      for (const p of previewPts) flat.push(p.x, p.y, p.z)
-
-      if (!this._mapMode.previewLine) {
-        const geo = new THREE.BufferGeometry()
-        // Solid line at 70% opacity for drawing state (ADR-031 §3)
-        const mat = new THREE.LineBasicMaterial({
-          color, depthTest: false, transparent: true, opacity: 0.70,
-        })
-        this._mapMode.previewLine = new THREE.Line(geo, mat)
-        this._mapMode.previewLine.renderOrder = 2
-        this._sceneView.scene.add(this._mapMode.previewLine)
-      }
-      this._mapMode.previewLine.geometry.setAttribute(
-        'position', new THREE.Float32BufferAttribute(new Float32Array(flat), 3),
-      )
-      this._mapMode.previewLine.geometry.attributes.position.needsUpdate = true
-      this._mapMode.previewLine.material.color.setHex(color)
-    } else if (this._mapMode.previewLine) {
-      this._sceneView.scene.remove(this._mapMode.previewLine)
-      this._mapMode.previewLine.geometry.dispose()
-      this._mapMode.previewLine.material.dispose()
-      this._mapMode.previewLine = null
-    }
-  }
-
-  /**
-   * Creates or updates the static dashed preview for the pending state (ADR-031 §3).
-   * Must be called after entering pending state with pendingPoints populated.
-   */
-  _showPendingPreview() {
-    const { tool, pendingPoints } = this._mapMode
-    if (!tool || !pendingPoints) return
-
-    const geometry = this._geometryForType(tool)
-    const entry    = getPlaceTypeEntry(this._placeTypeForType(tool))
-    const color    = entry ? parseInt(entry.color.slice(1), 16) : 0x80cbc4
-
-    // Remove cursor dot — pending state shows no live cursor
-    if (this._mapMode.cursorDot) {
-      this._sceneView.scene.remove(this._mapMode.cursorDot)
-      this._mapMode.cursorDot.geometry.dispose()
-      this._mapMode.cursorDot.material.dispose()
-      this._mapMode.cursorDot = null
-    }
-    // Hide snap ring
-    this._updateSnapRing(null, color)
-
-    // Frozen point list (close ring for region)
-    let previewPts = [...pendingPoints]
-    if (geometry === 'region' && previewPts.length >= 3) previewPts.push(previewPts[0])
-
-    if (previewPts.length < 2) {
-      // Point type (Hub / Anchor): no line to draw, but show a static dot at the
-      // placed position so the user can see where they placed it (ADR-031 §3).
-      if (this._mapMode.previewLine) {
-        this._sceneView.scene.remove(this._mapMode.previewLine)
-        this._mapMode.previewLine.geometry.dispose()
-        this._mapMode.previewLine.material.dispose()
-        this._mapMode.previewLine = null
-      }
-      if (previewPts.length === 1) {
-        const g = new THREE.SphereGeometry(0.15, 12, 12)
-        const m = new THREE.MeshBasicMaterial({ color, depthTest: false, transparent: true, opacity: 0.85 })
-        const dot = new THREE.Mesh(g, m)
-        dot.position.copy(previewPts[0])
-        dot.renderOrder = 3
-        this._sceneView.scene.add(dot)
-        this._mapMode.previewLine = dot  // reuse slot; disposed the same way on exit/confirm
-      }
-      return
-    }
-
-    const flat = []
-    for (const p of previewPts) flat.push(p.x, p.y, p.z)
-
-    // Recreate as dashed line (LineDashedMaterial) at 90% opacity (ADR-031 §3)
-    if (this._mapMode.previewLine) {
-      this._sceneView.scene.remove(this._mapMode.previewLine)
-      this._mapMode.previewLine.geometry.dispose()
-      this._mapMode.previewLine.material.dispose()
-      this._mapMode.previewLine = null
-    }
-    const geo = new THREE.BufferGeometry()
-    geo.setAttribute('position', new THREE.Float32BufferAttribute(new Float32Array(flat), 3))
-    const mat = new THREE.LineDashedMaterial({
-      color,
-      dashSize:    0.40,
-      gapSize:     0.20,
-      depthTest:   false,
-      transparent: true,
-      opacity:     0.90,
-    })
-    const line = new THREE.Line(geo, mat)
-    line.computeLineDistances()
-    line.renderOrder = 2
-    this._sceneView.scene.add(line)
-    this._mapMode.previewLine = line
-  }
-
-  /**
-   * Shows or hides the endpoint snap indicator ring (PC only, ADR-031 §6).
-   * @param {THREE.Vector3|null} snapPt  world position to show ring at; null = hide
-   * @param {number} color  hex color for the ring
-   */
-  _updateSnapRing(snapPt, color) {
-    const scene = this._sceneView.scene
-
-    if (!snapPt) {
-      if (this._mapMode.snapRingMesh) this._mapMode.snapRingMesh.visible = false
-      return
-    }
-
-    if (!this._mapMode.snapRingMesh) {
-      const geo = new THREE.RingGeometry(0.18, 0.30, 16)
-      const mat = new THREE.MeshBasicMaterial({
-        depthTest:   false,
-        transparent: true,
-        opacity:     0.85,
-        side:        THREE.DoubleSide,
-      })
-      const mesh = new THREE.Mesh(geo, mat)
-      mesh.renderOrder = 5
-      scene.add(mesh)
-      this._mapMode.snapRingMesh = mesh
-    }
-
-    this._mapMode.snapRingMesh.visible = true
-    this._mapMode.snapRingMesh.material.color.setHex(color)
-    this._mapMode.snapRingMesh.position.copy(snapPt)
-    this._mapMode.snapRingMesh.position.z = 0
-  }
-
-  /** Updates the status bar text during map drawing. */
-  _updateMapStatus() {
-    const { tool, points, drawState } = this._mapMode
-    if (!tool) return
-
-    if (drawState === 'pending') return   // pending status set in _enterMapPendingState
-
-    const geometry  = this._geometryForType(tool)
-    const typeLabel = this._placeTypeForType(tool)
-    const n = points.length
-    const mobile = this._isMapMobile()
-
-    if (geometry === 'point') {
-      this._uiView.setStatusRich([
-        { text: typeLabel, bold: true, color: '#80cbc4' },
-        { text: mobile ? 'Tap to place' : 'Click to place', color: '#888' },
-        { text: '  ESC cancel', color: '#444' },
-      ])
-    } else if (geometry === 'line') {
-      if (mobile) {
-        this._uiView.setStatusRich([
-          { text: typeLabel, bold: true, color: '#80cbc4' },
-          { text: 'Drag to draw a straight line', color: '#888' },
-          { text: '  ESC cancel', color: '#444' },
-        ])
-      } else {
-        this._uiView.setStatusRich([
-          { text: typeLabel, bold: true, color: '#80cbc4' },
-          { text: `${n} pts`, color: '#aaa' },
-          { text: 'click to add vertex', color: '#888' },
-          { text: n >= 2 ? '  Enter / RMB = done' : '', color: '#aaa' },
-          { text: '  ESC cancel', color: '#444' },
-        ])
-      }
-    } else {
-      const typeHint = mobile ? 'Drag to draw rectangle' : 'Drag to draw rectangle'
-      this._uiView.setStatusRich([
-        { text: typeLabel, bold: true, color: '#80cbc4' },
-        { text: typeHint, color: '#888' },
-        { text: '  ESC cancel', color: '#444' },
-      ])
-    }
-  }
-
-  /**
-   * Rebuilds the Map toolbar to reflect current state.
-   * In pending state: shows name input + Confirm + Cancel.
-   * In drawing state: shows tool buttons + (Confirm if ready) + Cancel.
-   * @private
-   */
-  _refreshMapToolbar() {
-    if (!this._mapMode.active) return
-    const { tool, drawState, pendingName } = this._mapMode
-
-    // In pending state: Confirm is always available; show name input
-    const isPending  = drawState === 'pending'
-    const canConfirm = isPending
-
-    this._uiView.showMapToolbar(
-      tool,
-      (t) => this._setMapTool(t),
-      canConfirm ? () => this._mapConfirmDrawing() : null,
-      tool       ? () => this._mapCancelDrawing()  : null,
-      ()         => this._exitMapMode(),
-      isPending ? (pendingName ?? '') : null,  // pendingName = show name input; null = hide
-    )
-  }
+  // ── 2D Map Mode — see MapModeController ─────────────────────────────────
+  // All map mode methods live in src/controller/map/MapModeController.js.
+  // AppController holds this._mapModeCtrl; event handlers delegate via
+  // this._mapModeCtrl.onPointerMove/Down/Up/KeyDown/onWheel.
 
   /**
    * Finds the nearest V/E/F snap target to the current mouse cursor.
@@ -3541,11 +2985,11 @@ export class AppController {
     const mode     = this._scene.selectionMode
     const substate = this._scene.editSubstate
 
-    if (this._mapMode.active) {
+    if (this._mapModeCtrl.isActive) {
       // In Map Mode the left-side map toolbar handles drawing controls.
       // Show a minimal "Exit Map" slot on mobile.
       this._uiView.setMobileToolbar([
-        { icon: ICONS.back, label: 'Exit Map', onClick: () => this._exitMapMode() },
+        { icon: ICONS.back, label: 'Exit Map', onClick: () => this._mapModeCtrl.exit() },
         { spacer: true },
         { spacer: true },
         { spacer: true },
@@ -3630,7 +3074,7 @@ export class AppController {
       if (hasObj && _isAnnotated(this._activeObj)) {
         this._uiView.setMobileToolbar([
           { icon: ICONS.grab,   label: 'Grab',   onClick: () => this._startGrab() },
-          { icon: ICONS.map,    label: 'Map',    onClick: () => this._enterMapMode() },
+          { icon: ICONS.map,    label: 'Map',    onClick: () => this._mapModeCtrl.enter() },
           { icon: ICONS.delete, label: 'Delete', onClick: () => this._deleteObject(this._scene.activeId), danger: true },
           { spacer: true },
         ])
@@ -5409,13 +4853,7 @@ export class AppController {
 
   _onWheel(e) {
     // ── 2D Map Mode: scroll to zoom ──────────────────────────────────────
-    if (this._mapMode.active) {
-      e.preventDefault()
-      const factor = e.deltaY > 0 ? 1.15 : 1 / 1.15
-      this._mapMode.frustumSize = Math.max(2, Math.min(500, this._mapMode.frustumSize * factor))
-      this._sceneView.setOrthoZoom(this._mapMode.frustumSize)
-      return
-    }
+    if (this._mapModeCtrl.onWheel(e)) return
     if (this._opState.is(S_ROTATE_ACTIVE) && this._ctrlHeld) {
       e.preventDefault()
       const steps = AppController.ANGLE_STEPS
@@ -5822,26 +5260,7 @@ export class AppController {
     }
 
     // ── 2D Map Mode: pan or drawing hover ────────────────────────────────
-    if (this._mapMode.active) {
-      if (this._mapMode.isPanning && this._mapMode.panStart) {
-        const { frustumSize } = this._mapMode
-        const aspect = innerWidth / innerHeight
-        const dx = (e.clientX - this._mapMode.panStart.screenX) * (frustumSize * aspect / innerWidth)
-        const dy = (e.clientY - this._mapMode.panStart.screenY) * (frustumSize / innerHeight)
-        this._sceneView.panOrthoCamera(
-          this._mapMode.panStart.camX - dx,
-          this._mapMode.panStart.camY + dy,
-        )
-        return
-      }
-      // Only update preview in drawing state; pending state shows frozen dashed preview
-      if (this._mapMode.tool && this._mapMode.drawState === 'drawing') {
-        const pt = this._mapPickPoint(e)
-        this._mapMode.cursor = pt
-        this._updateMapPreview()
-      }
-      return
-    }
+    if (this._mapModeCtrl.onPointerMove(e)) return
 
     // ── Measure placement hover ───────────────────────────────────────────
     if (this._opState.is(S_MEASURE_PLACING)) {
@@ -6069,7 +5488,7 @@ export class AppController {
     this._contextMenuSuppressed = e.button === 2 && (
       this._opState.is(S_ROTATE_ACTIVE) || this._opState.is(S_MOUNT_PICKING) ||
       this._opState.is(S_LINK_MODE) || this._opState.is(S_GRAB_ACTIVE) ||
-      this._opState.is(S_FACE_EXTRUDE) || !!this._mapMode.tool || this._opState.is(S_MEASURE_PLACING) ||
+      this._opState.is(S_FACE_EXTRUDE) || this._mapModeCtrl.hasTool || this._opState.is(S_MEASURE_PLACING) ||
       this._opState.is(S_FRAME_PLACEMENT)
     )
 
@@ -6222,90 +5641,7 @@ export class AppController {
     }
 
     // ── 2D Map Mode: drawing clicks and pan start ────────────────────────
-    if (this._mapMode.active) {
-      // Pan: middle button OR left button with no tool selected
-      if (e.button === 1 || (e.button === 0 && !this._mapMode.tool)) {
-        this._mapMode.isPanning = true
-        const cam = this._sceneView.activeCamera
-        this._mapMode.panStart = {
-          screenX: e.clientX, screenY: e.clientY,
-          camX: cam.position.x, camY: cam.position.y,
-        }
-        this._uiView.setCursor('grabbing')
-        this._activeDragPointerId = e.pointerId
-        return
-      }
-
-      if (e.button === 0 && this._mapMode.tool) {
-        const { drawState } = this._mapMode
-
-        // In pending state: LMB on canvas confirms (keyboard-free fallback)
-        if (drawState === 'pending') {
-          this._mapConfirmDrawing()
-          return
-        }
-
-        const pt       = this._mapPickPoint(e)
-        const geometry = this._geometryForType(this._mapMode.tool)
-
-        if (this._isMapMobile()) {
-          // ── Mobile: single drag gesture for all types (ADR-031 §2) ──────
-          // Record drag start; interaction completes on pointerup.
-          this._mapMode.mobileDragStart = { pt: pt.clone(), screenX: e.clientX, screenY: e.clientY }
-          this._mapMode.cursor          = pt.clone()
-          this._activeDragPointerId     = e.pointerId
-          this._updateMapPreview()
-          return
-        }
-
-        // ── PC interaction ───────────────────────────────────────────────
-        if (geometry === 'point') {
-          // Single click → enter pending immediately
-          this._enterMapPendingState([pt])
-          return
-        }
-
-        if (geometry === 'region') {
-          // Drag-to-rectangle: record drag start; pointerup enters pending
-          this._mapMode.mobileDragStart = { pt: pt.clone(), screenX: e.clientX, screenY: e.clientY }
-          this._mapMode.cursor          = pt.clone()
-          this._activeDragPointerId     = e.pointerId
-          const typeLabel = this._placeTypeForType(this._mapMode.tool)
-          this._uiView.setStatusRich([
-            { text: typeLabel, bold: true, color: '#80cbc4' },
-            { text: 'drag to draw rectangle', color: '#888' },
-            { text: '  ESC cancel', color: '#444' },
-          ])
-          return
-        }
-
-        // Line (PC): each click adds a vertex; Enter/RMB transitions to pending
-        this._mapMode.points.push(pt.clone())
-        this._mapMode.cursor = pt.clone()
-        this._updateMapPreview()
-        this._updateMapStatus()
-        return
-      }
-
-      if (e.button === 2 && this._mapMode.tool) {
-        const { drawState, points, tool: currentTool } = this._mapMode
-        if (drawState === 'pending') {
-          // RMB in pending → cancel back to drawing (re-select same tool)
-          this._mapCancelDrawing()
-          if (currentTool) this._setMapTool(currentTool)
-          return
-        }
-        // RMB in drawing: for PC Line with ≥2 pts → enter pending; else cancel
-        const geometry = this._geometryForType(this._mapMode.tool)
-        if (geometry === 'line' && points.length >= 2) {
-          this._enterMapPendingState(points)
-        } else {
-          this._mapCancelDrawing()
-        }
-        return
-      }
-      return
-    }
+    if (this._mapModeCtrl.onPointerDown(e)) return
 
     // ── Measure placement clicks ──────────────────────────────────────────
     if (this._opState.is(S_MEASURE_PLACING)) {
@@ -6562,72 +5898,8 @@ export class AppController {
       this._longPress.pointerId = null
     }
 
-    // ── 2D Map Mode: end panning on pointer up ────────────────────────────
-    if (this._mapMode.active && this._mapMode.isPanning) {
-      if (this._activeDragPointerId === e.pointerId) {
-        this._activeDragPointerId = null
-        this._mapMode.isPanning   = false
-        this._mapMode.panStart    = null
-        this._uiView.setCursor(this._mapMode.tool ? 'crosshair' : 'default')
-      }
-      return
-    }
-
-    // ── 2D Map Mode: drag gesture completion (mobile + PC Region) ─────────
-    if (this._mapMode.active && this._mapMode.mobileDragStart &&
-        this._activeDragPointerId === e.pointerId) {
-      const { pt: startPt, screenX: sx, screenY: sy } = this._mapMode.mobileDragStart
-      this._mapMode.mobileDragStart = null
-      this._activeDragPointerId     = null
-
-      const savedTool = this._mapMode.tool
-      if (!savedTool) return
-
-      const pt       = this._mapPickPoint(e)
-      const geometry = this._geometryForType(savedTool)
-      const dx       = e.clientX - sx
-      const dy       = e.clientY - sy
-      const moved    = Math.hypot(dx, dy)
-
-      if (geometry === 'point') {
-        // Point: any tap (no movement threshold) → pending (ADR-031 §2)
-        this._enterMapPendingState([startPt])
-        return
-      }
-
-      if (geometry === 'line') {
-        // Line: drag from start to end → 2-point straight line → pending
-        // Minimum drag threshold: 8 px screen-space (ADR-031 §2)
-        if (moved < 8) {
-          this._mapCancelDrawing()
-          this._setMapTool(savedTool)
-          return
-        }
-        this._enterMapPendingState([startPt, pt])
-        return
-      }
-
-      if (geometry === 'region') {
-        // Region: drag-to-rectangle → pending
-        // Minimum drag threshold: 8 px (ADR-031 §2)
-        if (moved < 8) {
-          this._mapCancelDrawing()
-          this._setMapTool(savedTool)
-          return
-        }
-        const p1 = startPt
-        const p2 = this._mapMode.cursor ?? pt
-        const rectPts = [
-          new THREE.Vector3(p1.x, p1.y, 0),
-          new THREE.Vector3(p2.x, p1.y, 0),
-          new THREE.Vector3(p2.x, p2.y, 0),
-          new THREE.Vector3(p1.x, p2.y, 0),
-        ]
-        this._enterMapPendingState(rectPts)
-        return
-      }
-      return
-    }
+    // ── 2D Map Mode: end panning / drag gesture completion ───────────────
+    if (this._mapModeCtrl.onPointerUp(e)) return
 
     // ── Endpoint drag confirmation (1D Edit Mode) ────────────────────────
     if (this._editOpState.is(EO_1D_DRAG) && this._activeDragPointerId === e.pointerId) {
@@ -6840,40 +6112,7 @@ export class AppController {
     }
 
     // ── 2D Map Mode keys ────────────────────────────────────────────────────
-    if (this._mapMode.active) {
-      const { drawState, tool } = this._mapMode
-
-      if (e.key === 'Escape') {
-        if (drawState === 'pending') {
-          // ESC in pending → cancel back to drawing with empty points
-          const savedTool = tool
-          this._mapCancelDrawing()
-          if (savedTool) this._setMapTool(savedTool)
-        } else if (tool) {
-          this._mapCancelDrawing()   // cancel drawing, stay in map mode
-        } else {
-          this._exitMapMode()        // exit map mode entirely
-        }
-        return
-      }
-
-      if (e.key === 'Enter' && tool) {
-        if (drawState === 'pending') {
-          // Enter in pending → confirm the entity
-          this._mapConfirmDrawing()
-        } else {
-          // Enter in drawing → transition to pending if enough points (PC Line)
-          const geometry = this._geometryForType(tool)
-          const n        = this._mapMode.points.length
-          if (geometry === 'line' && n >= 2) {
-            this._enterMapPendingState(this._mapMode.points)
-          }
-          // Region + Point enter pending via gesture (pointerup), not Enter key
-        }
-        return
-      }
-      return
-    }
+    if (this._mapModeCtrl.onKeyDown(e)) return
 
     // ── Frame placement pick sub-mode keys (ADR-034 §6) ──────────────────
     if (this._opState.is(S_FRAME_PLACEMENT)) {

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -37,8 +37,6 @@ import { createExtrudeSketchCommand } from '../command/ExtrudeSketchCommand.js'
 import { createAddSolidCommand }      from '../command/AddSolidCommand.js'
 import { createDeleteCommand }        from '../command/DeleteCommand.js'
 import { createRenameCommand }        from '../command/RenameCommand.js'
-import { createFrameRotateCommand }   from '../command/FrameRotateCommand.js'
-import { createSolidRotateCommand }   from '../command/SolidRotateCommand.js'
 import { createSetIfcClassCommand }   from '../command/SetIfcClassCommand.js'
 import { createSetPlaceTypeCommand }  from '../command/SetPlaceTypeCommand.js'  // N-panel place type change (post-hoc push)
 import { createReparentFrameCommand } from '../command/ReparentFrameCommand.js'
@@ -72,6 +70,7 @@ import { SpatialLinkView, LINK_TYPE_COLORS } from '../view/SpatialLinkView.js'
 import { RotateSectorPreview }        from '../view/RotateSectorPreview.js'
 import { RippleEffect }               from '../view/RippleEffect.js'
 import { MapModeController }          from './map/MapModeController.js'
+import { RotationHandler }            from './handler/RotationHandler.js'
 
 // ── Module-level helpers ──────────────────────────────────────────────────────
 
@@ -538,46 +537,7 @@ export class AppController {
     this._axisGuideRing = null
 
     // ── CoordinateFrame / Solid rotate state (R key, ADR-019 Phase B / ADR-036) ─
-    // Shared for both CoordinateFrame (quaternion-based) and Solid (corner-baking).
-    // Active state tracked by this._opState (S_ROTATE_ACTIVE).
-    this._rotate = {
-      /** World-space axis to rotate around: null = view-space Z, 'x'|'y'|'z' = world axes. */
-      axis:       null,
-      /** Screen-angle (radians) from projected pivot to mouse at start. */
-      startAngle: 0,
-      /** Saved rotation quaternion at the moment rotation begins (CoordinateFrame only). */
-      startRot:   new THREE.Quaternion(),
-      /** Numeric degree string typed by the user; empty when mouse-driven. */
-      inputStr:   '',
-      /** True when the user has typed at least one digit. */
-      hasInput:   false,
-      /** Degree increment for Ctrl snap. Cycled with Ctrl+Wheel. */
-      stepSize:   1,
-      // Mobile multi-segment drag support: re-initialized on each new touch drag.
-      /** True when startAngle should be captured from the next pointer position (mobile). */
-      needsStartAngle:      false,
-      /** Per-segment start angle; equals startAngle on PC (single drag). */
-      segmentStartAngle:    0,
-      /** Angle from pivot to cursor at the previous frame; used for incremental accumulation. */
-      prevCurrentAngle:     0,
-      /** Accumulated signed rotation (radians) for the current drag segment. */
-      accumulatedAngle:     0,
-      /** Per-segment quaternion for CoordinateFrame; equals startRot on PC. */
-      segmentStartRot:      new THREE.Quaternion(),
-      // ADR-040 Solid rotate state (replaces startCorners/segmentStartCorners/bodyRot fields)
-      /** Solid orientation snapshot at rotate start — for undo. @type {import('three').Quaternion|null} */
-      startOrientation:    null,
-      /** Solid _position snapshot at rotate start — for undo. @type {import('three').Vector3|null} */
-      startPos:            null,
-      /** Solid orientation snapshot at segment start — for reapplyable drag. @type {import('three').Quaternion|null} */
-      segStartOrientation: null,
-      /** Solid _position snapshot at segment start — for reapplyable drag. @type {import('three').Vector3|null} */
-      segStartPos:         null,
-      /** Centroid of solid corners at segment start — used as rotation pivot + screen projection. @type {import('three').Vector3|null} */
-      segStartPivot:       null,
-      /** Display angle (radians) from last _applyRotate(); used by _updateRotateStatus(). */
-      displayAngle:        0,
-    }
+    this._rotateHandler = new RotationHandler(this)
 
     this._ctrlHeld  = false
 
@@ -693,7 +653,7 @@ export class AppController {
     uiView.onFrameRotationChange((axis, val) => {
       const frame = this._activeObj
       if (!(frame instanceof CoordinateFrame) || frame.name === 'Origin') return
-      if (this._isFastenedRotationBlocked(frame)) return
+      if (this._rotateHandler.isFastenedRotationBlocked(frame)) return
       // rotation is already in parent-local space (ROS TF) — edit directly
       const localEuler = new THREE.Euler().setFromQuaternion(frame.rotation, 'ZYX')
       localEuler[axis] = THREE.MathUtils.degToRad(val)
@@ -3020,11 +2980,11 @@ export class AppController {
 
     if (this._opState.is(S_ROTATE_ACTIVE)) {
       this._uiView.setMobileToolbar([
-        { icon: ICONS.cancel,  label: 'Cancel',  onClick: () => this._cancelRotate(), danger: true },
-        { icon: 'X', label: 'X', onClick: () => this._setRotateAxis('x'), active: this._rotate.axis === 'x' },
-        { icon: 'Y', label: 'Y', onClick: () => this._setRotateAxis('y'), active: this._rotate.axis === 'y' },
-        { icon: 'Z', label: 'Z', onClick: () => this._setRotateAxis('z'), active: this._rotate.axis === 'z' },
-        { icon: ICONS.confirm, label: 'Confirm', onClick: () => this._confirmRotate() },
+        { icon: ICONS.cancel,  label: 'Cancel',  onClick: () => this._rotateHandler.cancel(), danger: true },
+        { icon: 'X', label: 'X', onClick: () => this._rotateHandler.setAxis('x'), active: this._rotateHandler.axis === 'x' },
+        { icon: 'Y', label: 'Y', onClick: () => this._rotateHandler.setAxis('y'), active: this._rotateHandler.axis === 'y' },
+        { icon: 'Z', label: 'Z', onClick: () => this._rotateHandler.setAxis('z'), active: this._rotateHandler.axis === 'z' },
+        { icon: ICONS.confirm, label: 'Confirm', onClick: () => this._rotateHandler.confirm() },
       ])
       return
     }
@@ -3054,7 +3014,7 @@ export class AppController {
           { icon: ICONS.grab,   label: 'Move',      onClick: () => this._startGrab(),                                                        disabled: isOriginCF },
           { spacer: true },
           { icon: ICONS.delete, label: 'Delete',    onClick: () => this._deleteObject(this._scene.activeId), danger: !isOriginCF, disabled: isOriginCF },
-          { icon: ICONS.rotate, label: 'Rotate',    onClick: () => this._startRotate(true),                                                   disabled: isOriginCF },
+          { icon: ICONS.rotate, label: 'Rotate',    onClick: () => this._rotateHandler.start(true),                                            disabled: isOriginCF },
         ])
         return
       }
@@ -3110,7 +3070,7 @@ export class AppController {
         { icon: ICONS.edit,      label: 'Edit',   onClick: () => this.setMode('edit'),                                           disabled: !canEdit },
         { icon: ICONS.delete,    label: 'Delete', onClick: () => this._deleteObject(this._scene.activeId), danger: hasObj,       disabled: !hasObj },
         canRotate
-          ? { icon: ICONS.rotate, label: 'Rotate', onClick: () => this._startRotate(true) }
+          ? { icon: ICONS.rotate, label: 'Rotate', onClick: () => this._rotateHandler.start(true) }
           : { icon: ICONS.stack,  label: 'Stack',  onClick: () => { this._grab.stackMode = !this._grab.stackMode; this._updateMobileToolbar() }, active: this._grab.stackMode, disabled: !canStack },
       ])
       return
@@ -3329,7 +3289,7 @@ export class AppController {
 
     // ── Cancel all in-progress operations ──────────────────────────────────
     if (this._opState.is(S_GRAB_ACTIVE))      this._cancelGrab()
-    if (this._opState.is(S_ROTATE_ACTIVE))    this._cancelRotate()
+    if (this._opState.is(S_ROTATE_ACTIVE))    this._rotateHandler.cancel()
     if (this._opState.is(S_FACE_EXTRUDE))     this._cancelFaceExtrude()
     if (this._opState.is(S_FRAME_PLACEMENT))  this._cancelFramePickSubMode()
     if (this._opState.is(S_MOUNT_PICKING))    this._cancelMountPicking()
@@ -4102,379 +4062,6 @@ export class AppController {
     })
   }
 
-  // ── CoordinateFrame / Solid rotation (R key, ADR-019 / ADR-036) ──────────
-
-  // ── Child-CF pose helpers (Solid rotation sync) ─────────────────────────────
-
-  /** Returns CoordinateFrames whose parentId === solidId. */
-  /**
-   * Starts rotate mode for the active CoordinateFrame or Solid.
-   * For CoordinateFrame: rotates the quaternion around the frame origin.
-   * For Solid: bakes the rotation into corner positions (ADR-036).
-   */
-
-  /**
-   * Centralised guard for any UI rotation entry point (R-key, N-panel, future inspectors…).
-   * Returns true and shows a toast when the frame must not be rotated because it is part of
-   * a fixed-joint source chain — rotating it would fight _updateFixedJointFrames() every frame
-   * and cause the root Solid to diverge (CODE_CONTRACTS §1 "R-key Rotation Blocked").
-   *
-   * Keeping the guard here (not inline in each handler) means new UI entry points only need
-   * one call, and the toast message stays consistent.
-   *
-   * @param {import('../domain/CoordinateFrame.js').CoordinateFrame} frame
-   * @returns {boolean} true = blocked (caller should return early)
-   */
-  _isFastenedRotationBlocked(frame) {
-    if (!this._service.isInFixedJointSourceChain(frame.id)) return false
-    this._uiView.showToast(
-      'This frame is part of a fixed-joint constraint chain. Unfasten it first to rotate it independently.',
-      { type: 'warn' },
-    )
-    return true
-  }
-
-  _startRotate(deferStartAngle = false) {
-    const obj = this._activeObj
-    if (!(obj instanceof CoordinateFrame) && !(obj instanceof Solid)) return
-
-    // ── Domain guards (with user feedback) — run before state transition ──
-    if (obj instanceof CoordinateFrame) {
-      // Provenance check (ADR-034 §8.2)
-      if (!RoleService.canEdit(obj)) {
-        this._uiView.showToast(`This frame was declared by a ${obj.declaredBy}. Switch to that role to edit it.`, { type: 'warn' })
-        return
-      }
-      if (this._isFastenedRotationBlocked(obj)) return
-    } else {
-      // Solid: block rotation when a fastened-source CF is a direct child (same guard as TC drag).
-      // _updateFixedJointFrames() overwrites bodyRotation and corners every frame, so R-key would
-      // fight the constraint — the solid snaps back each frame and the pose relationship breaks.
-      if (this._service.hasFastenedChild(obj.id)) {
-        this._uiView.showToast('This object is held by a fastened constraint. Unfasten it first to move it independently.', { type: 'warn' })
-        return
-      }
-    }
-
-    // All domain guards passed → mutual exclusion + state transition
-    if (!this._opState.send('BEGIN_ROTATE')) return
-
-    // ── Setup (state is now S_ROTATE_ACTIVE) ──────────────────────────────
-    this._rotate.axis     = null
-    this._rotate.inputStr = ''
-    this._rotate.hasInput = false
-
-    let projected
-    if (obj instanceof CoordinateFrame) {
-      this._rotate.startRot.copy(obj.rotation)
-      this._rotate.segmentStartRot.copy(obj.rotation)
-      projected = (this._service.worldPoseOf(obj.id)?.position ?? obj.translation).clone().project(this._camera)
-    } else {
-      // Solid: snapshot orientation+position from primary triple (ADR-040)
-      this._rotate.startOrientation    = obj.orientation.clone()
-      this._rotate.startPos            = obj._position.clone()
-      this._rotate.segStartOrientation = obj.orientation.clone()
-      this._rotate.segStartPos         = obj._position.clone()
-      const pivot = obj._position.clone()
-      this._rotate.segStartPivot       = pivot.clone()
-      projected = pivot.clone().project(this._camera)
-      obj.meshView.boxHelper.visible = false
-      // CFs follow automatically via ROS TF forward kinematics — no CF pose snapshot needed.
-    }
-
-    if (deferStartAngle) {
-      // Mobile: startAngle will be captured from the first canvas touch (CODE_CONTRACTS §2)
-      this._rotate.needsStartAngle   = true
-      this._rotate.startAngle        = 0
-      this._rotate.segmentStartAngle = 0
-      this._rotate.prevCurrentAngle  = 0
-      this._rotate.accumulatedAngle  = 0
-    } else {
-      // PC: startAngle from current mouse position
-      this._rotate.startAngle = Math.atan2(
-        this._mouse.y - projected.y,
-        this._mouse.x - projected.x,
-      )
-      this._rotate.segmentStartAngle = this._rotate.startAngle
-      this._rotate.prevCurrentAngle  = this._rotate.startAngle
-      this._rotate.accumulatedAngle  = 0
-      this._rotate.needsStartAngle   = false
-    }
-
-    this._refreshSectorPreview()
-    this._controls.enabled = false
-    this._updateRotateStatus()
-    if (window.matchMedia('(pointer: coarse)').matches) this._updateMobileToolbar()
-  }
-
-  /**
-   * Confirms the current rotation and exits rotate mode.
-   */
-  _confirmRotate() {
-    if (!this._opState.is(S_ROTATE_ACTIVE)) return
-    this._applyRotate()
-    // ── Record undo snapshot (ADR-022) ────────────────────────────────────
-    if (this._activeObj instanceof CoordinateFrame) {
-      const frame = this._activeObj
-      const endQuat = frame.rotation.clone()
-      if (!endQuat.equals(this._rotate.startRot)) {
-        const cmd = createFrameRotateCommand(
-          frame, this._rotate.startRot.clone(), endQuat, this._service,
-          () => this._updateNPanel(),
-        )
-        this._commandStack.push(cmd)
-      }
-    } else if (this._activeObj instanceof Solid && this._rotate.startOrientation) {
-      const solid = this._activeObj
-      const changed = !solid.orientation.equals(this._rotate.startOrientation)
-      if (changed) {
-        const cmd = createSolidRotateCommand(
-          solid,
-          this._rotate.startOrientation.clone(), solid.orientation.clone(),
-          this._rotate.startPos.clone(),         solid._position.clone(),
-          this._service, () => this._updateNPanel(),
-        )
-        this._commandStack.push(cmd)
-      }
-    }
-    if (this._activeObj instanceof Solid) this._activeObj.meshView.setObjectSelected(true)
-    this._rotate.axis            = null
-    this._rotate.inputStr        = ''
-    this._rotate.hasInput        = false
-    this._rotate.startOrientation    = null
-    this._rotate.startPos            = null
-    this._rotate.segStartOrientation = null
-    this._rotate.segStartPos         = null
-    this._rotate.segStartPivot       = null
-    this._rotate.needsStartAngle     = false
-    this._rotateSectorPreview.hide()
-    this._opState.send('CONFIRM')
-    this._controls.enabled          = true
-    this._refreshObjectModeStatus()
-    this._updateNPanel()
-    this._hideAxisGuide()
-    if (window.matchMedia('(pointer: coarse)').matches) this._updateMobileToolbar()
-  }
-
-  /**
-   * Cancels the rotation, restoring the object to its saved state.
-   */
-  _cancelRotate() {
-    if (!this._opState.is(S_ROTATE_ACTIVE)) return
-    const obj = this._activeObj
-    if (obj instanceof CoordinateFrame) {
-      obj.rotation.copy(this._rotate.startRot)
-      const parentWorldQuat = this._service._getParentWorldQuat(obj)
-      obj.meshView.updateRotation(parentWorldQuat.clone().multiply(obj.rotation))
-    } else if (obj instanceof Solid && this._rotate.startOrientation) {
-      obj.restorePose(this._rotate.startPos, this._rotate.startOrientation)
-      obj.meshView.updateGeometry(obj.corners)
-      obj.meshView.setObjectSelected(true)
-    }
-    this._rotate.axis            = null
-    this._rotate.inputStr        = ''
-    this._rotate.hasInput        = false
-    this._rotate.startOrientation    = null
-    this._rotate.startPos            = null
-    this._rotate.segStartOrientation = null
-    this._rotate.segStartPos         = null
-    this._rotate.segStartPivot       = null
-    this._rotate.needsStartAngle     = false
-    this._rotateSectorPreview.hide()
-    this._opState.send('CANCEL')
-    this._controls.enabled          = true
-    this._hideAxisGuide()
-    this._refreshObjectModeStatus()
-    if (window.matchMedia('(pointer: coarse)').matches) this._updateMobileToolbar()
-  }
-
-  /**
-   * Sets the world-axis constraint for the current rotation.
-   * Toggling the same axis clears the constraint (free rotation).
-   * @param {'x'|'y'|'z'} axis
-   */
-  _setRotateAxis(axis) {
-    this._rotate.axis = (this._rotate.axis === axis) ? null : axis
-    this._rotate.inputStr = ''
-    this._rotate.hasInput = false
-    const obj = this._activeObj
-    // Re-snapshot current orientation/pivot as new segment start so accumulated
-    // rotation from the prior axis constraint is preserved (mirrors _setGrabAxis()
-    // segmentStart re-snapshot pattern).
-    if (obj instanceof CoordinateFrame) {
-      this._rotate.segmentStartRot.copy(obj.rotation)
-    } else if (obj instanceof Solid) {
-      this._rotate.segStartOrientation = obj.orientation.clone()
-      this._rotate.segStartPos         = obj._position.clone()
-      this._rotate.segStartPivot       = obj._position.clone()
-    }
-    // Recompute start angle with new axis
-    let projected
-    let rotCenter = null
-    if (obj instanceof CoordinateFrame) {
-      rotCenter = this._service.worldPoseOf(obj.id)?.position ?? obj.translation
-      projected = rotCenter.clone().project(this._camera)
-    } else if (obj instanceof Solid && this._rotate.segStartPivot) {
-      rotCenter = this._rotate.segStartPivot
-      projected = rotCenter.clone().project(this._camera)
-    }
-    if (projected) {
-      this._rotate.startAngle = Math.atan2(
-        this._mouse.y - projected.y,
-        this._mouse.x - projected.x,
-      )
-    }
-    // Reset accumulation baseline for the new axis segment so the first
-    // _applyRotate() call produces delta = 0 (no spurious jump).
-    this._rotate.segmentStartAngle = this._rotate.startAngle
-    this._rotate.prevCurrentAngle  = this._rotate.startAngle
-    this._rotate.accumulatedAngle  = 0
-    this._rotate.displayAngle      = 0
-    if (this._rotate.axis && rotCenter) {
-      this._showAxisGuide(this._rotate.axis, rotCenter.clone(), 'rotate')
-    } else {
-      this._hideAxisGuide()
-    }
-    this._refreshSectorPreview()
-    this._applyRotate()
-    this._updateRotateStatus()
-    if (window.matchMedia('(pointer: coarse)').matches) this._updateMobileToolbar()
-  }
-
-  /**
-   * Applies the current rotation delta to the active CoordinateFrame or Solid.
-   * Called on every pointer move and on numeric input changes.
-   */
-  _applyRotate() {
-    const obj = this._activeObj
-    if (!this._opState.is(S_ROTATE_ACTIVE)) return
-    if (!(obj instanceof CoordinateFrame) && !(obj instanceof Solid)) return
-
-    let angle
-    if (this._rotate.hasInput) {
-      const parsed = parseFloat(this._rotate.inputStr)
-      angle = isNaN(parsed) ? 0 : parsed * (Math.PI / 180)
-    } else {
-      // Mouse/touch-driven: measure signed angle from segment start to current position.
-      let pivotScreen
-      if (obj instanceof CoordinateFrame) {
-        pivotScreen = (this._service.worldPoseOf(obj.id)?.position ?? obj.translation).clone().project(this._camera)
-      } else {
-        pivotScreen = (this._rotate.segStartPivot ?? obj._position.clone()).clone().project(this._camera)
-      }
-      const currentAngle = Math.atan2(
-        this._mouse.y - pivotScreen.y,
-        this._mouse.x - pivotScreen.x,
-      )
-      // Mobile: defer start angle to first canvas touch so there's no jump.
-      if (this._rotate.needsStartAngle) {
-        this._rotate.prevCurrentAngle = currentAngle
-        this._rotate.accumulatedAngle = 0
-        this._rotate.needsStartAngle  = false
-        return
-      }
-      // Incremental accumulation: normalize each per-frame delta to [-π, π] so
-      // crossing the atan2 branch-cut (directly left of pivot) never causes a
-      // sudden ±360° jump.
-      let delta = currentAngle - this._rotate.prevCurrentAngle
-      if (delta > Math.PI)  delta -= 2 * Math.PI
-      if (delta < -Math.PI) delta += 2 * Math.PI
-      this._rotate.accumulatedAngle += delta
-      this._rotate.prevCurrentAngle  = currentAngle
-      angle = this._rotate.accumulatedAngle
-      // Ctrl: snap to stepSize degree increments
-      if (this._ctrlHeld) {
-        const stepRad = this._rotate.stepSize * (Math.PI / 180)
-        angle = Math.round(angle / stepRad) * stepRad
-      }
-    }
-
-    // Build axis vector: world axis when constrained, view-direction when free.
-    let axisVec
-    if (this._rotate.axis === 'x') axisVec = new THREE.Vector3(1, 0, 0)
-    else if (this._rotate.axis === 'y') axisVec = new THREE.Vector3(0, 1, 0)
-    else if (this._rotate.axis === 'z') axisVec = new THREE.Vector3(0, 0, 1)
-    else {
-      // Screen-plane rotation: axis points toward the camera (view direction negated).
-      axisVec = new THREE.Vector3()
-      this._camera.getWorldDirection(axisVec).negate()
-    }
-
-    // Sign correction for pointer-driven axis-constrained rotation.
-    // Screen CCW (positive atan2 angle) maps to positive rotation only when the
-    // world axis points toward the viewer (camFwd · axisVec < 0). When the axis
-    // points away from the viewer (dot > 0 — e.g. +Y in the ROS frame for a
-    // typical above-right camera position), the apparent arc direction is reversed.
-    // Negating restores right-hand-rule consistency across all axes and camera poses.
-    // Free rotation and keyboard-input angles are already correct and are not touched.
-    if (!this._rotate.hasInput && this._rotate.axis) {
-      const camFwd = new THREE.Vector3()
-      this._camera.getWorldDirection(camFwd)
-      if (camFwd.dot(axisVec) > 0) angle = -angle
-    }
-
-    const deltaQ = new THREE.Quaternion().setFromAxisAngle(axisVec, angle)
-
-    this._service.applyPreviewRotation(obj, {
-      segStartOrientation: obj instanceof CoordinateFrame
-        ? this._rotate.segmentStartRot
-        : this._rotate.segStartOrientation,
-      segStartPos: this._rotate.segStartPos,
-      pivot: this._rotate.segStartPivot ?? obj._position.clone(),
-    }, deltaQ)
-    this._rotate.displayAngle = angle
-    this._updateRotateStatus()
-    this._rotateSectorPreview.updateAngle(angle)
-  }
-
-  /**
-   * (Re)creates the 3D sector preview at the pivot with the current axis orientation.
-   * Called at rotate start and on every axis toggle.
-   */
-  _refreshSectorPreview() {
-    const obj = this._activeObj
-    if (!obj) return
-
-    let center, radius
-    if (obj instanceof Solid) {
-      center = (this._rotate.segStartPivot ?? obj._position).clone()
-      // Radius: max corner distance from pivot; floor at 0.5 to stay visible on tiny solids
-      const raw = Math.max(...obj.corners.map(c => c.distanceTo(center)))
-      radius = Math.max(raw, 0.5) * 1.1
-    } else if (obj instanceof CoordinateFrame) {
-      center = (this._service.worldPoseOf(obj.id)?.position ?? obj.translation).clone()
-      radius = 0.8
-    } else {
-      return
-    }
-
-    this._rotateSectorPreview.show(center, radius, this._rotate.axis, this._camera)
-  }
-
-  /**
-   * Updates the status bar text to reflect the current rotate operation.
-   */
-  _updateRotateStatus() {
-    const AXIS_COLORS = { x: '#e05252', y: '#6ab04c', z: '#4a9eed' }
-    const parts = [{ text: 'Rotate', bold: true, color: '#80b3ff' }]
-
-    if (this._rotate.axis) {
-      parts.push({ text: this._rotate.axis.toUpperCase(), bold: true, color: AXIS_COLORS[this._rotate.axis] })
-    }
-    if (this._rotate.hasInput) {
-      parts.push({ text: this._rotate.inputStr + '°_', color: '#ffeb3b' })
-    } else {
-      const deg = (this._rotate.displayAngle * 180 / Math.PI).toFixed(1)
-      parts.push({ text: `${deg}°`, color: '#546e7a' })
-      if (this._ctrlHeld) {
-        parts.push({ text: `Step: ${this._rotate.stepSize}°`, bold: true, color: '#80cbc4' })
-        parts.push({ text: 'Scroll to change', color: '#444' })
-      }
-    }
-    parts.push({ text: 'Enter confirm  Esc cancel', color: '#444' })
-    this._uiView.setStatusRich(parts)
-  }
-
   _setGrabAxis(axis) {
     this._grab.axis     = (this._grab.axis === axis) ? null : axis
     this._grab.inputStr = ''
@@ -4857,14 +4444,14 @@ export class AppController {
     if (this._opState.is(S_ROTATE_ACTIVE) && this._ctrlHeld) {
       e.preventDefault()
       const steps = AppController.ANGLE_STEPS
-      const idx   = steps.indexOf(this._rotate.stepSize)
-      const cur   = idx >= 0 ? idx : (steps.findIndex(s => s >= this._rotate.stepSize) || 0)
+      const cur   = steps.indexOf(this._rotateHandler.stepSize)
+      const idx   = cur >= 0 ? cur : (steps.findIndex(s => s >= this._rotateHandler.stepSize) || 0)
       const next  = e.deltaY > 0
-        ? Math.min(cur + 1, steps.length - 1)
-        : Math.max(cur - 1, 0)
-      this._rotate.stepSize = steps[next]
-      this._applyRotate()
-      this._updateRotateStatus()
+        ? Math.min(idx + 1, steps.length - 1)
+        : Math.max(idx - 1, 0)
+      this._rotateHandler.stepSize = steps[next]
+      this._rotateHandler.apply()
+      this._rotateHandler.updateStatus()
       return
     }
     if (!this._opState.is(S_GRAB_ACTIVE) || !this._ctrlHeld) return
@@ -5192,7 +4779,7 @@ export class AppController {
     this._updateMouse(e)
 
     if (this._opState.is(S_ROTATE_ACTIVE)) {
-      this._applyRotate()
+      this._rotateHandler.apply()
       this._updateNPanel()
       return
     }
@@ -5512,20 +5099,21 @@ export class AppController {
         // Mobile: drag rotates the object; confirmation is via the toolbar button.
         // Re-snapshot segmentStart* so each new drag segment starts from current state.
         const obj = this._activeObj
+        const s = this._rotateHandler.state
         if (obj instanceof Solid) {
           // Re-snapshot segment-start triple for new drag segment (ADR-040)
-          this._rotate.segStartOrientation = obj.orientation.clone()
-          this._rotate.segStartPos         = obj._position.clone()
-          this._rotate.segStartPivot       = obj._position.clone()
+          s.segStartOrientation = obj.orientation.clone()
+          s.segStartPos         = obj._position.clone()
+          s.segStartPivot       = obj._position.clone()
         } else if (obj instanceof CoordinateFrame) {
-          this._rotate.segmentStartRot.copy(obj.rotation)
+          s.segmentStartRot.copy(obj.rotation)
         }
-        this._rotate.needsStartAngle  = true
-        this._activeDragPointerId     = e.pointerId
+        s.needsStartAngle     = true
+        this._activeDragPointerId = e.pointerId
         return
       }
-      if (e.button === 0) { this._confirmRotate(); return }
-      if (e.button === 2) { this._cancelRotate();  return }
+      if (e.button === 0) { this._rotateHandler.confirm(); return }
+      if (e.button === 2) { this._rotateHandler.cancel();  return }
       return
     }
 
@@ -5970,9 +5558,9 @@ export class AppController {
       this._ctrlHeld = false
       if (this._opState.is(S_GRAB_ACTIVE) && !this._grab.pivotSelectMode) this._updateGrabStatus()
       if (this._opState.is(S_FACE_EXTRUDE)) this._updateFaceExtrudeStatus()
-      if (this._opState.is(S_ROTATE_ACTIVE) && !this._rotate.hasInput) {
-        this._applyRotate()
-        this._updateRotateStatus()
+      if (this._opState.is(S_ROTATE_ACTIVE) && !this._rotateHandler.state.hasInput) {
+        this._rotateHandler.apply()
+        this._rotateHandler.updateStatus()
       }
     }
   }
@@ -5980,9 +5568,9 @@ export class AppController {
   _onKeyDown(e) {
     if (e.key === 'Control') {
       this._ctrlHeld = true
-      if (this._opState.is(S_ROTATE_ACTIVE) && !this._rotate.hasInput) {
-        this._applyRotate()
-        this._updateRotateStatus()
+      if (this._opState.is(S_ROTATE_ACTIVE) && !this._rotateHandler.state.hasInput) {
+        this._rotateHandler.apply()
+        this._rotateHandler.updateStatus()
       }
     }
 
@@ -6027,30 +5615,31 @@ export class AppController {
     // ── Keys active during rotate (CoordinateFrame R key, ADR-019) ────────
     if (this._opState.is(S_ROTATE_ACTIVE)) {
       switch (e.key) {
-        case 'x': case 'X': this._setRotateAxis('x'); return
-        case 'y': case 'Y': this._setRotateAxis('y'); return
-        case 'z': case 'Z': this._setRotateAxis('z'); return
-        case 'Enter':  this._confirmRotate(); return
-        case 'Escape': this._cancelRotate();  return
+        case 'x': case 'X': this._rotateHandler.setAxis('x'); return
+        case 'y': case 'Y': this._rotateHandler.setAxis('y'); return
+        case 'z': case 'Z': this._rotateHandler.setAxis('z'); return
+        case 'Enter':  this._rotateHandler.confirm(); return
+        case 'Escape': this._rotateHandler.cancel();  return
       }
+      const rs = this._rotateHandler.state
       if ((e.key >= '0' && e.key <= '9') || e.key === '.') {
-        this._rotate.inputStr += e.key
-        this._rotate.hasInput  = true
-        this._applyRotate()
-        this._updateRotateStatus()
+        rs.inputStr += e.key
+        rs.hasInput  = true
+        this._rotateHandler.apply()
+        this._rotateHandler.updateStatus()
         return
       }
-      if (e.key === '-' && this._rotate.inputStr.length === 0) {
-        this._rotate.inputStr = '-'
-        this._rotate.hasInput = true
-        this._updateRotateStatus()
+      if (e.key === '-' && rs.inputStr.length === 0) {
+        rs.inputStr = '-'
+        rs.hasInput = true
+        this._rotateHandler.updateStatus()
         return
       }
       if (e.key === 'Backspace') {
-        this._rotate.inputStr = this._rotate.inputStr.slice(0, -1)
-        this._rotate.hasInput = this._rotate.inputStr.length > 0 && this._rotate.inputStr !== '-'
-        this._applyRotate()
-        this._updateRotateStatus()
+        rs.inputStr = rs.inputStr.slice(0, -1)
+        rs.hasInput = rs.inputStr.length > 0 && rs.inputStr !== '-'
+        this._rotateHandler.apply()
+        this._rotateHandler.updateStatus()
         return
       }
       return
@@ -6265,7 +5854,7 @@ export class AppController {
       // R: rotate (CoordinateFrame or Solid, ADR-019 / ADR-036)
       if ((e.key === 'r' || e.key === 'R') &&
           (this._activeObj instanceof CoordinateFrame || this._activeObj instanceof Solid)) {
-        this._startRotate()
+        this._rotateHandler.start()
         return
       }
       // Shift+A: show Add menu

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -14,12 +14,7 @@ import {
   computeOutwardFaceNormal,
   getCentroid,
   toNDC,
-  getPivotCandidates,
-  getVertexPivotCandidates,
-  getEdgePivotCandidates,
-  getFacePivotCandidates,
   collectSnapTargets,
-  collectWorldSnapTargets,
 } from '../model/CuboidModel.js'
 import { SceneService }    from '../service/SceneService.js'
 import { Solid }           from '../domain/Solid.js'
@@ -32,7 +27,6 @@ import { ICONS }           from '../view/UIView.js'
 import { NodeEditorView }  from '../view/NodeEditorView.js'
 import { LinkNetworkView } from '../view/LinkNetworkView.js'
 import { CommandStack }              from '../service/CommandStack.js'
-import { createMoveCommand }          from '../command/MoveCommand.js'
 import { createExtrudeSketchCommand } from '../command/ExtrudeSketchCommand.js'
 import { createAddSolidCommand }      from '../command/AddSolidCommand.js'
 import { createDeleteCommand }        from '../command/DeleteCommand.js'
@@ -65,12 +59,13 @@ import { EndpointDragState } from '../core/states/EndpointDragState.js'
 import { SketchDrawState }   from '../core/states/SketchDrawState.js'
 import { QuickDragState }    from '../core/states/QuickDragState.js'
 import { RectSelectState }   from '../core/states/RectSelectState.js'
-import { inferSemanticRelationships, computeApproachWarmth } from '../service/SemanticInferencer.js'
+import { inferSemanticRelationships } from '../service/SemanticInferencer.js'
 import { SpatialLinkView, LINK_TYPE_COLORS } from '../view/SpatialLinkView.js'
 import { RotateSectorPreview }        from '../view/RotateSectorPreview.js'
 import { RippleEffect }               from '../view/RippleEffect.js'
 import { MapModeController }          from './map/MapModeController.js'
 import { RotationHandler }            from './handler/RotationHandler.js'
+import { GrabOperationHandler }       from './handler/GrabOperationHandler.js'
 
 // ── Module-level helpers ──────────────────────────────────────────────────────
 
@@ -474,51 +469,7 @@ export class AppController {
     }
 
     // ── Blender-style grab state ───────────────────────────────────────────
-    // Active state tracked by this._opState (S_GRAB_ACTIVE).
-    this._grab = {
-      axis:            null,
-      startMouse:      new THREE.Vector2(),
-      startCorners:    [],
-      /** @type {Map<string, import('three').Vector3[]>} corners snapshot for all selected objects */
-      allStartCorners: new Map(),
-      /** @type {Map<string, import('three').Vector3[]>} corners at the start of the current drag segment (touch re-grab) */
-      segmentStartCorners: new Map(),
-      /** @type {Map<string, import('three').Vector3>} Solid._position snapshot at segment start (ADR-040) */
-      segmentStartPositions: new Map(),
-      centroid:        new THREE.Vector3(),
-      pivot:           new THREE.Vector3(),
-      pivotLabel:      'Centroid',
-      dragPlane:       new THREE.Plane(),
-      startPoint:      new THREE.Vector3(),
-      inputStr:        '',
-      hasInput:        false,
-      pivotSelectMode: false,
-      hoveredPivotIdx: -1,
-      candidates:      [],
-      /** Current candidate filter in pivot select mode: 'all'|'vertex'|'edge'|'face' */
-      pivotMode:       'all',
-      snapping:        false,
-      /** Set to true after G->V pivot confirm; enables auto-snap without Ctrl */
-      autoSnap:        false,
-      /** The snap target currently locked to, or null */
-      snappedTarget:   null,
-      /** Snap target filter: 'all'|'vertex'|'edge'|'face' */
-      snapMode:        'all',
-      /** All snap candidates from last _trySnapToGeometry call (for display) */
-      snapTargets:     [],
-      /** Grid snap unit size (Ctrl during grab). Cycled with Ctrl+Wheel. */
-      gridSize:        1,
-      /** When true, grabbed object snaps Z so its bottom rests on the top surface below. */
-      stackMode:       false,
-      /** True when stacking is actively snapping Z this frame. */
-      stacking:        false,
-      /** Last delta applied via _applyGrabDeltaToAll; used for live coordinate display. */
-      lastDelta:       new THREE.Vector3(),
-      /** True when a live semantic suggestion is showing during G-key grab (ADR-041 Phase 3). */
-      isSuggesting:    false,
-      /** The suggestion currently displayed, or null. @type {object|null} */
-      currentSuggestion: null,
-    }
+    this._grabHandler = new GrabOperationHandler(this)
 
     /** Unsubscribe function for the active import.progress WS listener, or null */
     this._importProgressUnsub = null
@@ -825,8 +776,8 @@ export class AppController {
               this._objDragAllStartPositions,
               delta,
             )
-            if (this._grab.stackMode) {
-              this._applyStackSnap(this._objDragAllStartPositions, delta)
+            if (this._grabHandler.stackMode) {
+              this._grabHandler._applyStackSnap(this._objDragAllStartPositions, delta)
               for (const [id] of this._objDragAllStartCorners) {
                 const selObj = this._scene.getObject(id)
                 if (selObj) {
@@ -1797,7 +1748,7 @@ export class AppController {
     this._selectedIds.clear()
     this._selectedIds.add(copy.id)
     this._switchActiveObject(copy.id, true)
-    this._startGrab()
+    this._grabHandler.start()
   }
 
   // ─── Mobile Axis Guide helpers (replaces TransformControls) ──────────────
@@ -2857,7 +2808,7 @@ export class AppController {
     const items = [
       {
         label: 'Grab',
-        onClick: () => this._startGrab(),
+        onClick: () => this._grabHandler.start(),
       },
       ...(canDup ? [{
         label: 'Duplicate',
@@ -2991,11 +2942,11 @@ export class AppController {
 
     if (this._opState.is(S_GRAB_ACTIVE)) {
       this._uiView.setMobileToolbar([
-        { icon: ICONS.cancel,  label: 'Cancel',  onClick: () => this._cancelGrab(), danger: true },
-        { icon: 'X', label: 'X', onClick: () => this._setGrabAxis('x'), active: this._grab.axis === 'x' },
-        { icon: 'Y', label: 'Y', onClick: () => this._setGrabAxis('y'), active: this._grab.axis === 'y' },
-        { icon: 'Z', label: 'Z', onClick: () => this._setGrabAxis('z'), active: this._grab.axis === 'z' },
-        { icon: ICONS.confirm, label: 'Confirm', onClick: () => this._confirmGrab() },
+        { icon: ICONS.cancel,  label: 'Cancel',  onClick: () => this._grabHandler.cancel(), danger: true },
+        { icon: 'X', label: 'X', onClick: () => this._grabHandler.setAxis('x'), active: this._grabHandler.axis === 'x' },
+        { icon: 'Y', label: 'Y', onClick: () => this._grabHandler.setAxis('y'), active: this._grabHandler.axis === 'y' },
+        { icon: 'Z', label: 'Z', onClick: () => this._grabHandler.setAxis('z'), active: this._grabHandler.axis === 'z' },
+        { icon: ICONS.confirm, label: 'Confirm', onClick: () => this._grabHandler.confirm() },
       ])
       return
     }
@@ -3011,7 +2962,7 @@ export class AppController {
         const isOriginCF = this._activeObj.name === 'Origin'
         this._uiView.setMobileToolbar([
           { icon: ICONS.frame,  label: 'Add Frame', onClick: () => this._promptAddFrame(this._scene.activeId) },
-          { icon: ICONS.grab,   label: 'Move',      onClick: () => this._startGrab(),                                                        disabled: isOriginCF },
+          { icon: ICONS.grab,   label: 'Move',      onClick: () => this._grabHandler.start(),                                            disabled: isOriginCF },
           { spacer: true },
           { icon: ICONS.delete, label: 'Delete',    onClick: () => this._deleteObject(this._scene.activeId), danger: !isOriginCF, disabled: isOriginCF },
           { icon: ICONS.rotate, label: 'Rotate',    onClick: () => this._rotateHandler.start(true),                                            disabled: isOriginCF },
@@ -3033,7 +2984,7 @@ export class AppController {
       }
       if (hasObj && _isAnnotated(this._activeObj)) {
         this._uiView.setMobileToolbar([
-          { icon: ICONS.grab,   label: 'Grab',   onClick: () => this._startGrab() },
+          { icon: ICONS.grab,   label: 'Grab',   onClick: () => this._grabHandler.start() },
           { icon: ICONS.map,    label: 'Map',    onClick: () => this._mapModeCtrl.enter() },
           { icon: ICONS.delete, label: 'Delete', onClick: () => this._deleteObject(this._scene.activeId), danger: true },
           { spacer: true },
@@ -3066,12 +3017,12 @@ export class AppController {
             )
           },
         },
-        { icon: ICONS.grab,      label: 'Grab',   onClick: () => this._startGrab(),                                              disabled: !canGrab },
+        { icon: ICONS.grab,      label: 'Grab',   onClick: () => this._grabHandler.start(),                                      disabled: !canGrab },
         { icon: ICONS.edit,      label: 'Edit',   onClick: () => this.setMode('edit'),                                           disabled: !canEdit },
         { icon: ICONS.delete,    label: 'Delete', onClick: () => this._deleteObject(this._scene.activeId), danger: hasObj,       disabled: !hasObj },
         canRotate
           ? { icon: ICONS.rotate, label: 'Rotate', onClick: () => this._rotateHandler.start(true) }
-          : { icon: ICONS.stack,  label: 'Stack',  onClick: () => { this._grab.stackMode = !this._grab.stackMode; this._updateMobileToolbar() }, active: this._grab.stackMode, disabled: !canStack },
+          : { icon: ICONS.stack,  label: 'Stack',  onClick: () => { this._grabHandler.toggleStackMode(); this._updateMobileToolbar() }, active: this._grabHandler.stackMode, disabled: !canStack },
       ])
       return
     }
@@ -3288,7 +3239,7 @@ export class AppController {
     }
 
     // ── Cancel all in-progress operations ──────────────────────────────────
-    if (this._opState.is(S_GRAB_ACTIVE))      this._cancelGrab()
+    if (this._opState.is(S_GRAB_ACTIVE))      this._grabHandler.cancel()
     if (this._opState.is(S_ROTATE_ACTIVE))    this._rotateHandler.cancel()
     if (this._opState.is(S_FACE_EXTRUDE))     this._cancelFaceExtrude()
     if (this._opState.is(S_FRAME_PLACEMENT))  this._cancelFramePickSubMode()
@@ -3811,956 +3762,6 @@ export class AppController {
     this._uiView.showToast(`${assemblyIds.size} objects selected`)
   }
 
-  // ─── Blender-style grab ────────────────────────────────────────────────────
-
-  _startGrab() {
-    this._uiView.dismissSemanticSuggestion()
-    if (!this._objSelected) return
-    // SpatialLink has no geometry — cannot be grabbed (ADR-030)
-    if (this._activeObj instanceof SpatialLink) {
-      this._uiView.showToast('SpatialLink cannot be grabbed', { type: 'warn' })
-      return
-    }
-    // Origin frames are fixed at the Solid centroid — cannot be grabbed (ADR-037)
-    if (this._activeObj instanceof CoordinateFrame && this._activeObj.name === 'Origin') {
-      this._uiView.showToast('Origin frame is fixed at the centroid', { type: 'warn' })
-      return
-    }
-    // Provenance check: block grab if frame was declared by a different role (ADR-034 §8.2)
-    if (this._activeObj instanceof CoordinateFrame && !RoleService.canEdit(this._activeObj)) {
-      this._uiView.showToast(`This frame was declared by a ${this._activeObj.declaredBy}. Switch to that role to edit it.`, { type: 'warn' })
-      return
-    }
-    // Semantic guardrail: block grab when any selected entity is fastened or mounted to
-    // an entity outside the selection (PHILOSOPHY #1 — One Authoritative Entry Point).
-    const grabGuardrail = this._service.checkMoveGuardrail(this._selectedIds)
-    if (grabGuardrail.blocked) {
-      this._uiView.showToast(grabGuardrail.message, { type: 'warn' })
-      return
-    }
-    // All domain guards passed → mutual exclusion + state transition
-    if (!this._opState.send('BEGIN_GRAB')) return
-    // Rubber-band: activate marching ants + tension for links connected to dragged entities.
-    this._service.setLinkDragging(this._selectedIds, true)
-    this._grab.axis            = null
-    this._grab.inputStr        = ''
-    this._grab.hasInput        = false
-    this._grab.pivotSelectMode = false
-    this._grab.hoveredPivotIdx = -1
-    this._grab.snapMode        = 'all'
-    this._grab.snapTargets     = []
-    this._grab.startMouse.copy(this._mouse)
-    this._grab.startCorners = this._corners.map(c => c.clone())
-    // Snapshot corners of every selected object for multi-object grab
-    this._grab.allStartCorners = new Map()
-    for (const id of this._selectedIds) {
-      const selObj = this._scene.getObject(id)
-      if (selObj) this._grab.allStartCorners.set(id, _grabHandlesOf(selObj).map(c => c.clone()))
-    }
-    // segmentStartCorners tracks the start of each individual drag segment (touch).
-    // Initially identical to allStartCorners; re-snapshotted on each touch re-down.
-    this._grab.segmentStartCorners = new Map(
-      [...this._grab.allStartCorners.entries()].map(([id, cs]) => [id, cs.map(c => c.clone())])
-    )
-    // Solid _position snapshots for move() — separate from corner snapshots (ADR-040)
-    this._grab.segmentStartPositions = new Map()
-    for (const id of this._selectedIds) {
-      const selObj = this._scene.getObject(id)
-      if (selObj instanceof Solid) this._grab.segmentStartPositions.set(id, selObj._position.clone())
-    }
-    // For CoordinateFrame, corners = [translation] (parent-relative offset).
-    // Use the world position from the cache so the drag plane passes through
-    // the frame's actual world location (ADR-020).
-    const grabCenter = (this._activeObj instanceof CoordinateFrame)
-      ? (this._service.worldPoseOf(this._activeObj.id)?.position?.clone() ?? getCentroid(this._corners))
-      : (this._activeObj instanceof Solid ? this._activeObj._position.clone() : getCentroid(this._corners))
-    this._grab.centroid.copy(grabCenter)
-    this._grab.pivot.copy(this._grab.centroid)
-    this._grab.lastDelta.set(0, 0, 0)
-    this._grab.pivotLabel      = 'Centroid'
-    this._grab.autoSnap        = false
-    this._grab.isSuggesting    = false
-    this._grab.currentSuggestion = null
-
-    // ADR-032 §6: for mounted Annotated* entities, constrain drag to host local XY plane.
-    // For unmounted Annotated* entities, constrain to world XY (prevents Z drift).
-    // For all other entities, use the camera-facing plane (existing behaviour).
-    const isAnnotated = this._activeObj instanceof AnnotatedLine ||
-      this._activeObj instanceof AnnotatedRegion ||
-      this._activeObj instanceof AnnotatedPoint
-    let planeNormal = null
-    if (isAnnotated) {
-      const mountLink = this._scene.getMountsLink(this._scene.activeId)
-      if (mountLink) {
-        // Mounted: use host CoordinateFrame's local Z axis as drag plane normal
-        const hostPose = this._service.worldPoseOf(mountLink.targetId)
-        if (hostPose) {
-          planeNormal = new THREE.Vector3(0, 0, 1).applyQuaternion(hostPose.quaternion)
-        }
-      }
-      if (!planeNormal) {
-        // Unmounted Annotated*: use world Z (XY plane)
-        planeNormal = new THREE.Vector3(0, 0, 1)
-      }
-    } else {
-      const camDir = new THREE.Vector3()
-      this._camera.getWorldDirection(camDir)
-      planeNormal = camDir
-    }
-    this._grab.dragPlane.setFromNormalAndCoplanarPoint(planeNormal, this._grab.pivot)
-
-    this._raycaster.setFromCamera(this._mouse, this._camera)
-    const pt = new THREE.Vector3()
-    if (this._raycaster.ray.intersectPlane(this._grab.dragPlane, pt)) {
-      this._grab.startPoint.copy(pt)
-    } else {
-      this._grab.startPoint.copy(this._grab.pivot)
-    }
-
-    this._controls.enabled = false
-    this._uiView.setCursor('grabbing')
-    this._updateGrabStatus()
-    this._updateMobileToolbar()
-  }
-
-  _confirmGrab() {
-    if (!this._opState.is(S_GRAB_ACTIVE)) return
-    if (this._grab.pivotSelectMode) { this._cancelPivotSelect(); return }
-    // Clear live suggestion ghost before final state is committed (Drag Suggestion Lifecycle).
-    if (this._grab.isSuggesting) {
-      this._grab.isSuggesting      = false
-      this._grab.currentSuggestion = null
-      this._quickDragCtx.hideDragSuggestion()
-    }
-    // Clear approach warmth on all Solids.
-    for (const obj of this._scene.objects.values()) {
-      if (obj instanceof Solid) obj.meshView?.setApproachWarmth(0)
-    }
-    this._applyGrab()
-
-    // ADR-032 §6: after grab on mounted Annotated* entities, sync local positions
-    // so _updateMountedAnnotations uses the new world positions going forward.
-    for (const id of this._selectedIds) {
-      this._service.syncMountedPosition(id)
-    }
-
-    // ── Record undo snapshot (ADR-022 Phase 1) ────────────────────────────
-    const endCornersMap = new Map()
-    for (const id of this._selectedIds) {
-      const obj = this._scene.getObject(id)
-      if (obj) endCornersMap.set(id, _grabHandlesOf(obj).map(c => c.clone()))
-    }
-    if (endCornersMap.size > 0) {
-      const label = endCornersMap.size === 1 ? 'Move' : `Move ${endCornersMap.size} objects`
-      const cmd = createMoveCommand(label, this._grab.allStartCorners, endCornersMap, this._scene, this._service)
-      this._commandStack.push(cmd)
-    }
-
-    this._grab.axis          = null
-    this._grab.autoSnap      = false
-    this._grab.snappedTarget = null
-    this._grab.stackMode     = false
-    this._grab.stacking      = false
-    this._meshView.clearPivotDisplay()
-    this._meshView.clearSnapDisplay()
-    this._opState.send('CONFIRM')
-    // Rubber-band: end drag animation; stay highlighted since entity is still selected.
-    this._service.setLinkDragging(new Set(), false)
-    this._service.updateLinkSelectionHighlight(this._selectedIds)
-    this._controls.enabled = true
-    this._uiView.setCursor('default')
-    this._refreshObjectModeStatus()
-    this._updateNPanel()
-    this._updateMobileToolbar()
-    this._hideAxisGuide()
-
-    // ── Semantic inference (ADR-041) ─────────────────────────────────────
-    // Suggest a SpatialLink when a single Solid lands near another object.
-    this._runSemanticInference()
-  }
-
-  _cancelGrab() {
-    if (!this._opState.is(S_GRAB_ACTIVE)) return
-    if (this._grab.pivotSelectMode) { this._grab.pivotSelectMode = false }
-    if (this._grab.isSuggesting) {
-      this._grab.isSuggesting      = false
-      this._grab.currentSuggestion = null
-      this._quickDragCtx.hideDragSuggestion()
-    }
-    for (const obj of this._scene.objects.values()) {
-      if (obj instanceof Solid) obj.meshView?.setApproachWarmth(0)
-    }
-    // Restore all selected objects to their pre-grab positions
-    for (const [id, startCorners] of this._grab.allStartCorners) {
-      const selObj = this._scene.getObject(id)
-      if (!selObj) continue
-      if (selObj instanceof Solid) {
-        // Decompose world corners back into _position + localCorners (ADR-040)
-        selObj.setWorldCorners(startCorners)
-        selObj.meshView.updateGeometry(selObj.corners)
-      } else {
-        const handles = _grabHandlesOf(selObj)
-        startCorners.forEach((c, i) => handles[i].copy(c))
-        selObj.meshView.updateGeometry(handles)
-      }
-      selObj.meshView.updateBoxHelper()
-    }
-    this._meshView.clearPivotDisplay()
-    this._meshView.clearSnapDisplay()
-    this._grab.axis          = null
-    this._grab.autoSnap      = false
-    this._grab.snappedTarget = null
-    this._grab.stackMode     = false
-    this._grab.stacking      = false
-    this._opState.send('CANCEL')
-    // Rubber-band: end drag animation; stay highlighted since entity is still selected.
-    this._service.setLinkDragging(new Set(), false)
-    this._service.updateLinkSelectionHighlight(this._selectedIds)
-    this._controls.enabled = true
-    this._hideAxisGuide()
-    this._uiView.setCursor('default')
-    this._refreshObjectModeStatus()
-    this._updateNPanel()
-    this._updateMobileToolbar()
-  }
-
-  // ── Semantic inference (ADR-041) ─────────────────────────────────────────
-
-  /**
-   * Runs heuristic spatial-relationship inference after a single-Solid move and
-   * shows a non-intrusive suggestion banner if a plausible SpatialLink is found.
-   * No-ops when multiple objects are selected (ambiguous which pair to suggest).
-   */
-  _runSemanticInference() {
-    if (this._selectedIds.size !== 1) return
-    const [movedId] = this._selectedIds
-    const moved = this._scene.getObject(movedId)
-    if (!(moved instanceof Solid)) return
-
-    const existingPairs = new Set(
-      this._service.getLinks().map(l => `${l.sourceId}|${l.targetId}`),
-    )
-    const suggestions = inferSemanticRelationships(
-      moved,
-      this._scene.objects.values(),
-      existingPairs,
-    )
-    if (suggestions.length === 0) return
-
-    const top = suggestions[0]
-    const source = this._scene.getObject(top.sourceId)
-    const target = this._scene.getObject(top.targetId)
-    this._uiView.showSemanticSuggestion({
-      sourceId:     top.sourceId,
-      targetId:     top.targetId,
-      semanticType: top.semanticType,
-      label:        top.label,
-      sourceName:   source?.name ?? '?',
-      targetName:   target?.name ?? '?',
-    }, () => {
-      this._createSpatialLinkDirect(top.sourceId, top.targetId, top)
-    })
-  }
-
-  _setGrabAxis(axis) {
-    this._grab.axis     = (this._grab.axis === axis) ? null : axis
-    this._grab.inputStr = ''
-    this._grab.hasInput = false
-    // Re-snapshot current positions as the new segment start so accumulated
-    // movement from the previous axis constraint is preserved (e.g. X→Y keeps
-    // the X offset). Mirrors the touch re-grab pattern (pointerdown in S_GRAB_ACTIVE).
-    this._grab.segmentStartCorners = new Map()
-    this._grab.segmentStartPositions = new Map()
-    for (const id of this._selectedIds) {
-      const selObj = this._scene.getObject(id)
-      if (selObj) {
-        this._grab.segmentStartCorners.set(id, _grabHandlesOf(selObj).map(c => c.clone()))
-        if (selObj instanceof Solid) this._grab.segmentStartPositions.set(id, selObj._position.clone())
-      }
-    }
-    this._grab.startMouse.copy(this._mouse)
-    // Update centroid/pivot to current position so the axis guide and
-    // screen-projection track the object after accumulated movement from the
-    // prior constraint. Mirrors the touch re-grab centroid update (pointerdown
-    // in S_GRAB_ACTIVE). segmentStartPositions was just re-snapshotted above.
-    if (this._activeObj instanceof CoordinateFrame) {
-      const pos = this._service.worldPoseOf(this._activeObj.id)?.position
-      if (pos) { this._grab.centroid.copy(pos); this._grab.pivot.copy(pos) }
-    } else if (this._grab.segmentStartPositions.size > 0) {
-      const avg = new THREE.Vector3()
-      for (const p of this._grab.segmentStartPositions.values()) avg.add(p)
-      avg.divideScalar(this._grab.segmentStartPositions.size)
-      this._grab.centroid.copy(avg)
-      this._grab.pivot.copy(avg)
-    }
-    if (!this._grab.axis) {
-      // Switching back to free grab: reset the 3D drag-plane anchor to the current
-      // mouse position so the free-grab delta starts at zero.
-      this._raycaster.setFromCamera(this._mouse, this._camera)
-      const _pt = new THREE.Vector3()
-      if (this._raycaster.ray.intersectPlane(this._grab.dragPlane, _pt)) {
-        this._grab.startPoint.copy(_pt)
-      }
-    }
-    this._applyGrab()
-    this._updateGrabStatus()
-    if (this._grab.axis) {
-      this._showAxisGuide(this._grab.axis, this._grab.centroid.clone(), 'translate')
-    } else {
-      this._hideAxisGuide()
-    }
-    if (window.matchMedia('(pointer: coarse)').matches) this._updateMobileToolbar()
-  }
-
-  _getAxisVec(axis) {
-    return new THREE.Vector3(
-      axis === 'x' ? 1 : 0,
-      axis === 'y' ? 1 : 0,
-      axis === 'z' ? 1 : 0,
-    )
-  }
-
-  _applyGrab() {
-    if (!this._opState.is(S_GRAB_ACTIVE)) return
-    if (this._grab.hasInput && this._grab.axis) {
-      this._applyGrabFromInput()
-    } else if (this._grab.axis) {
-      this._applyAxisConstrainedGrab()
-    } else {
-      this._applyFreeGrab()
-    }
-    // Stack snap: adjust Z so grabbed objects rest on top of any object below.
-    // applyPreviewTranslation (called from _applyGrabDeltaToAll) already updated
-    // views; re-update after stack snap since it re-applies domain mutations.
-    if (this._grab.stackMode) {
-      this._applyStackSnap(this._grab.segmentStartPositions, this._grab.lastDelta)
-      for (const id of this._selectedIds) {
-        const selObj = this._scene.getObject(id)
-        if (selObj) {
-          selObj.meshView.updateGeometry(_grabHandlesOf(selObj))
-          selObj.meshView.updateBoxHelper()
-        }
-      }
-    } else {
-      this._grab.stacking = false
-    }
-
-    // Live inference preview during G-key grab (ADR-041 Phase 3 — mirrors QuickDragState sub-state).
-    if (this._selectedIds.size === 1) {
-      const ctx        = this._quickDragCtx
-      const suggestion = ctx.runInference()
-      const key        = suggestion ? `${suggestion.semanticType}|${suggestion.targetId}` : null
-      const prevKey    = this._grab.currentSuggestion
-        ? `${this._grab.currentSuggestion.semanticType}|${this._grab.currentSuggestion.targetId}` : null
-      if (suggestion) {
-        if (!this._grab.isSuggesting || key !== prevKey) {
-          this._grab.isSuggesting      = true
-          this._grab.currentSuggestion = suggestion
-          ctx.showDragSuggestion(suggestion)
-        } else {
-          ctx.updateDragSuggestion(suggestion)
-        }
-      } else if (this._grab.isSuggesting) {
-        this._grab.isSuggesting      = false
-        this._grab.currentSuggestion = null
-        ctx.hideDragSuggestion()
-      }
-    }
-
-    // Approach gradient: warm wireframe of nearby Solids before the snap threshold is reached.
-    const [movedId] = this._selectedIds
-    const movedObj  = this._scene.getObject(movedId)
-    if (movedObj instanceof Solid) {
-      const warmthEntries = computeApproachWarmth(movedObj, this._scene.objects.values())
-      const warmthMap     = new Map(warmthEntries.map(e => [e.targetId, e.warmth]))
-      for (const obj of this._scene.objects.values()) {
-        if (obj instanceof Solid && !this._selectedIds.has(obj.id)) {
-          obj.meshView?.setApproachWarmth(warmthMap.get(obj.id) ?? 0)
-        }
-      }
-    }
-  }
-
-  /** Toggles stacking mode on/off during an active grab. */
-  _toggleStackMode() {
-    this._grab.stackMode = !this._grab.stackMode
-    this._grab.stacking  = false
-    this._applyGrab()
-    this._updateGrabStatus()
-    this._updateMobileToolbar()
-  }
-
-  /**
-   * Stack snap: after all grab movement is applied, cast downward rays from the
-   * bottom face of the active grabbed object. If another object is directly below,
-   * shift all grabbed objects upward so the bottom face rests on that surface.
-   * @param {Map<string, import('three').Vector3>} segStartPositions  per-Solid _position snapshots
-   * @param {import('three').Vector3} currentDelta  world delta already applied by the caller
-   */
-  _applyStackSnap(segStartPositions, currentDelta) {
-    const grabbed = this._activeObj
-    if (!(grabbed instanceof Solid)) { this._grab.stacking = false; return }
-
-    // Find bottom Z of the grabbed object
-    const gCorners = grabbed.corners
-    let gZMin = Infinity
-    gCorners.forEach(c => { if (c.z < gZMin) gZMin = c.z })
-
-    // Collect meshes from non-grabbed objects (excluding MeasureLine)
-    const grabbedIds = new Set(this._selectedIds)
-    const targetMeshes = [...this._scene.objects.values()]
-      .filter(o => !grabbedIds.has(o.id) && !(o instanceof MeasureLine) && o.meshView?.cuboid?.visible)
-      .map(o => o.meshView.cuboid)
-
-    if (!targetMeshes.length) { this._grab.stacking = false; return }
-
-    // Sample the bottom face: 4 corners at gZMin + centroid
-    const bottomCorners = gCorners.filter(c => Math.abs(c.z - gZMin) < 0.001)
-    const center = new THREE.Vector3()
-    bottomCorners.forEach(c => center.add(c))
-    center.divideScalar(bottomCorners.length || 1)
-
-    const origins = [...bottomCorners, center]
-    const downDir = new THREE.Vector3(0, 0, -1)
-    const stackRay = new THREE.Raycaster()
-
-    // Cast downward from well above the scene; find the highest surface hit at (x,y).
-    // Using gZMin+ε as origin would miss surfaces above the current bottom face.
-    const RAY_TOP = 10000
-    let highestHitZ = null
-    for (const origin of origins) {
-      stackRay.set(new THREE.Vector3(origin.x, origin.y, RAY_TOP), downDir)
-      const hits = stackRay.intersectObjects(targetMeshes)
-      if (hits.length > 0) {
-        const hz = hits[0].point.z
-        if (highestHitZ === null || hz > highestHitZ) highestHitZ = hz
-      }
-    }
-
-    if (highestHitZ === null) { this._grab.stacking = false; return }
-
-    const zOffset = highestHitZ - gZMin
-    // Skip if already resting on the surface (within 1mm tolerance)
-    if (Math.abs(zOffset) < 0.001) { this._grab.stacking = false; return }
-
-    // Apply additional Z shift via the public Solid.move() API (ADR-040: never mutate
-    // corners directly — _position and localCorners must remain the SSOT).
-    const snapDelta = currentDelta.clone().add(new THREE.Vector3(0, 0, zOffset))
-    for (const id of this._selectedIds) {
-      const selObj = this._scene.getObject(id)
-      if (selObj instanceof Solid) {
-        const segStartPos = segStartPositions?.get(id)
-        if (segStartPos) selObj.move(segStartPos, snapDelta)
-      }
-    }
-    this._grab.stacking = true
-  }
-
-  /**
-   * Applies `delta` to the active object and all other selected objects.
-   * Uses each object's own startCorners snapshot from `_grab.allStartCorners`.
-   * @param {import('three').Vector3} delta
-   */
-  _applyGrabDeltaToAll(delta) {
-    this._grab.lastDelta.copy(delta)
-    this._service.applyPreviewTranslation(
-      this._grab.segmentStartCorners,
-      this._grab.segmentStartPositions,
-      delta,
-    )
-  }
-
-  _applyGrabFromInput() {
-    this._grab.snapping = false
-    const parsed = parseFloat(this._grab.inputStr)
-    if (this._grab.inputStr && isNaN(parsed)) {
-      this._uiView.showToast('Invalid number')
-      return
-    }
-    const dist    = isNaN(parsed) ? 0 : parsed
-    const axisVec = this._getAxisVec(this._grab.axis)
-    this._applyGrabDeltaToAll(axisVec.clone().multiplyScalar(dist))
-  }
-
-  _applyFreeGrab() {
-    this._raycaster.setFromCamera(this._mouse, this._camera)
-    const pt = new THREE.Vector3()
-    if (!this._raycaster.ray.intersectPlane(this._grab.dragPlane, pt)) return
-    let delta = pt.clone().sub(this._grab.startPoint)
-    if (this._grab.autoSnap) {
-      delta = this._trySnapToGeometry(delta)
-    } else if (this._ctrlHeld) {
-      delta = this._applyGridSnapToDelta(delta)
-      this._grab.snapping      = false
-      this._grab.snappedTarget = null
-    } else {
-      this._grab.snapping      = false
-      this._grab.snappedTarget = null
-      const _fgTension = this._service.getLinkDragTension()
-      if (_fgTension > 0) delta.multiplyScalar(Math.max(0.15, 1.0 - Math.min(_fgTension, 1.0) * 0.85))
-    }
-    this._applyGrabDeltaToAll(delta)
-  }
-
-  _applyAxisConstrainedGrab() {
-    const axisVec = this._getAxisVec(this._grab.axis)
-
-    // Compute the screen-space direction of the world axis using the analytic
-    // Jacobian of the perspective projection, evaluated at the grab pivot.
-    //
-    // The previous approach projected (pivot + axisVec) to NDC and subtracted
-    // project(pivot). When the camera is close to the object, (pivot + axisVec)
-    // can land behind the camera. THREE.js perspective division by a negative W
-    // flips the NDC sign, reversing the apparent axis direction and causing the
-    // object to move opposite to the cursor.
-    //
-    // The Jacobian d(ndc)/dt at t=0 is computed entirely at the pivot point
-    // (always in front of the camera), so it is immune to this sign-flip.
-    //
-    // Derivation for perspective projection  ndc.x = x_c * f_x / (−z_c):
-    //   dx_ndc/dt = f_x * (v_x * (−z_c) − x_c * v_z) / z_c²
-    //   dy_ndc/dt = f_y * (v_y * (−z_c) − y_c * v_z) / z_c²
-    // where (x_c, y_c, z_c) = pivot in camera space, (v_x, v_y, v_z) = axis
-    // in camera space, and z_c < 0 for points in front of the camera.
-    const P_c = this._grab.pivot.clone().applyMatrix4(this._camera.matrixWorldInverse)
-    const v_c = axisVec.clone().transformDirection(this._camera.matrixWorldInverse)
-    const f_y = 1 / Math.tan(THREE.MathUtils.degToRad(this._camera.fov * 0.5))
-    const f_x = f_y / this._camera.aspect
-    const z   = P_c.z    // negative for in-front points
-
-    const dx        = f_x * (v_c.x * (-z) - P_c.x * v_c.z) / (z * z)
-    const dy        = f_y * (v_c.y * (-z) - P_c.y * v_c.z) / (z * z)
-    const screenLen = Math.sqrt(dx * dx + dy * dy)
-    if (screenLen < 1e-4) return
-
-    const axisNormX = dx / screenLen
-    const axisNormY = dy / screenLen
-
-    const mdx  = this._mouse.x - this._grab.startMouse.x
-    const mdy  = this._mouse.y - this._grab.startMouse.y
-    const dist = (mdx * axisNormX + mdy * axisNormY) / screenLen
-
-    if (this._grab.autoSnap) {
-      const delta        = new THREE.Vector3().addScaledVector(axisVec, dist)
-      const snappedDelta = this._trySnapToGeometry(delta)
-      this._applyGrabDeltaToAll(snappedDelta)
-    } else if (this._ctrlHeld) {
-      this._grab.snapping      = false
-      this._grab.snappedTarget = null
-      const g           = this._grab.gridSize
-      const snappedDist = Math.round(dist / g) * g
-      this._applyGrabDeltaToAll(axisVec.clone().multiplyScalar(snappedDist))
-    } else {
-      this._grab.snapping      = false
-      this._grab.snappedTarget = null
-      const _acTension = this._service.getLinkDragTension()
-      const _acDist    = _acTension > 0 ? dist * Math.max(0.15, 1.0 - Math.min(_acTension, 1.0) * 0.85) : dist
-      this._applyGrabDeltaToAll(axisVec.clone().multiplyScalar(_acDist))
-    }
-  }
-
-  _updateGrabStatus() {
-    if (this._grab.pivotSelectMode) {
-      const MODE_LABEL = { all: 'All', vertex: 'Vertex', edge: 'Edge', face: 'Face' }
-      const MODE_COLOR = { all: '#aaa', vertex: '#69f0ae', edge: '#ffd740', face: '#4fc3f7' }
-      const m = this._grab.pivotMode ?? 'all'
-      this._uiView.setStatusRich([
-        { text: 'Select Pivot', bold: true, color: '#e8e8e8' },
-        { text: MODE_LABEL[m], color: MODE_COLOR[m] },
-        { text: '1 Vertex  2 Edge  3 Face', color: '#444' },
-      ])
-      return
-    }
-
-    const AXIS_COLORS = { x: '#e05252', y: '#6ab04c', z: '#4a9eed' }
-    const parts = [{ text: 'Grab', bold: true, color: '#ffffff' }]
-
-    if (this._grab.axis) {
-      parts.push({ text: this._grab.axis.toUpperCase(), bold: true, color: AXIS_COLORS[this._grab.axis] })
-    }
-    if (this._grab.hasInput) {
-      parts.push({ text: this._grab.inputStr + '_', color: '#ffeb3b' })
-    }
-    if (this._grab.pivotLabel !== 'Centroid') {
-      parts.push({ text: this._grab.pivotLabel, color: '#888' })
-    }
-    if (this._grab.stackMode) {
-      if (this._grab.stacking) {
-        parts.push({ text: 'Stack: ON', bold: true, color: '#a5d6a7' })
-      } else {
-        parts.push({ text: 'Stack', color: '#4caf50' })
-      }
-    }
-    if (this._grab.snapping && this._grab.snappedTarget) {
-      parts.push({ text: `Snap: ${this._grab.snappedTarget.label}`, bold: true, color: '#ff9800' })
-    } else if (this._grab.autoSnap) {
-      parts.push({ text: 'Auto Snap [World]', color: '#80cbc4' })
-      parts.push({ text: 'Origin / X / Y / Z', color: '#444' })
-    } else if (this._ctrlHeld) {
-      parts.push({ text: `Grid: ${this._grab.gridSize}`, bold: true, color: '#80cbc4' })
-      parts.push({ text: 'Scroll to change', color: '#444' })
-    }
-
-    if (!this._grab.hasInput) {
-      const d = this._grab.lastDelta
-      const cx = (this._grab.centroid.x + d.x).toFixed(2)
-      const cy = (this._grab.centroid.y + d.y).toFixed(2)
-      const cz = (this._grab.centroid.z + d.z).toFixed(2)
-      parts.push({ text: `X:${cx} Y:${cy} Z:${cz}`, color: '#546e7a' })
-      const dx = (d.x >= 0 ? '+' : '') + d.x.toFixed(2)
-      const dy = (d.y >= 0 ? '+' : '') + d.y.toFixed(2)
-      const dz = (d.z >= 0 ? '+' : '') + d.z.toFixed(2)
-      parts.push({ text: `Δ ${dx} ${dy} ${dz}`, color: '#78909c' })
-    }
-
-    this._uiView.setStatusRich(parts)
-  }
-
-  // ─── Grid snap (Ctrl during grab) ─────────────────────────────────────────
-
-  /** Grid sizes cycled by Ctrl+Wheel during grab */
-  static get GRID_SIZES() { return [0.1, 0.25, 0.5, 1, 2.5, 5, 10] }
-
-  /** Angle step sizes (degrees) cycled by Ctrl+Wheel during rotate */
-  static get ANGLE_STEPS() { return [1, 5, 10, 15, 22.5, 45, 90] }
-
-  /**
-   * Rounds a delta vector to the nearest multiple of the current grid size.
-   * @param {THREE.Vector3} delta
-   * @returns {THREE.Vector3}
-   */
-  _applyGridSnapToDelta(delta) {
-    const g = this._grab.gridSize
-    return new THREE.Vector3(
-      Math.round(delta.x / g) * g,
-      Math.round(delta.y / g) * g,
-      Math.round(delta.z / g) * g,
-    )
-  }
-
-  _onWheel(e) {
-    // ── 2D Map Mode: scroll to zoom ──────────────────────────────────────
-    if (this._mapModeCtrl.onWheel(e)) return
-    if (this._opState.is(S_ROTATE_ACTIVE) && this._ctrlHeld) {
-      e.preventDefault()
-      const steps = AppController.ANGLE_STEPS
-      const cur   = steps.indexOf(this._rotateHandler.stepSize)
-      const idx   = cur >= 0 ? cur : (steps.findIndex(s => s >= this._rotateHandler.stepSize) || 0)
-      const next  = e.deltaY > 0
-        ? Math.min(idx + 1, steps.length - 1)
-        : Math.max(idx - 1, 0)
-      this._rotateHandler.stepSize = steps[next]
-      this._rotateHandler.apply()
-      this._rotateHandler.updateStatus()
-      return
-    }
-    if (!this._opState.is(S_GRAB_ACTIVE) || !this._ctrlHeld) return
-    e.preventDefault()
-    const sizes = AppController.GRID_SIZES
-    const idx   = sizes.indexOf(this._grab.gridSize)
-    // fall back to nearest index if current size not in list
-    const cur   = idx >= 0 ? idx : sizes.findIndex(s => s >= this._grab.gridSize) || 0
-    const next  = e.deltaY > 0
-      ? Math.min(cur + 1, sizes.length - 1)
-      : Math.max(cur - 1, 0)
-    this._grab.gridSize = sizes[next]
-    this._applyGrab()
-    this._updateGrabStatus()
-  }
-
-  // ─── Face extrude (E key) ──────────────────────────────────────────────────
-
-  _startFaceExtrude(face) {
-    this._opState.send('BEGIN_FACE_EXTRUDE')
-    const fe = this._faceExtrude
-    fe.face          = face
-    fe.savedCorners  = face.vertices.map(v => v.position.clone())  // world, for display / snap
-    fe.allStartCorners = this._corners.map(c => c.clone())   // full Solid snapshot for undo (ADR-022)
-    fe.dist          = 0
-    fe.inputStr      = ''
-    fe.hasInput      = false
-    fe.snapping      = false
-    fe.snappedTarget = null
-    // World normal (for distance dot product and drag plane)
-    fe.normal.copy(computeOutwardFaceNormal(this._corners, face.index))
-    // Body-frame normal and face corners for extrudeFace() call (ADR-040)
-    const solid = this._activeObj
-    fe.savedLocalFaceCorners = face.vertices.map(v => {
-      const i = solid.vertices.indexOf(v)
-      return solid.localCorners[i].clone()
-    })
-    fe.localNormal.copy(fe.normal).applyQuaternion(solid.orientation.clone().invert())
-    const center = fe.savedCorners.reduce((a, c) => a.add(c), new THREE.Vector3()).divideScalar(fe.savedCorners.length)
-    const camDir = new THREE.Vector3()
-    this._camera.getWorldDirection(camDir)
-    fe.dragPlane.setFromNormalAndCoplanarPoint(camDir, center)
-    const pt = new THREE.Vector3()
-    this._raycaster.setFromCamera(this._mouse, this._camera)
-    fe.startPoint.copy(this._raycaster.ray.intersectPlane(fe.dragPlane, pt) ? pt : center)
-    this._controls.enabled = false
-    this._updateFaceExtrudeStatus()
-    this._updateMobileToolbar()
-  }
-
-  _applyFaceExtrude() {
-    const { face, savedCorners, savedLocalFaceCorners, localNormal, normal, dist } = this._faceExtrude
-    this._activeObj.extrudeFace(face, savedLocalFaceCorners, localNormal, dist)
-    this._meshView.updateGeometry(this._corners)
-    this._meshView.setFaceHighlight(face.index, this._corners)
-    const currentFaceCorners = face.vertices.map(v => v.position)
-    const { spanMid, armDir } = this._meshView.setExtrusionDisplay(savedCorners, currentFaceCorners)
-    const labelPos = spanMid.clone().addScaledVector(armDir, 0.25)
-    const screen = this._projectToScreen(labelPos)
-    this._uiView.setExtrusionLabel(`D ${Math.abs(dist).toFixed(3)}`, screen.x, screen.y)
-    this._updateNPanel()
-  }
-
-  _applyFaceExtrudeFromInput() {
-    this._faceExtrude.snapping = false
-    const parsed = parseFloat(this._faceExtrude.inputStr)
-    if (this._faceExtrude.inputStr && isNaN(parsed)) {
-      this._uiView.showToast('Invalid number')
-      return
-    }
-    this._faceExtrude.dist = isNaN(parsed) ? 0 : parsed
-    this._applyFaceExtrude()
-  }
-
-  _confirmFaceExtrude() {
-    if (!this._opState.is(S_FACE_EXTRUDE)) return
-    // ── Record undo snapshot (ADR-022 Phase 2) ────────────────────────────
-    if (this._scene.activeId) {
-      const activeId = this._scene.activeId
-      const endCornersMap   = new Map([[activeId, this._corners.map(c => c.clone())]])
-      const startCornersMap = new Map([[activeId, this._faceExtrude.allStartCorners]])
-      const cmd = createMoveCommand('Face Extrude', startCornersMap, endCornersMap, this._scene, this._service)
-      this._commandStack.push(cmd)
-    }
-
-    this._opState.send('CONFIRM')
-    this._controls.enabled = true
-    this._meshView.clearExtrusionDisplay()
-    this._meshView.clearSnapDisplay()
-    this._meshView.setFaceHighlight(null, this._corners)
-    this._scene.editSelection.clear()
-    this._meshView.updateEditSelection(this._scene.editSelection, this._corners)
-    this._uiView.clearExtrusionLabel()
-    this._updateNPanel()
-    this._refreshEditModeStatus()
-    this._updateMobileToolbar()
-  }
-
-  _cancelFaceExtrude() {
-    if (!this._opState.is(S_FACE_EXTRUDE)) return
-    const { face, savedLocalFaceCorners, localNormal } = this._faceExtrude
-    if (face) {
-      this._activeObj.extrudeFace(face, savedLocalFaceCorners, localNormal, 0)
-      this._meshView.updateGeometry(this._corners)
-      this._meshView.setFaceHighlight(face.index, this._corners)
-    }
-    this._opState.send('CANCEL')
-    this._controls.enabled = true
-    this._meshView.clearExtrusionDisplay()
-    this._meshView.clearSnapDisplay()
-    this._uiView.clearExtrusionLabel()
-    this._refreshEditModeStatus()
-    this._updateMobileToolbar()
-  }
-
-  _updateFaceExtrudeStatus() {
-    const fe = this._faceExtrude
-    const parts = [
-      { text: 'Extrude', bold: true, color: '#ffffff' },
-      { text: fe.face?.name ?? '', color: '#4fc3f7' },
-    ]
-    if (fe.hasInput) {
-      parts.push({ text: fe.inputStr + '_', color: '#ffeb3b' })
-    } else {
-      parts.push({ text: `D: ${fe.dist.toFixed(3)}`, color: '#ffeb3b' })
-    }
-    if (fe.snapping && fe.snappedTarget) {
-      parts.push({ text: `Snap: ${fe.snappedTarget.label}`, bold: true, color: '#ff9800' })
-    }
-    const hint = window.innerWidth < 768
-      ? 'Release to confirm'
-      : 'Enter confirm  Esc cancel'
-    parts.push({ text: hint, color: '#444' })
-    this._uiView.setStatusRich(parts)
-  }
-
-  /**
-   * Snaps face extrude distance to nearest geometry element projected onto the face normal.
-   * @param {number} dist  raw extrude distance
-   * @returns {number}  snapped or original distance
-   */
-  _trySnapFaceExtrude(dist) {
-    const fe      = this._faceExtrude
-    const center  = fe.savedCorners.reduce((a, c) => a.add(c), new THREE.Vector3()).divideScalar(fe.savedCorners.length)
-    const posAfter = center.clone().addScaledVector(fe.normal, dist)
-
-    // Compare snap targets to the mouse cursor, not the face center
-    const mx = (this._mouse.x + 1) / 2 * innerWidth
-    const my = (-this._mouse.y + 1) / 2 * innerHeight
-
-    const geoTargets   = collectSnapTargets(this._scene.objects, 'all', new Set([this._scene.activeId]))
-    const worldTargets = collectWorldSnapTargets(posAfter)
-    const targets      = [...geoTargets, ...worldTargets]
-    fe.snapTargets = targets
-    const bestTarget = this._pickBestSnapTarget(targets, mx, my)
-
-    if (bestTarget) {
-      fe.snapping      = true
-      fe.snappedTarget = bestTarget
-      return bestTarget.position.clone().sub(center).dot(fe.normal)
-    }
-    fe.snapping      = false
-    fe.snappedTarget = null
-    return dist
-  }
-
-  // ─── Geometry snap ─────────────────────────────────────────────────────────
-
-  /**
-   * Attempts to snap the grab pivot to the nearest geometry element.
-   * Snap candidates: all Vertex positions, Edge midpoints, Face centers.
-   * @param {THREE.Vector3} delta  current free delta
-   * @returns {THREE.Vector3}  snapped or original delta
-   */
-  _trySnapToGeometry(delta) {
-    const pivotAfter = this._grab.pivot.clone().add(delta)
-    const pScreen    = this._projectToScreen(pivotAfter)
-
-    const grabbedIds   = new Set(this._grab.allStartCorners.keys())
-    const geoTargets   = collectSnapTargets(this._scene.objects, this._grab.snapMode, grabbedIds)
-    const worldTargets = collectWorldSnapTargets(pivotAfter)
-    const targets      = [...geoTargets, ...worldTargets]
-    this._grab.snapTargets = targets  // cache for candidate display
-    const bestTarget = this._pickBestSnapTarget(targets, pScreen.x, pScreen.y)
-
-    if (bestTarget) {
-      this._grab.snapping      = true
-      this._grab.snappedTarget = bestTarget
-      return bestTarget.position.clone().sub(this._grab.pivot)
-    }
-    this._grab.snapping      = false
-    this._grab.snappedTarget = null
-    return delta
-  }
-
-  // ─── Pivot point selection ─────────────────────────────────────────────────
-
-  _startPivotSelect() {
-    if (!this._opState.is(S_GRAB_ACTIVE) || this._grab.pivotSelectMode) return
-    // Pivot selection uses Cuboid-specific vertex geometry — skip for non-Cuboid types.
-    if (this._activeObj instanceof ImportedMesh || this._activeObj instanceof MeasureLine || this._activeObj instanceof CoordinateFrame) return
-    this._grab.startCorners.forEach((c, i) => this._corners[i].copy(c))
-    this._meshView.updateGeometry(this._corners)
-    this._meshView.updateBoxHelper()
-    this._grab.pivotSelectMode = true
-    this._grab.pivotMode       = 'all'
-    this._grab.hoveredPivotIdx = -1
-    this._grab.candidates = getPivotCandidates(this._grab.startCorners)
-    this._meshView.showPivotCandidates(this._grab.candidates)
-    this._updateGrabStatus()
-  }
-
-  /**
-   * Filters pivot candidates by sub-element type and refreshes the display.
-   * @param {'all'|'vertex'|'edge'|'face'} mode
-   */
-  _setPivotCandidateMode(mode) {
-    this._grab.pivotMode = mode
-    const corners = this._grab.startCorners
-    const candidates =
-      mode === 'vertex' ? getVertexPivotCandidates(corners) :
-      mode === 'edge'   ? getEdgePivotCandidates(corners)   :
-      mode === 'face'   ? getFacePivotCandidates(corners)   :
-                          getPivotCandidates(corners)
-    this._grab.candidates      = candidates
-    this._grab.hoveredPivotIdx = -1
-    this._meshView.showPivotCandidates(candidates)
-    this._meshView.setHoveredPivot(null)
-    this._updateGrabStatus()
-  }
-
-  _updatePivotHover() {
-    const SNAP_PX = 30
-    let minDist    = Infinity
-    let closestIdx = -1
-    const mx = (this._mouse.x + 1) / 2 * innerWidth
-    const my = (-this._mouse.y + 1) / 2 * innerHeight
-    this._grab.candidates.forEach((c, i) => {
-      const ndc = c.position.clone().project(this._camera)
-      const sx  = (ndc.x + 1) / 2 * innerWidth
-      const sy  = (-ndc.y + 1) / 2 * innerHeight
-      const d   = Math.hypot(sx - mx, sy - my)
-      if (d < minDist) { minDist = d; closestIdx = i }
-    })
-    if (minDist <= SNAP_PX && closestIdx >= 0) {
-      this._grab.hoveredPivotIdx = closestIdx
-      const cand = this._grab.candidates[closestIdx]
-      this._meshView.setHoveredPivot(cand)
-      this._uiView.setStatusRich([
-        { text: 'Pivot', color: '#aaa' },
-        { text: cand.label, bold: true, color: '#ffeb3b' },
-      ])
-    } else {
-      this._grab.hoveredPivotIdx = -1
-      this._meshView.setHoveredPivot(null)
-      this._uiView.setStatusRich([
-        { text: 'Select Pivot', bold: true, color: '#e8e8e8' },
-        { text: 'Click to confirm', color: '#aaa' },
-        { text: 'Esc to cancel', color: '#666' },
-      ])
-    }
-  }
-
-  /**
-   * Changes the snap target filter during grab and resets the current snap lock.
-   * @param {'all'|'vertex'|'edge'|'face'} mode
-   */
-  _setSnapMode(mode) {
-    this._grab.snapMode      = mode
-    this._grab.snapping      = false
-    this._grab.snappedTarget = null
-    this._meshView.clearSnapLocked()
-    this._updateGrabStatus()
-  }
-
-  _confirmPivotSelect() {
-    const idx = this._grab.hoveredPivotIdx
-    if (idx >= 0) {
-      const cand = this._grab.candidates[idx]
-      this._grab.pivot.copy(cand.position)
-      this._grab.pivotLabel = cand.label
-      this._restartGrabFromPivot()
-      this._grab.autoSnap = true  // auto-snap enabled after pivot selection
-    }
-    this._grab.pivotSelectMode = false
-    this._grab.hoveredPivotIdx = -1
-    this._meshView.clearPivotDisplay()
-    this._updateGrabStatus()
-  }
-
-  _cancelPivotSelect() {
-    this._grab.pivotSelectMode = false
-    this._grab.hoveredPivotIdx = -1
-    this._meshView.clearPivotDisplay()
-    this._updateGrabStatus()
-  }
-
-  _restartGrabFromPivot() {
-    const pivot  = this._grab.pivot
-    const camDir = new THREE.Vector3()
-    this._camera.getWorldDirection(camDir)
-    this._grab.dragPlane.setFromNormalAndCoplanarPoint(camDir, pivot)
-    this._grab.startPoint.copy(pivot)
-    this._grab.axis     = null
-    this._grab.inputStr = ''
-    this._grab.hasInput = false
-    this._grab.startMouse.copy(this._mouse)
-  }
-
   // ─── Pointer events (mouse + touch + stylus) ──────────────────────────────
   _onPointerMove(e) {
     // Cancel long-press grab if the finger moved more than 8 px
@@ -4785,32 +3786,33 @@ export class AppController {
     }
 
     if (this._opState.is(S_GRAB_ACTIVE)) {
-      if (this._grab.pivotSelectMode) {
-        this._updatePivotHover()
+      const gs = this._grabHandler.state
+      if (this._grabHandler.pivotSelectMode) {
+        this._grabHandler.updatePivotHover()
         return
       }
-      this._applyGrab()
-      if (this._grab.autoSnap) {
+      this._grabHandler.apply()
+      if (gs.autoSnap) {
         const mx = (this._mouse.x + 1) / 2 * innerWidth
         const my = (-this._mouse.y + 1) / 2 * innerHeight
-        this._meshView.showSnapCandidates(this._filterNearbySnapTargets(this._grab.snapTargets))
-        if (this._grab.snapping && this._grab.snappedTarget) {
+        this._meshView.showSnapCandidates(this._filterNearbySnapTargets(gs.snapTargets))
+        if (gs.snapping && gs.snappedTarget) {
           this._meshView.clearSnapNearest()
           this._meshView.showSnapLocked(
-            this._grab.snappedTarget.position,
-            this._grab.snappedTarget.type,
-            this._grab.pivot,
+            gs.snappedTarget.position,
+            gs.snappedTarget.type,
+            gs.pivot,
           )
         } else {
           this._meshView.clearSnapLocked()
-          const nearest = this._findNearestSnapCandidate(this._grab.snapTargets, mx, my)
+          const nearest = this._findNearestSnapCandidate(gs.snapTargets, mx, my)
           if (nearest) this._meshView.showSnapNearest(nearest.position, nearest.type)
           else         this._meshView.clearSnapNearest()
         }
       } else {
         this._meshView.clearSnapDisplay()
       }
-      this._updateGrabStatus()
+      this._grabHandler.updateStatus()
       this._updateNPanel()
       return
     }
@@ -5171,49 +4173,50 @@ export class AppController {
     }
 
     if (this._opState.is(S_GRAB_ACTIVE)) {
-      if (this._grab.pivotSelectMode) {
+      if (this._grabHandler.pivotSelectMode) {
         if (e.button === 0) { this._confirmPivotSelect(); return }
-        if (e.button === 2) { this._cancelPivotSelect();  return }
+        if (e.button === 2) { this._grabHandler.cancelPivotSelect();  return }
         return
       }
       if (e.button === 0) {
         if (e.pointerType === 'touch') {
           // On touch: checkpoint the current position as the start of a new drag
           // segment, then track the pointer. Grab stays active until Confirm is pressed.
-          this._grab.segmentStartCorners = new Map()
-          this._grab.segmentStartPositions = new Map()
+          const gs = this._grabHandler.state
+          gs.segmentStartCorners = new Map()
+          gs.segmentStartPositions = new Map()
           for (const id of this._selectedIds) {
             const selObj = this._scene.getObject(id)
             if (selObj) {
-              this._grab.segmentStartCorners.set(id, _grabHandlesOf(selObj).map(c => c.clone()))
-              if (selObj instanceof Solid) this._grab.segmentStartPositions.set(id, selObj._position.clone())
+              gs.segmentStartCorners.set(id, _grabHandlesOf(selObj).map(c => c.clone()))
+              if (selObj instanceof Solid) gs.segmentStartPositions.set(id, selObj._position.clone())
             }
           }
-          this._grab.startCorners = this._corners.map(c => c.clone())
+          gs.startCorners = this._corners.map(c => c.clone())
           const grabCenter = (this._activeObj instanceof CoordinateFrame)
             ? (this._service.worldPoseOf(this._activeObj.id)?.position?.clone() ?? getCentroid(this._corners))
             : (this._activeObj instanceof Solid ? this._activeObj._position.clone() : getCentroid(this._corners))
-          this._grab.centroid.copy(grabCenter)
-          this._grab.pivot.copy(grabCenter)
-          this._grab.lastDelta.set(0, 0, 0)
+          gs.centroid.copy(grabCenter)
+          gs.pivot.copy(grabCenter)
+          gs.lastDelta.set(0, 0, 0)
           const camDir = new THREE.Vector3()
           this._camera.getWorldDirection(camDir)
-          this._grab.dragPlane.setFromNormalAndCoplanarPoint(camDir, grabCenter)
+          gs.dragPlane.setFromNormalAndCoplanarPoint(camDir, grabCenter)
           this._raycaster.setFromCamera(this._mouse, this._camera)
           const _segPt = new THREE.Vector3()
-          if (this._raycaster.ray.intersectPlane(this._grab.dragPlane, _segPt)) {
-            this._grab.startPoint.copy(_segPt)
+          if (this._raycaster.ray.intersectPlane(gs.dragPlane, _segPt)) {
+            gs.startPoint.copy(_segPt)
           } else {
-            this._grab.startPoint.copy(grabCenter)
+            gs.startPoint.copy(grabCenter)
           }
-          this._grab.startMouse.copy(this._mouse)
+          gs.startMouse.copy(this._mouse)
           this._activeDragPointerId = e.pointerId
           return
         }
-        this._confirmGrab()
+        this._grabHandler.confirm()
         return
       }
-      if (e.button === 2) { this._cancelGrab();  return }
+      if (e.button === 2) { this._grabHandler.cancel();  return }
       return
     }
 
@@ -5556,7 +4559,7 @@ export class AppController {
   _onKeyUp(e) {
     if (e.key === 'Control') {
       this._ctrlHeld = false
-      if (this._opState.is(S_GRAB_ACTIVE) && !this._grab.pivotSelectMode) this._updateGrabStatus()
+      if (this._opState.is(S_GRAB_ACTIVE) && !this._grabHandler.pivotSelectMode) this._grabHandler.updateStatus()
       if (this._opState.is(S_FACE_EXTRUDE)) this._updateFaceExtrudeStatus()
       if (this._opState.is(S_ROTATE_ACTIVE) && !this._rotateHandler.state.hasInput) {
         this._rotateHandler.apply()
@@ -5647,53 +4650,55 @@ export class AppController {
 
     // ── Keys active during grab ────────────────────────────────────────────
     if (this._opState.is(S_GRAB_ACTIVE)) {
-      if (this._grab.pivotSelectMode) {
-        if (e.key === 'Escape') this._cancelPivotSelect()
-        if (e.key === '1') { this._setPivotCandidateMode('vertex'); return }
-        if (e.key === '2') { this._setPivotCandidateMode('edge');   return }
-        if (e.key === '3') { this._setPivotCandidateMode('face');   return }
+      const gh = this._grabHandler
+      const gs = gh.state
+      if (gh.pivotSelectMode) {
+        if (e.key === 'Escape') gh.cancelPivotSelect()
+        if (e.key === '1') { gh.setPivotCandidateMode('vertex'); return }
+        if (e.key === '2') { gh.setPivotCandidateMode('edge');   return }
+        if (e.key === '3') { gh.setPivotCandidateMode('face');   return }
         return
       }
       switch (e.key) {
-        case 'v': case 'V': this._startPivotSelect(); return
-        case 'x': case 'X': this._setGrabAxis('x'); return
-        case 'y': case 'Y': this._setGrabAxis('y'); return
-        case 'z': case 'Z': this._setGrabAxis('z'); return
-        case 's': case 'S': this._toggleStackMode(); return
+        case 'v': case 'V': gh.startPivotSelect(); return
+        case 'x': case 'X': gh.setAxis('x'); return
+        case 'y': case 'Y': gh.setAxis('y'); return
+        case 'z': case 'Z': gh.setAxis('z'); return
+        case 's': case 'S': gh.toggleStackMode(); return
         case 'Enter':
-          if (this._grab.isSuggesting && this._grab.currentSuggestion) {
+          if (gh.isSuggesting && gh.currentSuggestion) {
             this._createSpatialLinkDirect(
-              this._grab.currentSuggestion.sourceId,
-              this._grab.currentSuggestion.targetId,
-              this._grab.currentSuggestion,
+              gh.currentSuggestion.sourceId,
+              gh.currentSuggestion.targetId,
+              gh.currentSuggestion,
             )
           }
-          this._confirmGrab()
+          gh.confirm()
           return
-        case 'Escape':       this._cancelGrab();     return
+        case 'Escape':       gh.cancel();     return
         case '1': this._setSnapMode('vertex'); return
         case '2': this._setSnapMode('edge');   return
         case '3': this._setSnapMode('face');   return
       }
-      if (this._grab.axis) {
+      if (gs.axis) {
         if ((e.key >= '0' && e.key <= '9') || e.key === '.') {
-          this._grab.inputStr += e.key
-          this._grab.hasInput  = true
-          this._applyGrab()
-          this._updateGrabStatus()
+          gs.inputStr += e.key
+          gs.hasInput  = true
+          gh.apply()
+          gh.updateStatus()
           return
         }
-        if (e.key === '-' && this._grab.inputStr.length === 0) {
-          this._grab.inputStr = '-'
-          this._grab.hasInput = true
-          this._updateGrabStatus()
+        if (e.key === '-' && gs.inputStr.length === 0) {
+          gs.inputStr = '-'
+          gs.hasInput = true
+          gh.updateStatus()
           return
         }
         if (e.key === 'Backspace') {
-          this._grab.inputStr = this._grab.inputStr.slice(0, -1)
-          this._grab.hasInput = this._grab.inputStr.length > 0 && this._grab.inputStr !== '-'
-          this._applyGrab()
-          this._updateGrabStatus()
+          gs.inputStr = gs.inputStr.slice(0, -1)
+          gs.hasInput = gs.inputStr.length > 0 && gs.inputStr !== '-'
+          gh.apply()
+          gh.updateStatus()
           return
         }
       }
@@ -5848,7 +4853,7 @@ export class AppController {
       }
       // G: grab
       if ((e.key === 'g' || e.key === 'G') && this._objSelected) {
-        this._startGrab()
+        this._grabHandler.start()
         return
       }
       // R: rotate (CoordinateFrame or Solid, ADR-019 / ADR-036)

--- a/src/controller/handler/FaceExtrudeHandler.js
+++ b/src/controller/handler/FaceExtrudeHandler.js
@@ -1,0 +1,325 @@
+/**
+ * FaceExtrudeHandler — manages E-key face extrusion in Edit Mode · 3D.
+ *
+ * Encapsulates all face-extrude state and the start/applyPreview/confirm/cancel
+ * lifecycle. Snap-to-geometry is handled via trySnap().
+ *
+ * Owned by AppController as this._faceExtrudeHandler.
+ * Accesses parent controller via this._ctrl.
+ *
+ * State machine: S_FACE_EXTRUDE ∈ AppController._opState.
+ * Triggered by: E key (keyboard), tap on face (touch auto-start).
+ */
+
+import * as THREE from 'three'
+import { Solid }                    from '../../domain/Solid.js'
+import { S_FACE_EXTRUDE }           from '../../core/editorStates.js'
+import { computeOutwardFaceNormal, collectSnapTargets } from '../../model/CuboidModel.js'
+
+// Snap distance threshold in world units.
+const SNAP_THRESHOLD = 0.15
+
+export class FaceExtrudeHandler {
+  /**
+   * @param {import('../AppController.js').AppController} ctrl
+   */
+  constructor(ctrl) {
+    this._ctrl = ctrl
+
+    /**
+     * All mutable face-extrude state — mirrors the old AppController._faceExtrude.
+     * @type {object}
+     */
+    this.state = {
+      /** @type {import('../../graph/Face.js').Face|null} The face being extruded. */
+      face:          null,
+      /** World-space face corner snapshots at drag start (for snap display). */
+      savedCorners:  [],
+      /** Body-frame face corner snapshots at drag start (for extrudeFace call). ADR-040 */
+      savedLocalFaceCorners: [],
+      /** World face normal — used for drag-plane dot product. @type {THREE.Vector3} */
+      normal:        new THREE.Vector3(),
+      /** Body-frame face normal — passed to Solid.extrudeFace(). @type {THREE.Vector3} */
+      localNormal:   new THREE.Vector3(),
+      /** Current signed extrusion distance (world units). */
+      dist:          0,
+      /** Drag plane aligned with the face normal; mouse ray intersects this. */
+      dragPlane:     new THREE.Plane(),
+      /** World-space drag start point (ray × dragPlane at operation start). */
+      startPoint:    new THREE.Vector3(),
+      /** Numeric distance string typed by the user; empty when mouse-driven. */
+      inputStr:      '',
+      /** True when the user has typed at least one digit. */
+      hasInput:      false,
+      /** True when the current dist is locked to a snap target. */
+      snapping:      false,
+      /** @type {{position: THREE.Vector3, type: string}|null} The locked snap target, or null. */
+      snappedTarget: null,
+      /** @type {{position: THREE.Vector3, type: string}[]} All snap candidates from last trySnap(). */
+      snapTargets:   [],
+    }
+  }
+
+  // ── Convenience getters ───────────────────────────────────────────────────
+
+  get hasInput() { return this.state.hasInput }
+
+  // ── Public operation lifecycle ────────────────────────────────────────────
+
+  /**
+   * Starts face extrude for the given face.
+   * Initialises the drag plane, saves corner snapshots, collects snap targets.
+   * @param {import('../../graph/Face.js').Face} face
+   */
+  start(face) {
+    const { _ctrl: ctrl } = this
+    const obj = ctrl._activeObj
+    if (!(obj instanceof Solid)) return
+    if (!ctrl._opState.send('BEGIN_FACE_EXTRUDE')) return
+
+    const s = this.state
+    s.face         = face
+    s.dist         = 0
+    s.inputStr     = ''
+    s.hasInput     = false
+    s.snapping     = false
+    s.snappedTarget = null
+
+    // Snapshot world-space face corners (for snap display centroid computation)
+    s.savedCorners = face.vertices.map(v => v.position.clone())
+
+    // Snapshot body-frame face corners (ADR-040: Solid mutation uses localCorners)
+    const vIdx = face.vertices.map(v => obj.vertices.indexOf(v))
+    s.savedLocalFaceCorners = vIdx.map(i => obj.localCorners[i].clone())
+
+    // Compute world face normal (for drag distance dot product)
+    const worldNormal = computeOutwardFaceNormal(obj.corners, face.index)
+    s.normal.copy(worldNormal)
+
+    // Compute body-frame face normal (for Solid.extrudeFace)
+    // Body-frame normal = worldNormal rotated by the inverse of Solid orientation
+    const invQ = obj.orientation.clone().conjugate()
+    s.localNormal.copy(worldNormal).applyQuaternion(invQ)
+
+    // Drag plane: passes through the face center, normal = camera direction
+    // projected onto the face normal plane (allows Z variation along normal).
+    const faceCenter = s.savedCorners
+      .reduce((a, c) => a.add(c), new THREE.Vector3())
+      .divideScalar(s.savedCorners.length)
+    const camDir = new THREE.Vector3()
+    ctrl._camera.getWorldDirection(camDir)
+    // Use a plane whose normal is perpendicular to both the face normal and camDir,
+    // so that horizontal mouse movement maps cleanly to extrusion distance.
+    // Fallback: if camDir is nearly parallel to face normal, use camDir directly.
+    let planeNormal = new THREE.Vector3().crossVectors(s.normal, camDir).cross(s.normal)
+    if (planeNormal.lengthSq() < 0.001) planeNormal = camDir.clone()
+    else planeNormal.normalize()
+    s.dragPlane.setFromNormalAndCoplanarPoint(planeNormal, faceCenter)
+
+    // Capture the ray intersection on drag plane as the start point
+    ctrl._raycaster.setFromCamera(ctrl._mouse, ctrl._camera)
+    const pt = new THREE.Vector3()
+    if (ctrl._raycaster.ray.intersectPlane(s.dragPlane, pt)) {
+      s.startPoint.copy(pt)
+    } else {
+      s.startPoint.copy(faceCenter)
+    }
+
+    // Collect snap targets from all other objects in the scene
+    s.snapTargets = collectSnapTargets(ctrl._scene.objects, 'all', new Set([ctrl._scene.activeId]))
+
+    ctrl._controls.enabled = false
+    this.updateStatus()
+    if (window.matchMedia('(pointer: coarse)').matches) ctrl._updateMobileToolbar()
+  }
+
+  /**
+   * Applies the current extrusion distance to the active Solid.
+   * Uses the mouse-driven dist (state.dist) — not the typed input.
+   */
+  applyPreview() {
+    const { _ctrl: ctrl } = this
+    const s   = this.state
+    const obj = ctrl._activeObj
+    if (!ctrl._opState.is(S_FACE_EXTRUDE)) return
+    if (!(obj instanceof Solid) || !s.face) return
+    obj.extrudeFace(s.face, s.savedLocalFaceCorners, s.localNormal, s.dist)
+    obj.meshView.updateGeometry(obj.corners)
+    obj.meshView.updateBoxHelper()
+  }
+
+  /**
+   * Applies the current extrusion distance from the typed input string.
+   * Falls back to applyPreview() if the input is invalid.
+   */
+  applyFromInput() {
+    const { _ctrl: ctrl } = this
+    const s   = this.state
+    const obj = ctrl._activeObj
+    if (!ctrl._opState.is(S_FACE_EXTRUDE)) return
+    if (!(obj instanceof Solid) || !s.face) return
+    const parsed = parseFloat(s.inputStr)
+    const dist   = isNaN(parsed) ? 0 : parsed
+    obj.extrudeFace(s.face, s.savedLocalFaceCorners, s.localNormal, dist)
+    obj.meshView.updateGeometry(obj.corners)
+    obj.meshView.updateBoxHelper()
+  }
+
+  /**
+   * Confirms the extrusion, records an undo command, and exits face-extrude mode.
+   */
+  confirm() {
+    const { _ctrl: ctrl } = this
+    if (!ctrl._opState.is(S_FACE_EXTRUDE)) return
+    const s   = this.state
+    const obj = ctrl._activeObj
+
+    // Apply final distance from input or mouse
+    const dist = s.hasInput ? (parseFloat(s.inputStr) || 0) : s.dist
+
+    if (obj instanceof Solid && s.face) {
+      obj.extrudeFace(s.face, s.savedLocalFaceCorners, s.localNormal, dist)
+      obj.meshView.updateGeometry(obj.corners)
+      obj.meshView.updateBoxHelper()
+
+      // Record undo snapshot — store corner delta as a post-hoc command
+      const endCorners = obj.corners.map(c => c.clone())
+      // Reconstruct start corners from savedLocalFaceCorners being at dist=0
+      const startLocalCorners = [...obj.localCorners]  // current localCorners ARE the committed ones
+      // Use a simple inline undo command: re-extrude with saved data
+      const face              = s.face
+      const savedLocalFC      = s.savedLocalFaceCorners.map(c => c.clone())
+      const localNormal       = s.localNormal.clone()
+      const commitDist        = dist
+      const service           = ctrl._service
+      const cmd = {
+        label: 'Face Extrude',
+        execute() {
+          obj.extrudeFace(face, savedLocalFC, localNormal, commitDist)
+          obj.meshView.updateGeometry(obj.corners)
+          obj.meshView.updateBoxHelper()
+          service.invalidateWorldPose(obj.id)
+        },
+        undo() {
+          obj.extrudeFace(face, savedLocalFC, localNormal, 0)
+          obj.meshView.updateGeometry(obj.corners)
+          obj.meshView.updateBoxHelper()
+          service.invalidateWorldPose(obj.id)
+        },
+      }
+      ctrl._commandStack.push(cmd)
+    }
+
+    // Clear snap display
+    if (ctrl._meshView) ctrl._meshView.clearSnapDisplay()
+
+    this._resetState()
+    ctrl._opState.send('CONFIRM')
+    ctrl._controls.enabled = true
+    ctrl._refreshObjectModeStatus()
+    if (window.matchMedia('(pointer: coarse)').matches) ctrl._updateMobileToolbar()
+  }
+
+  /**
+   * Cancels the face extrusion, restoring the Solid to its pre-extrude shape.
+   */
+  cancel() {
+    const { _ctrl: ctrl } = this
+    if (!ctrl._opState.is(S_FACE_EXTRUDE)) return
+    const s   = this.state
+    const obj = ctrl._activeObj
+
+    // Restore original shape by re-extruding at dist = 0
+    if (obj instanceof Solid && s.face) {
+      obj.extrudeFace(s.face, s.savedLocalFaceCorners, s.localNormal, 0)
+      obj.meshView.updateGeometry(obj.corners)
+      obj.meshView.updateBoxHelper()
+    }
+
+    // Clear snap display
+    if (ctrl._meshView) ctrl._meshView.clearSnapDisplay()
+
+    this._resetState()
+    ctrl._opState.send('CANCEL')
+    ctrl._controls.enabled = true
+    ctrl._refreshObjectModeStatus()
+    if (window.matchMedia('(pointer: coarse)').matches) ctrl._updateMobileToolbar()
+  }
+
+  /**
+   * Updates the status bar text to reflect the current face-extrude operation.
+   */
+  updateStatus() {
+    const { _ctrl: ctrl } = this
+    const s = this.state
+    const dist = s.hasInput ? (parseFloat(s.inputStr) || 0) : s.dist
+    const parts = [{ text: 'Extrude Face', bold: true, color: '#ffffff' }]
+    if (s.hasInput) {
+      parts.push({ text: s.inputStr + '_', color: '#ffeb3b' })
+    } else {
+      parts.push({ text: `D: ${dist.toFixed(3)}`, color: '#ffeb3b' })
+    }
+    if (s.snapping && s.snappedTarget) {
+      parts.push({ text: `Snapped: ${s.snappedTarget.type}`, color: '#69f0ae' })
+    }
+    parts.push({ text: 'Enter confirm  Esc cancel', color: '#444' })
+    ctrl._uiView.setStatusRich(parts)
+  }
+
+  /**
+   * Tries to snap `rawDist` to the nearest relevant snap target on the face normal axis.
+   * Updates state.snapping and state.snappedTarget.
+   * @param {number} rawDist  Unsnapped distance from startPoint along face normal
+   * @returns {number}        Snapped (or unchanged) distance
+   */
+  trySnap(rawDist) {
+    const { _ctrl: ctrl } = this
+    const s   = this.state
+    const obj = ctrl._activeObj
+    if (!(obj instanceof Solid) || !s.face) return rawDist
+
+    // Face center after applying rawDist
+    const faceCenter = s.savedCorners
+      .reduce((a, c) => a.add(c), new THREE.Vector3())
+      .divideScalar(s.savedCorners.length)
+    const projectedCenter = faceCenter.clone().addScaledVector(s.normal, rawDist)
+
+    // Test each snap target: project its position onto the face normal axis
+    // and check if the distance is within the snap threshold.
+    let bestDist  = rawDist
+    let bestSnap  = null
+    let bestDelta = Infinity
+
+    for (const t of s.snapTargets) {
+      // Project the target onto the face normal: signed dist from face center
+      const snappedDist = t.position.clone().sub(faceCenter).dot(s.normal)
+      const screenDelta = Math.abs(snappedDist - rawDist)
+      if (screenDelta < SNAP_THRESHOLD && screenDelta < bestDelta) {
+        bestDelta = screenDelta
+        bestDist  = snappedDist
+        bestSnap  = t
+      }
+    }
+
+    s.snapping     = bestSnap !== null
+    s.snappedTarget = bestSnap
+    return bestDist
+  }
+
+  // ── Private ──────────────────────────────────────────────────────────────
+
+  _resetState() {
+    const s = this.state
+    s.face                  = null
+    s.savedCorners          = []
+    s.savedLocalFaceCorners = []
+    s.normal.set(0, 0, 0)
+    s.localNormal.set(0, 0, 0)
+    s.dist                  = 0
+    s.inputStr              = ''
+    s.hasInput              = false
+    s.snapping              = false
+    s.snappedTarget         = null
+    s.snapTargets           = []
+  }
+}

--- a/src/controller/handler/FramePlacementHandler.js
+++ b/src/controller/handler/FramePlacementHandler.js
@@ -1,0 +1,308 @@
+/**
+ * FramePlacementHandler — manages the CoordinateFrame placement pick sub-mode.
+ *
+ * Encapsulates all frame-placement state and the start/confirm/cancel/pickPoint
+ * lifecycle (ADR-034 §6).
+ *
+ * Owned by AppController as this._framePlacementHandler.
+ * Accesses parent controller via this._ctrl.
+ *
+ * State machine: S_FRAME_PLACEMENT ∈ AppController._opState.
+ * Triggered by: _addCoordinateFrame() → start(parentId).
+ *
+ * Visual elements (lazily created, reused):
+ *   _parentAxesOverlay  THREE.Group — world-aligned dimmed dashed axes at parent centroid.
+ *   _frameCursorGhost   THREE.Group — bright axes following the cursor during pick.
+ * These are kept on the handler (mirroring the original AppController fields).
+ */
+
+import * as THREE from 'three'
+import { CoordinateFrame }                      from '../../domain/CoordinateFrame.js'
+import { S_FRAME_PLACEMENT }                    from '../../core/editorStates.js'
+import { createCreateCoordinateFrameCommand }   from '../../command/CreateCoordinateFrameCommand.js'
+
+// ── Module-level ghost geometry helpers (ADR-034 §6, §7) ──────────────────────
+
+const _GHOST_AXIS_LEN = 0.5
+const _GHOST_OPACITY  = 0.35
+const _GHOST_DASH     = 0.08
+const _GHOST_GAP      = 0.05
+
+/** Creates a dimmed dashed axis-lines group (world-aligned — always identity rotation). */
+function _makeGhostAxesGroup() {
+  const group = new THREE.Group()
+  for (const [dx, dy, dz, color] of [
+    [_GHOST_AXIS_LEN, 0, 0, 0xff4444],
+    [0, _GHOST_AXIS_LEN, 0, 0x44cc44],
+    [0, 0, _GHOST_AXIS_LEN, 0x4488ff],
+  ]) {
+    const geo = new THREE.BufferGeometry()
+    geo.setAttribute('position', new THREE.Float32BufferAttribute([0, 0, 0, dx, dy, dz], 3))
+    const mat = new THREE.LineDashedMaterial({
+      color, dashSize: _GHOST_DASH, gapSize: _GHOST_GAP,
+      depthTest: false, transparent: true, opacity: _GHOST_OPACITY,
+    })
+    const line = new THREE.Line(geo, mat)
+    line.renderOrder = 1
+    line.computeLineDistances()
+    group.add(line)
+  }
+  return group
+}
+
+/** Creates a bright solid axis-lines group to show as cursor ghost during frame pick. */
+function _makeFrameAxesGroup() {
+  const group = new THREE.Group()
+  for (const [dx, dy, dz, color] of [
+    [_GHOST_AXIS_LEN, 0, 0, 0xff4444],
+    [0, _GHOST_AXIS_LEN, 0, 0x44cc44],
+    [0, 0, _GHOST_AXIS_LEN, 0x4488ff],
+  ]) {
+    const geo = new THREE.BufferGeometry()
+    geo.setAttribute('position', new THREE.Float32BufferAttribute([0, 0, 0, dx, dy, dz], 3))
+    const mat = new THREE.LineBasicMaterial({ color, depthTest: false, transparent: true, opacity: 0.75 })
+    const line = new THREE.Line(geo, mat)
+    line.renderOrder = 2
+    group.add(line)
+  }
+  return group
+}
+
+export class FramePlacementHandler {
+  /**
+   * @param {import('../AppController.js').AppController} ctrl
+   */
+  constructor(ctrl) {
+    this._ctrl = ctrl
+
+    /**
+     * All mutable placement state — accessed externally via .state or getters.
+     * @type {{ parentId: string|null }}
+     */
+    this.state = { parentId: null }
+
+    /**
+     * Scene-level Three.js Group showing world-aligned parent axes during pick sub-mode.
+     * Lazily created on first entry; reused on subsequent entries.
+     * @type {THREE.Group|null}
+     */
+    this._parentAxesOverlay = null
+
+    /**
+     * Ghost CoordinateFrame axes following the cursor during pick sub-mode.
+     * @type {THREE.Group|null}
+     */
+    this._frameCursorGhost = null
+  }
+
+  // ── Convenience getters ───────────────────────────────────────────────────
+
+  get isActive() {
+    return this._ctrl._opState.is(S_FRAME_PLACEMENT)
+  }
+
+  // ── Public operation lifecycle ────────────────────────────────────────────
+
+  /**
+   * Enters the frame placement pick sub-mode for the given parent entity.
+   * Shows the parent axes ghost and cursor ghost; updates status bar and mobile toolbar.
+   * @param {string} parentId
+   */
+  start(parentId) {
+    const { _ctrl: ctrl } = this
+    if (!ctrl._opState.send('BEGIN_FRAME_PLACEMENT')) return
+    this.state.parentId = parentId
+
+    // Show parent axes overlay at geometry ancestor centroid (ADR-034 §7)
+    const ancestorCentroid = this._geometryAncestorCentroid(parentId)
+    if (ancestorCentroid) {
+      if (!this._parentAxesOverlay) {
+        this._parentAxesOverlay = _makeGhostAxesGroup()
+        ctrl._sceneView.scene.add(this._parentAxesOverlay)
+      }
+      this._parentAxesOverlay.position.copy(ancestorCentroid)
+      this._parentAxesOverlay.quaternion.set(0, 0, 0, 1)
+      this._parentAxesOverlay.visible = true
+    }
+
+    // Cursor ghost axes (hidden until hover)
+    if (!this._frameCursorGhost) {
+      this._frameCursorGhost = _makeFrameAxesGroup()
+      ctrl._sceneView.scene.add(this._frameCursorGhost)
+    }
+    this._frameCursorGhost.visible = false
+
+    const mobile = window.innerWidth < 768
+    if (mobile) {
+      ctrl._uiView.setStatus('Tap to place frame')
+      ctrl._updateMobileToolbar()
+    } else {
+      ctrl._uiView.setStatus('Click to place frame — Esc to cancel')
+      ctrl._uiView.setCursor('crosshair')
+    }
+  }
+
+  /**
+   * Cancels pick sub-mode; hides overlays and restores normal state.
+   */
+  cancel() {
+    const { _ctrl: ctrl } = this
+    if (!ctrl._opState.is(S_FRAME_PLACEMENT)) return
+    this.state.parentId = null
+    if (this._parentAxesOverlay) this._parentAxesOverlay.visible = false
+    if (this._frameCursorGhost)  this._frameCursorGhost.visible  = false
+    ctrl._uiView.setCursor('default')
+    ctrl._opState.send('CANCEL')
+    ctrl._refreshObjectModeStatus()
+    ctrl._updateMobileToolbar()
+  }
+
+  /**
+   * Confirms frame placement at the given world position.
+   * Creates the CoordinateFrame, records undo, exits sub-mode.
+   * @param {THREE.Vector3} worldPos
+   */
+  confirm(worldPos) {
+    const { _ctrl: ctrl } = this
+    if (!ctrl._opState.is(S_FRAME_PLACEMENT)) return
+    const parentId = this.state.parentId
+    this.state.parentId = null
+    if (this._parentAxesOverlay) this._parentAxesOverlay.visible = false
+    if (this._frameCursorGhost)  this._frameCursorGhost.visible  = false
+    ctrl._uiView.setCursor('default')
+    ctrl._opState.send('CONFIRM')
+    ctrl._refreshObjectModeStatus()
+    ctrl._updateMobileToolbar()
+
+    // User CFs are always parented to the Origin CF of the Solid (ADR-037 §2)
+    const parentObj = ctrl._scene.getObject(parentId)
+    let effectiveParentId = parentId
+    if (parentObj && !(parentObj instanceof CoordinateFrame)) {
+      const originFrame = [...ctrl._scene.objects.values()]
+        .find(o => o instanceof CoordinateFrame && o.parentId === parentId && o.name === 'Origin')
+      if (originFrame) effectiveParentId = originFrame.id
+    }
+
+    const frame = ctrl._service.createCoordinateFrame(effectiveParentId, null, worldPos)
+    if (!frame) return
+
+    const cmd = createCreateCoordinateFrameCommand(
+      frame, ctrl._service,
+      () => {
+        // After undo: restore parent selection if parent still exists
+        const parent = ctrl._scene.getObject(parentId)
+        if (parent) ctrl._switchActiveObject(parentId, true)
+        else {
+          ctrl._objSelected = false
+          ctrl._selectedIds.clear()
+          ctrl._refreshObjectModeStatus()
+          ctrl._updateMobileToolbar()
+        }
+      },
+      (id) => ctrl._switchActiveObject(id, true),
+    )
+    ctrl._commandStack.push(cmd)
+    ctrl._switchActiveObject(frame.id, true)
+  }
+
+  /**
+   * Updates the cursor ghost position and scale during hover (pointer move).
+   * Call from the S_FRAME_PLACEMENT branch of _onPointerMove for non-touch events.
+   */
+  updateCursorGhost() {
+    const { _ctrl: ctrl } = this
+    const pt = this.pickPoint()
+    if (pt && this._frameCursorGhost) {
+      this._frameCursorGhost.position.copy(pt)
+      this._frameCursorGhost.quaternion.set(0, 0, 0, 1)
+      this._frameCursorGhost.visible = true
+      // Scale cursor ghost to consistent screen size
+      const d = ctrl._camera.position.distanceTo(pt)
+      if (d > 0 && ctrl._camera.isPerspectiveCamera) {
+        const tanHalfFov = Math.tan((ctrl._camera.fov * Math.PI) / 360)
+        const screenH    = ctrl._sceneView.renderer.domElement.clientHeight || 1
+        const ws = (60 / screenH) * 2 * d * tanHalfFov
+        this._frameCursorGhost.scale.setScalar(ws / _GHOST_AXIS_LEN)
+      }
+    } else if (this._frameCursorGhost) {
+      this._frameCursorGhost.visible = false
+    }
+    // Scale parent axes overlay too
+    if (this._parentAxesOverlay?.visible) {
+      const dp = ctrl._camera.position.distanceTo(this._parentAxesOverlay.position)
+      if (dp > 0 && ctrl._camera.isPerspectiveCamera) {
+        const tanHalfFov = Math.tan((ctrl._camera.fov * Math.PI) / 360)
+        const screenH    = ctrl._sceneView.renderer.domElement.clientHeight || 1
+        const ws = (80 / screenH) * 2 * dp * tanHalfFov
+        this._parentAxesOverlay.scale.setScalar(ws / _GHOST_AXIS_LEN)
+      }
+    }
+  }
+
+  /**
+   * Picks a world position on the parent entity's surface from the current mouse/pointer.
+   * Returns null when the ray misses the entity bounding box.
+   * @returns {THREE.Vector3|null}
+   */
+  pickPoint() {
+    const { _ctrl: ctrl } = this
+    const { parentId } = this.state
+    const parent = ctrl._scene.getObject(parentId)
+    if (!parent) return null
+
+    ctrl._raycaster.setFromCamera(ctrl._mouse, ctrl._camera)
+    const ray = ctrl._raycaster.ray
+    const pt  = new THREE.Vector3()
+
+    // Try raycasting against the parent's cuboid mesh first (Solid)
+    const cuboid = parent.meshView?.cuboid
+    if (cuboid) {
+      const hits = []
+      ctrl._raycaster.intersectObject(cuboid, true, hits)
+      if (hits.length > 0) return hits[0].point.clone()
+    }
+
+    // Fallback: bounding box intersection
+    if (parent.corners?.length > 0) {
+      const box = new THREE.Box3()
+      for (const c of parent.corners) box.expandByPoint(c)
+      if (ray.intersectBox(box, pt)) return pt.clone()
+    }
+
+    // For CoordinateFrame parent: use a plane at the frame world position
+    if (parent instanceof CoordinateFrame) {
+      const wp = ctrl._service.worldPoseOf(parentId)?.position
+      if (wp) {
+        const camDir = new THREE.Vector3()
+        ctrl._camera.getWorldDirection(camDir)
+        const plane = new THREE.Plane().setFromNormalAndCoplanarPoint(camDir, wp)
+        if (ray.intersectPlane(plane, pt)) return pt.clone()
+      }
+    }
+
+    return null
+  }
+
+  // ── Private ──────────────────────────────────────────────────────────────
+
+  /**
+   * Walks from the given id up the parent chain past CoordinateFrames to find
+   * the geometry ancestor, then returns its centroid.
+   * @param {string} frameId
+   * @returns {THREE.Vector3|null}
+   */
+  _geometryAncestorCentroid(frameId) {
+    const { _ctrl: ctrl } = this
+    let obj = ctrl._scene.getObject(frameId)
+    while (obj instanceof CoordinateFrame) {
+      obj = ctrl._scene.getObject(obj.parentId)
+    }
+    if (!obj) return null
+    const corners = obj.corners
+    if (!corners || corners.length === 0) return null
+    const centroid = new THREE.Vector3()
+    for (const c of corners) centroid.add(c)
+    centroid.divideScalar(corners.length)
+    return centroid
+  }
+}

--- a/src/controller/handler/GrabOperationHandler.js
+++ b/src/controller/handler/GrabOperationHandler.js
@@ -1,0 +1,871 @@
+/**
+ * GrabOperationHandler — manages G-key grab/move operations.
+ *
+ * Encapsulates all grab state and the start/apply/confirm/cancel lifecycle
+ * for Solid, CoordinateFrame, and all other entity types that support grab.
+ *
+ * Owned by AppController as this._grabHandler.
+ * Accesses parent controller via this._ctrl.
+ */
+
+import * as THREE from 'three'
+import { CoordinateFrame } from '../../domain/CoordinateFrame.js'
+import { Solid }           from '../../domain/Solid.js'
+import { MeasureLine }     from '../../domain/MeasureLine.js'
+import { ImportedMesh }    from '../../domain/ImportedMesh.js'
+import { SpatialLink }     from '../../domain/SpatialLink.js'
+import { AnnotatedLine }   from '../../domain/AnnotatedLine.js'
+import { AnnotatedRegion } from '../../domain/AnnotatedRegion.js'
+import { AnnotatedPoint }  from '../../domain/AnnotatedPoint.js'
+import { RoleService }     from '../../service/RoleService.js'
+import { createMoveCommand } from '../../command/MoveCommand.js'
+import { S_GRAB_ACTIVE }   from '../../core/editorStates.js'
+import {
+  getCentroid,
+  getPivotCandidates,
+  getVertexPivotCandidates,
+  getEdgePivotCandidates,
+  getFacePivotCandidates,
+  collectSnapTargets,
+  collectWorldSnapTargets,
+} from '../../model/CuboidModel.js'
+import { computeApproachWarmth } from '../../service/SemanticInferencer.js'
+
+/**
+ * Returns the appropriate handles array for grab/move operations.
+ * Geometry entities → world-space corners; CoordinateFrame → localOffset.
+ * @param {object} obj  scene entity
+ * @returns {import('three').Vector3[]}
+ */
+function _grabHandlesOf(obj) {
+  return (obj instanceof CoordinateFrame) ? obj.localOffset : obj.corners
+}
+
+export class GrabOperationHandler {
+  /**
+   * @param {import('../AppController.js').AppController} ctrl
+   */
+  constructor(ctrl) {
+    this._ctrl = ctrl
+
+    /**
+     * All mutable grab state — accessed externally via .state or getters.
+     * @type {object}
+     */
+    this.state = {
+      /** World axis constraint: null = free, 'x'|'y'|'z' = world axes. */
+      axis:            null,
+      /** Mouse position at grab start (NDC). */
+      startMouse:      new THREE.Vector2(),
+      /** Grab-handle snapshots for the active object at grab start. */
+      startCorners:    [],
+      /** @type {Map<string, import('three').Vector3[]>} corners snapshot for all selected objects */
+      allStartCorners: new Map(),
+      /** @type {Map<string, import('three').Vector3[]>} corners at the start of the current drag segment (touch re-grab) */
+      segmentStartCorners: new Map(),
+      /** @type {Map<string, import('three').Vector3>} Solid._position snapshot at segment start (ADR-040) */
+      segmentStartPositions: new Map(),
+      /** Centroid of the grabbed selection (updated on segment re-start). */
+      centroid:        new THREE.Vector3(),
+      /** Custom pivot point (changes after V pivot selection). */
+      pivot:           new THREE.Vector3(),
+      /** Display label for the current pivot. */
+      pivotLabel:      'Centroid',
+      /** Camera-facing drag plane. */
+      dragPlane:       new THREE.Plane(),
+      /** World-space intersection point at grab start. */
+      startPoint:      new THREE.Vector3(),
+      /** Numeric distance string typed by the user; empty when mouse-driven. */
+      inputStr:        '',
+      /** True when the user has typed at least one digit. */
+      hasInput:        false,
+      /** True when the handler is in pivot-selection sub-mode. */
+      pivotSelectMode: false,
+      /** Index of the currently hovered pivot candidate, or -1. */
+      hoveredPivotIdx: -1,
+      /** Current pivot candidates (recomputed on pivot-select entry and mode change). */
+      candidates:      [],
+      /** Current candidate filter in pivot select mode: 'all'|'vertex'|'edge'|'face' */
+      pivotMode:       'all',
+      /** True when a snap target is currently locked. */
+      snapping:        false,
+      /** Set to true after G→V pivot confirm; enables auto-snap without Ctrl. */
+      autoSnap:        false,
+      /** The snap target currently locked to, or null. */
+      snappedTarget:   null,
+      /** Snap target filter: 'all'|'vertex'|'edge'|'face' */
+      snapMode:        'all',
+      /** All snap candidates from last _trySnapToGeometry call (for display). */
+      snapTargets:     [],
+      /** Grid snap unit size (Ctrl during grab). Cycled with Ctrl+Wheel. */
+      gridSize:        1,
+      /** When true, grabbed object snaps Z so its bottom rests on the top surface below. */
+      stackMode:       false,
+      /** True when stacking is actively snapping Z this frame. */
+      stacking:        false,
+      /** Last delta applied via _applyDeltaToAll; used for live coordinate display. */
+      lastDelta:       new THREE.Vector3(),
+      /** True when a live semantic suggestion is showing during G-key grab (ADR-041 Phase 3). */
+      isSuggesting:    false,
+      /** The suggestion currently displayed, or null. @type {object|null} */
+      currentSuggestion: null,
+    }
+  }
+
+  // ── Convenience getters (used by AppController toolbars / wheel handler) ───
+
+  get axis()           { return this.state.axis }
+  get stackMode()      { return this.state.stackMode }
+  get pivotSelectMode(){ return this.state.pivotSelectMode }
+  get hoveredPivotIdx(){ return this.state.hoveredPivotIdx }
+  get isSuggesting()   { return this.state.isSuggesting }
+  get currentSuggestion() { return this.state.currentSuggestion }
+
+  // ── Public operation lifecycle ─────────────────────────────────────────────
+
+  /**
+   * Starts grab mode for the currently selected entity/entities.
+   * Runs all domain guards (SpatialLink, Origin CF, Role, semantic guardrail)
+   * before transitioning to S_GRAB_ACTIVE.
+   */
+  start() {
+    const { _ctrl: ctrl } = this
+    ctrl._uiView.dismissSemanticSuggestion()
+    if (!ctrl._objSelected) return
+    // SpatialLink has no geometry — cannot be grabbed (ADR-030)
+    if (ctrl._activeObj instanceof SpatialLink) {
+      ctrl._uiView.showToast('SpatialLink cannot be grabbed', { type: 'warn' })
+      return
+    }
+    // Origin frames are fixed at the Solid centroid — cannot be grabbed (ADR-037)
+    if (ctrl._activeObj instanceof CoordinateFrame && ctrl._activeObj.name === 'Origin') {
+      ctrl._uiView.showToast('Origin frame is fixed at the centroid', { type: 'warn' })
+      return
+    }
+    // Provenance check: block grab if frame was declared by a different role (ADR-034 §8.2)
+    if (ctrl._activeObj instanceof CoordinateFrame && !RoleService.canEdit(ctrl._activeObj)) {
+      ctrl._uiView.showToast(`This frame was declared by a ${ctrl._activeObj.declaredBy}. Switch to that role to edit it.`, { type: 'warn' })
+      return
+    }
+    // Semantic guardrail: block grab when any selected entity is fastened or mounted to
+    // an entity outside the selection (PHILOSOPHY #1 — One Authoritative Entry Point).
+    const grabGuardrail = ctrl._service.checkMoveGuardrail(ctrl._selectedIds)
+    if (grabGuardrail.blocked) {
+      ctrl._uiView.showToast(grabGuardrail.message, { type: 'warn' })
+      return
+    }
+    // All domain guards passed → mutual exclusion + state transition
+    if (!ctrl._opState.send('BEGIN_GRAB')) return
+    // Rubber-band: activate marching ants + tension for links connected to dragged entities.
+    ctrl._service.setLinkDragging(ctrl._selectedIds, true)
+
+    const s = this.state
+    s.axis            = null
+    s.inputStr        = ''
+    s.hasInput        = false
+    s.pivotSelectMode = false
+    s.hoveredPivotIdx = -1
+    s.snapMode        = 'all'
+    s.snapTargets     = []
+    s.startMouse.copy(ctrl._mouse)
+    s.startCorners = ctrl._corners.map(c => c.clone())
+    // Snapshot corners of every selected object for multi-object grab
+    s.allStartCorners = new Map()
+    for (const id of ctrl._selectedIds) {
+      const selObj = ctrl._scene.getObject(id)
+      if (selObj) s.allStartCorners.set(id, _grabHandlesOf(selObj).map(c => c.clone()))
+    }
+    // segmentStartCorners tracks the start of each individual drag segment (touch).
+    // Initially identical to allStartCorners; re-snapshotted on each touch re-down.
+    s.segmentStartCorners = new Map(
+      [...s.allStartCorners.entries()].map(([id, cs]) => [id, cs.map(c => c.clone())])
+    )
+    // Solid _position snapshots for move() — separate from corner snapshots (ADR-040)
+    s.segmentStartPositions = new Map()
+    for (const id of ctrl._selectedIds) {
+      const selObj = ctrl._scene.getObject(id)
+      if (selObj instanceof Solid) s.segmentStartPositions.set(id, selObj._position.clone())
+    }
+    // For CoordinateFrame, corners = [translation] (parent-relative offset).
+    // Use the world position from the cache so the drag plane passes through
+    // the frame's actual world location (ADR-020).
+    const grabCenter = (ctrl._activeObj instanceof CoordinateFrame)
+      ? (ctrl._service.worldPoseOf(ctrl._activeObj.id)?.position?.clone() ?? getCentroid(ctrl._corners))
+      : (ctrl._activeObj instanceof Solid ? ctrl._activeObj._position.clone() : getCentroid(ctrl._corners))
+    s.centroid.copy(grabCenter)
+    s.pivot.copy(s.centroid)
+    s.lastDelta.set(0, 0, 0)
+    s.pivotLabel       = 'Centroid'
+    s.autoSnap         = false
+    s.isSuggesting     = false
+    s.currentSuggestion = null
+
+    // ADR-032 §6: for mounted Annotated* entities, constrain drag to host local XY plane.
+    // For unmounted Annotated* entities, constrain to world XY (prevents Z drift).
+    // For all other entities, use the camera-facing plane (existing behaviour).
+    const isAnnotated = ctrl._activeObj instanceof AnnotatedLine ||
+      ctrl._activeObj instanceof AnnotatedRegion ||
+      ctrl._activeObj instanceof AnnotatedPoint
+    let planeNormal = null
+    if (isAnnotated) {
+      const mountLink = ctrl._scene.getMountsLink(ctrl._scene.activeId)
+      if (mountLink) {
+        // Mounted: use host CoordinateFrame's local Z axis as drag plane normal
+        const hostPose = ctrl._service.worldPoseOf(mountLink.targetId)
+        if (hostPose) {
+          planeNormal = new THREE.Vector3(0, 0, 1).applyQuaternion(hostPose.quaternion)
+        }
+      }
+      if (!planeNormal) {
+        // Unmounted Annotated*: use world Z (XY plane)
+        planeNormal = new THREE.Vector3(0, 0, 1)
+      }
+    } else {
+      const camDir = new THREE.Vector3()
+      ctrl._camera.getWorldDirection(camDir)
+      planeNormal = camDir
+    }
+    s.dragPlane.setFromNormalAndCoplanarPoint(planeNormal, s.pivot)
+
+    ctrl._raycaster.setFromCamera(ctrl._mouse, ctrl._camera)
+    const pt = new THREE.Vector3()
+    if (ctrl._raycaster.ray.intersectPlane(s.dragPlane, pt)) {
+      s.startPoint.copy(pt)
+    } else {
+      s.startPoint.copy(s.pivot)
+    }
+
+    ctrl._controls.enabled = false
+    ctrl._uiView.setCursor('grabbing')
+    this.updateStatus()
+    ctrl._updateMobileToolbar()
+  }
+
+  /**
+   * Confirms the current grab and exits grab mode.
+   * Records an undo command and runs semantic inference.
+   */
+  confirm() {
+    const { _ctrl: ctrl } = this
+    if (!ctrl._opState.is(S_GRAB_ACTIVE)) return
+    const s = this.state
+    if (s.pivotSelectMode) { this.cancelPivotSelect(); return }
+    // Clear live suggestion ghost before final state is committed (Drag Suggestion Lifecycle).
+    if (s.isSuggesting) {
+      s.isSuggesting      = false
+      s.currentSuggestion = null
+      ctrl._quickDragCtx.hideDragSuggestion()
+    }
+    // Clear approach warmth on all Solids.
+    for (const obj of ctrl._scene.objects.values()) {
+      if (obj instanceof Solid) obj.meshView?.setApproachWarmth(0)
+    }
+    this.apply()
+
+    // ADR-032 §6: after grab on mounted Annotated* entities, sync local positions
+    // so _updateMountedAnnotations uses the new world positions going forward.
+    for (const id of ctrl._selectedIds) {
+      ctrl._service.syncMountedPosition(id)
+    }
+
+    // ── Record undo snapshot (ADR-022 Phase 1) ────────────────────────────
+    const endCornersMap = new Map()
+    for (const id of ctrl._selectedIds) {
+      const obj = ctrl._scene.getObject(id)
+      if (obj) endCornersMap.set(id, _grabHandlesOf(obj).map(c => c.clone()))
+    }
+    if (endCornersMap.size > 0) {
+      const label = endCornersMap.size === 1 ? 'Move' : `Move ${endCornersMap.size} objects`
+      const cmd = createMoveCommand(label, s.allStartCorners, endCornersMap, ctrl._scene, ctrl._service)
+      ctrl._commandStack.push(cmd)
+    }
+
+    s.axis          = null
+    s.autoSnap      = false
+    s.snappedTarget = null
+    s.stackMode     = false
+    s.stacking      = false
+    ctrl._meshView.clearPivotDisplay()
+    ctrl._meshView.clearSnapDisplay()
+    ctrl._opState.send('CONFIRM')
+    // Rubber-band: end drag animation; stay highlighted since entity is still selected.
+    ctrl._service.setLinkDragging(new Set(), false)
+    ctrl._service.updateLinkSelectionHighlight(ctrl._selectedIds)
+    ctrl._controls.enabled = true
+    ctrl._uiView.setCursor('default')
+    ctrl._refreshObjectModeStatus()
+    ctrl._updateNPanel()
+    ctrl._updateMobileToolbar()
+    ctrl._hideAxisGuide()
+
+    // ── Semantic inference (ADR-041) ─────────────────────────────────────
+    // Suggest a SpatialLink when a single Solid lands near another object.
+    ctrl._runSemanticInference()
+  }
+
+  /**
+   * Cancels the current grab, restoring all moved entities to their pre-grab positions.
+   */
+  cancel() {
+    const { _ctrl: ctrl } = this
+    if (!ctrl._opState.is(S_GRAB_ACTIVE)) return
+    const s = this.state
+    if (s.pivotSelectMode) { s.pivotSelectMode = false }
+    if (s.isSuggesting) {
+      s.isSuggesting      = false
+      s.currentSuggestion = null
+      ctrl._quickDragCtx.hideDragSuggestion()
+    }
+    for (const obj of ctrl._scene.objects.values()) {
+      if (obj instanceof Solid) obj.meshView?.setApproachWarmth(0)
+    }
+    // Restore all selected objects to their pre-grab positions
+    for (const [id, startCorners] of s.allStartCorners) {
+      const selObj = ctrl._scene.getObject(id)
+      if (!selObj) continue
+      if (selObj instanceof Solid) {
+        // Decompose world corners back into _position + localCorners (ADR-040)
+        selObj.setWorldCorners(startCorners)
+        selObj.meshView.updateGeometry(selObj.corners)
+      } else {
+        const handles = _grabHandlesOf(selObj)
+        startCorners.forEach((c, i) => handles[i].copy(c))
+        selObj.meshView.updateGeometry(handles)
+      }
+      selObj.meshView.updateBoxHelper()
+    }
+    ctrl._meshView.clearPivotDisplay()
+    ctrl._meshView.clearSnapDisplay()
+    s.axis          = null
+    s.autoSnap      = false
+    s.snappedTarget = null
+    s.stackMode     = false
+    s.stacking      = false
+    ctrl._opState.send('CANCEL')
+    // Rubber-band: end drag animation; stay highlighted since entity is still selected.
+    ctrl._service.setLinkDragging(new Set(), false)
+    ctrl._service.updateLinkSelectionHighlight(ctrl._selectedIds)
+    ctrl._controls.enabled = true
+    ctrl._hideAxisGuide()
+    ctrl._uiView.setCursor('default')
+    ctrl._refreshObjectModeStatus()
+    ctrl._updateNPanel()
+    ctrl._updateMobileToolbar()
+  }
+
+  /**
+   * Sets or toggles the world-axis constraint for the current grab.
+   * Toggleing the same axis clears the constraint (free grab).
+   * Re-snapshots segment start so accumulated movement from the prior constraint is preserved.
+   * @param {'x'|'y'|'z'} axis
+   */
+  setAxis(axis) {
+    const { _ctrl: ctrl } = this
+    const s = this.state
+    s.axis     = (s.axis === axis) ? null : axis
+    s.inputStr = ''
+    s.hasInput = false
+    // Re-snapshot current positions as the new segment start so accumulated
+    // movement from the previous axis constraint is preserved (e.g. X→Y keeps
+    // the X offset). Mirrors the touch re-grab pattern (pointerdown in S_GRAB_ACTIVE).
+    s.segmentStartCorners   = new Map()
+    s.segmentStartPositions = new Map()
+    for (const id of ctrl._selectedIds) {
+      const selObj = ctrl._scene.getObject(id)
+      if (selObj) {
+        s.segmentStartCorners.set(id, _grabHandlesOf(selObj).map(c => c.clone()))
+        if (selObj instanceof Solid) s.segmentStartPositions.set(id, selObj._position.clone())
+      }
+    }
+    s.startMouse.copy(ctrl._mouse)
+    // Update centroid/pivot to current position so the axis guide and
+    // screen-projection track the object after accumulated movement from the
+    // prior constraint. Mirrors the touch re-grab centroid update (pointerdown
+    // in S_GRAB_ACTIVE). segmentStartPositions was just re-snapshotted above.
+    if (ctrl._activeObj instanceof CoordinateFrame) {
+      const pos = ctrl._service.worldPoseOf(ctrl._activeObj.id)?.position
+      if (pos) { s.centroid.copy(pos); s.pivot.copy(pos) }
+    } else if (s.segmentStartPositions.size > 0) {
+      const avg = new THREE.Vector3()
+      for (const p of s.segmentStartPositions.values()) avg.add(p)
+      avg.divideScalar(s.segmentStartPositions.size)
+      s.centroid.copy(avg)
+      s.pivot.copy(avg)
+    }
+    if (!s.axis) {
+      // Switching back to free grab: reset the 3D drag-plane anchor to the current
+      // mouse position so the free-grab delta starts at zero.
+      ctrl._raycaster.setFromCamera(ctrl._mouse, ctrl._camera)
+      const _pt = new THREE.Vector3()
+      if (ctrl._raycaster.ray.intersectPlane(s.dragPlane, _pt)) {
+        s.startPoint.copy(_pt)
+      }
+    }
+    this.apply()
+    this.updateStatus()
+    if (s.axis) {
+      ctrl._showAxisGuide(s.axis, s.centroid.clone(), 'translate')
+    } else {
+      ctrl._hideAxisGuide()
+    }
+    if (window.matchMedia('(pointer: coarse)').matches) ctrl._updateMobileToolbar()
+  }
+
+  /**
+   * Applies the current grab delta to all selected entities.
+   * Called on every pointer move and on numeric input changes.
+   * Also drives stack snap and live semantic inference.
+   */
+  apply() {
+    const { _ctrl: ctrl } = this
+    if (!ctrl._opState.is(S_GRAB_ACTIVE)) return
+    const s = this.state
+    if (s.hasInput && s.axis) {
+      this._applyFromInput()
+    } else if (s.axis) {
+      this._applyAxisConstrained()
+    } else {
+      this._applyFree()
+    }
+    // Stack snap: adjust Z so grabbed objects rest on top of any object below.
+    // applyPreviewTranslation (called from _applyDeltaToAll) already updated
+    // views; re-update after stack snap since it re-applies domain mutations.
+    if (s.stackMode) {
+      this._applyStackSnap(s.segmentStartPositions, s.lastDelta)
+      for (const id of ctrl._selectedIds) {
+        const selObj = ctrl._scene.getObject(id)
+        if (selObj) {
+          selObj.meshView.updateGeometry(_grabHandlesOf(selObj))
+          selObj.meshView.updateBoxHelper()
+        }
+      }
+    } else {
+      s.stacking = false
+    }
+
+    // Live inference preview during G-key grab (ADR-041 Phase 3 — mirrors QuickDragState sub-state).
+    if (ctrl._selectedIds.size === 1) {
+      const ctx        = ctrl._quickDragCtx
+      const suggestion = ctx.runInference()
+      const key        = suggestion ? `${suggestion.semanticType}|${suggestion.targetId}` : null
+      const prevKey    = s.currentSuggestion
+        ? `${s.currentSuggestion.semanticType}|${s.currentSuggestion.targetId}` : null
+      if (suggestion) {
+        if (!s.isSuggesting || key !== prevKey) {
+          s.isSuggesting      = true
+          s.currentSuggestion = suggestion
+          ctx.showDragSuggestion(suggestion)
+        } else {
+          ctx.updateDragSuggestion(suggestion)
+        }
+      } else if (s.isSuggesting) {
+        s.isSuggesting      = false
+        s.currentSuggestion = null
+        ctx.hideDragSuggestion()
+      }
+    }
+
+    // Approach gradient: warm wireframe of nearby Solids before the snap threshold is reached.
+    const [movedId] = ctrl._selectedIds
+    const movedObj  = ctrl._scene.getObject(movedId)
+    if (movedObj instanceof Solid) {
+      const warmthEntries = computeApproachWarmth(movedObj, ctrl._scene.objects.values())
+      const warmthMap     = new Map(warmthEntries.map(e => [e.targetId, e.warmth]))
+      for (const obj of ctrl._scene.objects.values()) {
+        if (obj instanceof Solid && !ctrl._selectedIds.has(obj.id)) {
+          obj.meshView?.setApproachWarmth(warmthMap.get(obj.id) ?? 0)
+        }
+      }
+    }
+  }
+
+  /** Toggles stacking mode on/off during an active grab. */
+  toggleStackMode() {
+    const { _ctrl: ctrl } = this
+    const s = this.state
+    s.stackMode = !s.stackMode
+    s.stacking  = false
+    this.apply()
+    this.updateStatus()
+    ctrl._updateMobileToolbar()
+  }
+
+  /**
+   * Updates the status bar text to reflect the current grab operation.
+   */
+  updateStatus() {
+    const { _ctrl: ctrl } = this
+    const s = this.state
+    if (s.pivotSelectMode) {
+      const MODE_LABEL = { all: 'All', vertex: 'Vertex', edge: 'Edge', face: 'Face' }
+      const MODE_COLOR = { all: '#aaa', vertex: '#69f0ae', edge: '#ffd740', face: '#4fc3f7' }
+      const m = s.pivotMode ?? 'all'
+      ctrl._uiView.setStatusRich([
+        { text: 'Select Pivot', bold: true, color: '#e8e8e8' },
+        { text: MODE_LABEL[m], color: MODE_COLOR[m] },
+        { text: '1 Vertex  2 Edge  3 Face', color: '#444' },
+      ])
+      return
+    }
+
+    const AXIS_COLORS = { x: '#e05252', y: '#6ab04c', z: '#4a9eed' }
+    const parts = [{ text: 'Grab', bold: true, color: '#ffffff' }]
+
+    if (s.axis) {
+      parts.push({ text: s.axis.toUpperCase(), bold: true, color: AXIS_COLORS[s.axis] })
+    }
+    if (s.hasInput) {
+      parts.push({ text: s.inputStr + '_', color: '#ffeb3b' })
+    }
+    if (s.pivotLabel !== 'Centroid') {
+      parts.push({ text: s.pivotLabel, color: '#888' })
+    }
+    if (s.stackMode) {
+      if (s.stacking) {
+        parts.push({ text: 'Stack: ON', bold: true, color: '#a5d6a7' })
+      } else {
+        parts.push({ text: 'Stack', color: '#4caf50' })
+      }
+    }
+    if (s.snapping && s.snappedTarget) {
+      parts.push({ text: `Snap: ${s.snappedTarget.label}`, bold: true, color: '#ff9800' })
+    } else if (s.autoSnap) {
+      parts.push({ text: 'Auto Snap [World]', color: '#80cbc4' })
+      parts.push({ text: 'Origin / X / Y / Z', color: '#444' })
+    } else if (ctrl._ctrlHeld) {
+      parts.push({ text: `Grid: ${s.gridSize}`, bold: true, color: '#80cbc4' })
+      parts.push({ text: 'Scroll to change', color: '#444' })
+    }
+
+    if (!s.hasInput) {
+      const d = s.lastDelta
+      const cx = (s.centroid.x + d.x).toFixed(2)
+      const cy = (s.centroid.y + d.y).toFixed(2)
+      const cz = (s.centroid.z + d.z).toFixed(2)
+      parts.push({ text: `X:${cx} Y:${cy} Z:${cz}`, color: '#546e7a' })
+      const dx = (d.x >= 0 ? '+' : '') + d.x.toFixed(2)
+      const dy = (d.y >= 0 ? '+' : '') + d.y.toFixed(2)
+      const dz = (d.z >= 0 ? '+' : '') + d.z.toFixed(2)
+      parts.push({ text: `Δ ${dx} ${dy} ${dz}`, color: '#78909c' })
+    }
+
+    ctrl._uiView.setStatusRich(parts)
+  }
+
+  // ── Pivot point selection ─────────────────────────────────────────────────
+
+  /**
+   * Enters pivot-selection sub-mode during an active grab.
+   * Only available for Cuboid-based entities (Solid).
+   */
+  startPivotSelect() {
+    const { _ctrl: ctrl } = this
+    if (!ctrl._opState.is(S_GRAB_ACTIVE) || this.state.pivotSelectMode) return
+    // Pivot selection uses Cuboid-specific vertex geometry — skip for non-Cuboid types.
+    if (ctrl._activeObj instanceof ImportedMesh || ctrl._activeObj instanceof MeasureLine || ctrl._activeObj instanceof CoordinateFrame) return
+    const s = this.state
+    s.startCorners.forEach((c, i) => ctrl._corners[i].copy(c))
+    ctrl._meshView.updateGeometry(ctrl._corners)
+    ctrl._meshView.updateBoxHelper()
+    s.pivotSelectMode = true
+    s.pivotMode       = 'all'
+    s.hoveredPivotIdx = -1
+    s.candidates = getPivotCandidates(s.startCorners)
+    ctrl._meshView.showPivotCandidates(s.candidates)
+    this.updateStatus()
+  }
+
+  /**
+   * Filters pivot candidates by sub-element type and refreshes the display.
+   * @param {'all'|'vertex'|'edge'|'face'} mode
+   */
+  setPivotCandidateMode(mode) {
+    const { _ctrl: ctrl } = this
+    const s = this.state
+    s.pivotMode = mode
+    const corners = s.startCorners
+    const candidates =
+      mode === 'vertex' ? getVertexPivotCandidates(corners) :
+      mode === 'edge'   ? getEdgePivotCandidates(corners)   :
+      mode === 'face'   ? getFacePivotCandidates(corners)   :
+                          getPivotCandidates(corners)
+    s.candidates      = candidates
+    s.hoveredPivotIdx = -1
+    ctrl._meshView.showPivotCandidates(candidates)
+    ctrl._meshView.setHoveredPivot(null)
+    this.updateStatus()
+  }
+
+  /**
+   * Updates the hovered pivot candidate based on the current mouse position.
+   * Called on every pointer move when pivotSelectMode is active.
+   */
+  updatePivotHover() {
+    const { _ctrl: ctrl } = this
+    const s = this.state
+    const SNAP_PX = 30
+    let minDist    = Infinity
+    let closestIdx = -1
+    const mx = (ctrl._mouse.x + 1) / 2 * innerWidth
+    const my = (-ctrl._mouse.y + 1) / 2 * innerHeight
+    s.candidates.forEach((c, i) => {
+      const ndc = c.position.clone().project(ctrl._camera)
+      const sx  = (ndc.x + 1) / 2 * innerWidth
+      const sy  = (-ndc.y + 1) / 2 * innerHeight
+      const d   = Math.hypot(sx - mx, sy - my)
+      if (d < minDist) { minDist = d; closestIdx = i }
+    })
+    if (minDist <= SNAP_PX && closestIdx >= 0) {
+      s.hoveredPivotIdx = closestIdx
+      const cand = s.candidates[closestIdx]
+      ctrl._meshView.setHoveredPivot(cand)
+      ctrl._uiView.setStatusRich([
+        { text: 'Pivot', color: '#aaa' },
+        { text: cand.label, bold: true, color: '#ffeb3b' },
+      ])
+    } else {
+      s.hoveredPivotIdx = -1
+      ctrl._meshView.setHoveredPivot(null)
+      ctrl._uiView.setStatusRich([
+        { text: 'Select Pivot', bold: true, color: '#e8e8e8' },
+        { text: 'Click to confirm', color: '#aaa' },
+        { text: 'Esc to cancel', color: '#666' },
+      ])
+    }
+  }
+
+  /**
+   * Cancels pivot-select sub-mode and returns to regular grab mode.
+   */
+  cancelPivotSelect() {
+    const { _ctrl: ctrl } = this
+    const s = this.state
+    s.pivotSelectMode = false
+    s.hoveredPivotIdx = -1
+    ctrl._meshView.clearPivotDisplay()
+    this.updateStatus()
+  }
+
+  /**
+   * Resets the drag plane and start point to the current pivot position.
+   * Called after a pivot is confirmed via pivot select (G→V).
+   */
+  restartFromPivot() {
+    const { _ctrl: ctrl } = this
+    const s = this.state
+    const pivot  = s.pivot
+    const camDir = new THREE.Vector3()
+    ctrl._camera.getWorldDirection(camDir)
+    s.dragPlane.setFromNormalAndCoplanarPoint(camDir, pivot)
+    s.startPoint.copy(pivot)
+    s.axis     = null
+    s.inputStr = ''
+    s.hasInput = false
+    s.startMouse.copy(ctrl._mouse)
+  }
+
+  // ── Private helpers ───────────────────────────────────────────────────────
+
+  /**
+   * Returns a THREE.Vector3 for the given axis letter.
+   * @param {'x'|'y'|'z'} axis
+   * @returns {THREE.Vector3}
+   */
+  _getAxisVec(axis) {
+    return new THREE.Vector3(
+      axis === 'x' ? 1 : 0,
+      axis === 'y' ? 1 : 0,
+      axis === 'z' ? 1 : 0,
+    )
+  }
+
+  /**
+   * Stack snap: after all grab movement is applied, cast downward rays from the
+   * bottom face of the active grabbed object. If another object is directly below,
+   * shift all grabbed objects upward so the bottom face rests on that surface.
+   * @param {Map<string, import('three').Vector3>} segStartPositions  per-Solid _position snapshots
+   * @param {import('three').Vector3} currentDelta  world delta already applied by the caller
+   */
+  _applyStackSnap(segStartPositions, currentDelta) {
+    const { _ctrl: ctrl } = this
+    const s = this.state
+    const grabbed = ctrl._activeObj
+    if (!(grabbed instanceof Solid)) { s.stacking = false; return }
+
+    // Find bottom Z of the grabbed object
+    const gCorners = grabbed.corners
+    let gZMin = Infinity
+    gCorners.forEach(c => { if (c.z < gZMin) gZMin = c.z })
+
+    // Collect meshes from non-grabbed objects (excluding MeasureLine)
+    const grabbedIds = new Set(ctrl._selectedIds)
+    const targetMeshes = [...ctrl._scene.objects.values()]
+      .filter(o => !grabbedIds.has(o.id) && !(o instanceof MeasureLine) && o.meshView?.cuboid?.visible)
+      .map(o => o.meshView.cuboid)
+
+    if (!targetMeshes.length) { s.stacking = false; return }
+
+    // Sample the bottom face: 4 corners at gZMin + centroid
+    const bottomCorners = gCorners.filter(c => Math.abs(c.z - gZMin) < 0.001)
+    const center = new THREE.Vector3()
+    bottomCorners.forEach(c => center.add(c))
+    center.divideScalar(bottomCorners.length || 1)
+
+    const origins = [...bottomCorners, center]
+    const downDir = new THREE.Vector3(0, 0, -1)
+    const stackRay = new THREE.Raycaster()
+
+    // Cast downward from well above the scene; find the highest surface hit at (x,y).
+    // Using gZMin+ε as origin would miss surfaces above the current bottom face.
+    const RAY_TOP = 10000
+    let highestHitZ = null
+    for (const origin of origins) {
+      stackRay.set(new THREE.Vector3(origin.x, origin.y, RAY_TOP), downDir)
+      const hits = stackRay.intersectObjects(targetMeshes)
+      if (hits.length > 0) {
+        const hz = hits[0].point.z
+        if (highestHitZ === null || hz > highestHitZ) highestHitZ = hz
+      }
+    }
+
+    if (highestHitZ === null) { s.stacking = false; return }
+
+    const zOffset = highestHitZ - gZMin
+    // Skip if already resting on the surface (within 1mm tolerance)
+    if (Math.abs(zOffset) < 0.001) { s.stacking = false; return }
+
+    // Apply additional Z shift via the public Solid.move() API (ADR-040: never mutate
+    // corners directly — _position and localCorners must remain the SSOT).
+    const snapDelta = currentDelta.clone().add(new THREE.Vector3(0, 0, zOffset))
+    for (const id of ctrl._selectedIds) {
+      const selObj = ctrl._scene.getObject(id)
+      if (selObj instanceof Solid) {
+        const segStartPos = segStartPositions?.get(id)
+        if (segStartPos) selObj.move(segStartPos, snapDelta)
+      }
+    }
+    s.stacking = true
+  }
+
+  /**
+   * Applies `delta` to the active object and all other selected objects.
+   * Uses each object's own startCorners snapshot from `state.allStartCorners`.
+   * @param {import('three').Vector3} delta
+   */
+  _applyDeltaToAll(delta) {
+    const { _ctrl: ctrl } = this
+    const s = this.state
+    s.lastDelta.copy(delta)
+    ctrl._service.applyPreviewTranslation(
+      s.segmentStartCorners,
+      s.segmentStartPositions,
+      delta,
+    )
+  }
+
+  /**
+   * Applies grab when the user has typed a numeric distance along the axis.
+   */
+  _applyFromInput() {
+    const { _ctrl: ctrl } = this
+    const s = this.state
+    s.snapping = false
+    const parsed = parseFloat(s.inputStr)
+    if (s.inputStr && isNaN(parsed)) {
+      ctrl._uiView.showToast('Invalid number')
+      return
+    }
+    const dist    = isNaN(parsed) ? 0 : parsed
+    const axisVec = this._getAxisVec(s.axis)
+    this._applyDeltaToAll(axisVec.clone().multiplyScalar(dist))
+  }
+
+  /**
+   * Applies free (camera-facing plane) grab based on raycaster intersection.
+   */
+  _applyFree() {
+    const { _ctrl: ctrl } = this
+    const s = this.state
+    ctrl._raycaster.setFromCamera(ctrl._mouse, ctrl._camera)
+    const pt = new THREE.Vector3()
+    if (!ctrl._raycaster.ray.intersectPlane(s.dragPlane, pt)) return
+    let delta = pt.clone().sub(s.startPoint)
+    if (s.autoSnap) {
+      delta = ctrl._trySnapToGeometry(delta)
+    } else if (ctrl._ctrlHeld) {
+      delta = ctrl._applyGridSnapToDelta(delta)
+      s.snapping      = false
+      s.snappedTarget = null
+    } else {
+      s.snapping      = false
+      s.snappedTarget = null
+      const _fgTension = ctrl._service.getLinkDragTension()
+      if (_fgTension > 0) delta.multiplyScalar(Math.max(0.15, 1.0 - Math.min(_fgTension, 1.0) * 0.85))
+    }
+    this._applyDeltaToAll(delta)
+  }
+
+  /**
+   * Applies axis-constrained grab: projects mouse movement onto the world axis
+   * using the analytic Jacobian of the perspective projection (immune to
+   * behind-camera sign-flip that the old pivot+axisVec NDC approach had).
+   */
+  _applyAxisConstrained() {
+    const { _ctrl: ctrl } = this
+    const s = this.state
+    const axisVec = this._getAxisVec(s.axis)
+
+    // Compute the screen-space direction of the world axis using the analytic
+    // Jacobian of the perspective projection, evaluated at the grab pivot.
+    //
+    // The previous approach projected (pivot + axisVec) to NDC and subtracted
+    // project(pivot). When the camera is close to the object, (pivot + axisVec)
+    // can land behind the camera. THREE.js perspective division by a negative W
+    // flips the NDC sign, reversing the apparent axis direction and causing the
+    // object to move opposite to the cursor.
+    //
+    // The Jacobian d(ndc)/dt at t=0 is computed entirely at the pivot point
+    // (always in front of the camera), so it is immune to this sign-flip.
+    //
+    // Derivation for perspective projection  ndc.x = x_c * f_x / (−z_c):
+    //   dx_ndc/dt = f_x * (v_x * (−z_c) − x_c * v_z) / z_c²
+    //   dy_ndc/dt = f_y * (v_y * (−z_c) − y_c * v_z) / z_c²
+    // where (x_c, y_c, z_c) = pivot in camera space, (v_x, v_y, v_z) = axis
+    // in camera space, and z_c < 0 for points in front of the camera.
+    const P_c = s.pivot.clone().applyMatrix4(ctrl._camera.matrixWorldInverse)
+    const v_c = axisVec.clone().transformDirection(ctrl._camera.matrixWorldInverse)
+    const f_y = 1 / Math.tan(THREE.MathUtils.degToRad(ctrl._camera.fov * 0.5))
+    const f_x = f_y / ctrl._camera.aspect
+    const z   = P_c.z    // negative for in-front points
+
+    const dx        = f_x * (v_c.x * (-z) - P_c.x * v_c.z) / (z * z)
+    const dy        = f_y * (v_c.y * (-z) - P_c.y * v_c.z) / (z * z)
+    const screenLen = Math.sqrt(dx * dx + dy * dy)
+    if (screenLen < 1e-4) return
+
+    const axisNormX = dx / screenLen
+    const axisNormY = dy / screenLen
+
+    const mdx  = ctrl._mouse.x - s.startMouse.x
+    const mdy  = ctrl._mouse.y - s.startMouse.y
+    const dist = (mdx * axisNormX + mdy * axisNormY) / screenLen
+
+    if (s.autoSnap) {
+      const delta        = new THREE.Vector3().addScaledVector(axisVec, dist)
+      const snappedDelta = ctrl._trySnapToGeometry(delta)
+      this._applyDeltaToAll(snappedDelta)
+    } else if (ctrl._ctrlHeld) {
+      s.snapping      = false
+      s.snappedTarget = null
+      const g           = s.gridSize
+      const snappedDist = Math.round(dist / g) * g
+      this._applyDeltaToAll(axisVec.clone().multiplyScalar(snappedDist))
+    } else {
+      s.snapping      = false
+      s.snappedTarget = null
+      const _acTension = ctrl._service.getLinkDragTension()
+      const _acDist    = _acTension > 0 ? dist * Math.max(0.15, 1.0 - Math.min(_acTension, 1.0) * 0.85) : dist
+      this._applyDeltaToAll(axisVec.clone().multiplyScalar(_acDist))
+    }
+  }
+}

--- a/src/controller/handler/LinkCreationHandler.js
+++ b/src/controller/handler/LinkCreationHandler.js
@@ -1,0 +1,276 @@
+/**
+ * LinkCreationHandler — manages L-key SpatialLink creation flow.
+ *
+ * Encapsulates the two-phase L-key link creation (select source → click target),
+ * link-type picker, mount annotation, and fasten-frame flows.
+ *
+ * Owned by AppController as this._linkHandler.
+ * Accesses parent controller via this._ctrl.
+ */
+
+import { CoordinateFrame } from '../../domain/CoordinateFrame.js'
+import { Solid }           from '../../domain/Solid.js'
+import { AnnotatedLine }   from '../../domain/AnnotatedLine.js'
+import { AnnotatedRegion } from '../../domain/AnnotatedRegion.js'
+import { AnnotatedPoint }  from '../../domain/AnnotatedPoint.js'
+import { createSpatialLinkCommand }     from '../../command/CreateSpatialLinkCommand.js'
+import { createMountAnnotationCommand } from '../../command/MountAnnotationCommand.js'
+import { createFastenFrameCommand }     from '../../command/FastenFrameCommand.js'
+import { LINK_TYPE_COLORS }             from '../../view/SpatialLinkView.js'
+import { RippleEffect }                 from '../../view/RippleEffect.js'
+import { S_LINK_MODE, S_MOUNT_PICKING } from '../../core/editorStates.js'
+
+// ── Module-level helper ───────────────────────────────────────────────────────
+
+/**
+ * Returns the set of valid link options for a given source/target entity pair.
+ * Each option carries jointType (URDF kinematic), semanticType (domain annotation),
+ * and a display label. Based on ADR-038 validation table.
+ *
+ * @param {object|null} source
+ * @param {object|null} target
+ * @returns {{ jointType: string|null, semanticType: string, label: string }[]}
+ */
+function _computeLinkOptions(source, target) {
+  const isAnnotated = o => o instanceof AnnotatedLine || o instanceof AnnotatedRegion || o instanceof AnnotatedPoint
+  const isCF = o => o instanceof CoordinateFrame
+
+  const options = []
+
+  // ── Kinematic (fixed joint) options ──────────────────────────────────────
+  if (isCF(source) && isCF(target)) {
+    options.push({ jointType: 'fixed', semanticType: 'fastened', label: 'Fixed · Fastened' })
+    options.push({ jointType: 'fixed', semanticType: 'aligned',  label: 'Fixed · Aligned' })
+  }
+  if (isAnnotated(source) && isCF(target)) {
+    options.push({ jointType: 'fixed', semanticType: 'mounts',   label: 'Fixed · Mounts' })
+  }
+
+  // ── Topological / semantic annotation options ─────────────────────────────
+  if (source instanceof AnnotatedRegion) {
+    options.push({ jointType: null, semanticType: 'contains',  label: 'Contains' })
+  }
+  if (source instanceof AnnotatedLine) {
+    if (source.placeType === 'Route' && target instanceof AnnotatedPoint && target.placeType === 'Hub') {
+      // Tact-time constrained route connections (deadline + speed stored in properties).
+      options.push({ jointType: null, semanticType: 'connects', label: 'Tact 30 s · 1.5 m/s',  properties: { deadline: 30,  speed: 1.5 } })
+      options.push({ jointType: null, semanticType: 'connects', label: 'Tact 60 s · 1.5 m/s',  properties: { deadline: 60,  speed: 1.5 } })
+      options.push({ jointType: null, semanticType: 'connects', label: 'Tact 120 s · 1.5 m/s', properties: { deadline: 120, speed: 1.5 } })
+    } else {
+      options.push({ jointType: null, semanticType: 'connects', label: 'Connects' })
+    }
+  }
+  if ((source instanceof AnnotatedLine || source instanceof AnnotatedRegion) && target instanceof Solid) {
+    options.push({ jointType: null, semanticType: 'bounded_by', label: 'Bounded By (500mm)',   properties: { clearance: 500 } })
+    options.push({ jointType: null, semanticType: 'bounded_by', label: 'Bounded By (1000mm)',  properties: { clearance: 1000 } })
+    options.push({ jointType: null, semanticType: 'bounded_by', label: 'Bounded By (no gap)',  properties: { clearance: 0 } })
+  }
+  options.push({ jointType: null, semanticType: 'adjacent',   label: 'Adjacent' })
+  options.push({ jointType: null, semanticType: 'above',      label: 'Above' })
+  // Anchor → CoordinateFrame: tolerance-constrained references presets (ADR-043 Phase 4).
+  if (source instanceof AnnotatedPoint && source.placeType === 'Anchor' && isCF(target)) {
+    options.push({ jointType: null, semanticType: 'references', label: 'Tolerance ±1 mm',  properties: { tolerance: 1 } })
+    options.push({ jointType: null, semanticType: 'references', label: 'Tolerance ±5 mm',  properties: { tolerance: 5 } })
+    options.push({ jointType: null, semanticType: 'references', label: 'Tolerance ±10 mm', properties: { tolerance: 10 } })
+  } else {
+    options.push({ jointType: null, semanticType: 'references', label: 'References' })
+  }
+  options.push({ jointType: null, semanticType: 'represents', label: 'Represents' })
+
+  return options
+}
+
+export class LinkCreationHandler {
+  /**
+   * @param {import('../AppController.js').AppController} ctrl
+   */
+  constructor(ctrl) {
+    this._ctrl = ctrl
+
+    /**
+     * All mutable SpatialLink creation state — mirrored from AppController._spatialLinkMode.
+     * AppController._spatialLinkMode must point to this.state after construction.
+     * @type {object}
+     */
+    this.state = {
+      /** @type {string|null} ID of the source entity */
+      sourceId:        null,
+      /** @type {string|null} ID of the candidate target (pending picker) */
+      pendingTargetId: null,
+    }
+  }
+
+  // ── Public operation lifecycle ─────────────────────────────────────────────
+
+  /**
+   * Starts the two-phase L-key link creation. Source = currently active entity.
+   * Shows all CFs so the target frame is visible for picking.
+   */
+  start() {
+    const { _ctrl: ctrl } = this
+    ctrl._opState.send('BEGIN_LINK')
+    this.state.sourceId        = ctrl._scene.activeId
+    this.state.pendingTargetId = null
+    // Show all CFs so the target frame is visible for picking regardless of selection state
+    for (const obj of ctrl._scene.objects.values()) {
+      if (obj instanceof CoordinateFrame && obj.meshView) obj.meshView.showFull()
+    }
+    ctrl._uiView.setStatus('Click target entity  [Esc: cancel]')
+    ctrl._uiView.setCursor('crosshair')
+  }
+
+  /**
+   * Cancels link creation mode and restores normal status.
+   */
+  cancel() {
+    const { _ctrl: ctrl } = this
+    ctrl._opState.send('CANCEL')
+    this.state.sourceId        = null
+    this.state.pendingTargetId = null
+    this._restoreCFVisibility()
+    ctrl._uiView.setCursor('default')
+    ctrl._refreshObjectModeStatus()
+  }
+
+  /**
+   * Opens the link-type picker at (x, y) for the given target entity.
+   * Filters valid link types based on source / target entity type (ADR-032 §2).
+   * @param {number} x  client X
+   * @param {number} y  client Y
+   * @param {string} targetId
+   */
+  showTypePicker(x, y, targetId) {
+    const { _ctrl: ctrl } = this
+    this.state.pendingTargetId = targetId
+    const sourceId   = this.state.sourceId
+    const source     = ctrl._scene.getObject(sourceId)
+    const target     = ctrl._scene.getObject(targetId)
+    const linkOptions = _computeLinkOptions(source, target)
+    ctrl._uiView.showLinkTypePicker(x, y, (option) => {
+      if (option.semanticType === 'mounts') {
+        this.confirmMount(sourceId, targetId)
+      } else if (option.jointType === 'fixed') {
+        this.confirmFasten(sourceId, targetId, option.semanticType)
+      } else {
+        this.confirm(option)
+      }
+    }, { linkOptions })
+  }
+
+  /**
+   * Shared link creation used by L-key flow and Node Editor (Phase S-2).
+   * Creates SpatialLink + records undo command without touching state.
+   * @param {string} sourceId
+   * @param {string} targetId
+   * @param {{ jointType: string|null, semanticType: string, label: string }} option
+   */
+  createDirect(sourceId, targetId, option) {
+    const { _ctrl: ctrl } = this
+    const link = ctrl._service.createSpatialLink(sourceId, targetId, option.jointType, option.semanticType, option.properties ?? {})
+    ctrl._commandStack.push(createSpatialLinkCommand(link, ctrl._service))
+    ctrl._uiView.showToast(`Link created: ${option.label}`)
+    ctrl._updateNPanel()
+    // Acceptance ceremony: ripple sphere at link midpoint + brief line flash.
+    const srcPos = ctrl._dragSuggestionCentroid(sourceId)
+    const tgtPos = ctrl._dragSuggestionCentroid(targetId)
+    if (srcPos && tgtPos) {
+      const midpoint = srcPos.clone().lerp(tgtPos, 0.5)
+      const color    = LINK_TYPE_COLORS[option.semanticType] ?? 0x888888
+      ctrl._activeRipples.push(new RippleEffect(ctrl._sceneView.scene, midpoint, color))
+    }
+    ctrl._service._linkViews.get(link.id)?.triggerFlash?.()
+  }
+
+  /**
+   * Creates the SpatialLink from L-key picking flow and records the undo command.
+   * @param {{ jointType: string|null, semanticType: string, label: string }} option
+   */
+  confirm(option) {
+    const { sourceId, pendingTargetId } = this.state
+    if (!sourceId || !pendingTargetId) return
+    this.createDirect(sourceId, pendingTargetId, option)
+    this.cancel()
+  }
+
+  /**
+   * Mounts an Annotated* entity onto a CoordinateFrame and records the command.
+   * Called from both the L-key flow (PC) and the mobile mount-picking flow.
+   * @param {string} sourceId  Annotated* entity ID
+   * @param {string} targetId  CoordinateFrame entity ID
+   */
+  confirmMount(sourceId, targetId) {
+    const { _ctrl: ctrl } = this
+    const result = ctrl._service.mountAnnotation(sourceId, targetId)
+    if (!result) {
+      ctrl._uiView.showToast('Cannot mount — host frame pose unknown', { type: 'warn' })
+      return
+    }
+    const { link, worldPositionsBefore } = result
+    ctrl._commandStack.push(createMountAnnotationCommand(
+      link, worldPositionsBefore, ctrl._service,
+      () => { ctrl._updateNPanel() },
+      () => { ctrl._updateNPanel() },
+    ))
+    ctrl._uiView.showToast(`Mounted on frame "${ctrl._scene.getObject(targetId)?.name}"`)
+    this.cancel()
+    if (ctrl._opState.is(S_MOUNT_PICKING)) {
+      ctrl._mountPicking.sourceId = null
+      ctrl._uiView.setCursor('default')
+      ctrl._opState.send('CONFIRM')
+      ctrl._refreshObjectModeStatus()
+    }
+    ctrl._updateNPanel()
+  }
+
+  /**
+   * Fastens a source CoordinateFrame to a target CoordinateFrame and records the command.
+   * Called from the L-key link-type picker when the user selects a fixed joint for CF→CF.
+   * @param {string} sourceId     CoordinateFrame entity ID (slave / constrained frame)
+   * @param {string} targetId     CoordinateFrame entity ID (master / reference frame)
+   * @param {string} [semanticType='fastened']  Semantic annotation for the link
+   */
+  confirmFasten(sourceId, targetId, semanticType = 'fastened') {
+    const { _ctrl: ctrl } = this
+    const source = ctrl._scene.getObject(sourceId)
+    const target = ctrl._scene.getObject(targetId)
+    if (!(source instanceof CoordinateFrame) || !(target instanceof CoordinateFrame)) {
+      ctrl._uiView.showToast('Select a coordinate frame as source and target', { type: 'warn' })
+      return
+    }
+    // Force-update world poses so cache is fresh even if called between animation ticks
+    ctrl._service._updateWorldPoses()
+    const result = ctrl._service.fastenFrame(sourceId, targetId, semanticType)
+    if (!result) {
+      ctrl._uiView.showToast('Cannot fasten — frame pose unknown', { type: 'warn' })
+      return
+    }
+    const { link, translationBefore, rotationBefore, relativeOffset, relativeQuat } = result
+    ctrl._commandStack.push(createFastenFrameCommand(
+      link, translationBefore, rotationBefore, relativeOffset, relativeQuat, ctrl._service,
+      () => { ctrl._updateNPanel() },
+      () => { ctrl._updateNPanel() },
+    ))
+    ctrl._uiView.showToast(`Fastened to "${ctrl._scene.getObject(targetId)?.name}"`)
+    this.cancel()
+    ctrl._updateNPanel()
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Restores CF visibility after link-creation mode:
+   * show only CFs whose parent (or self) is the active object.
+   */
+  _restoreCFVisibility() {
+    const { _ctrl: ctrl } = this
+    const activeId = ctrl._activeObj?.id
+    for (const obj of ctrl._scene.objects.values()) {
+      if (!(obj instanceof CoordinateFrame) || !obj.meshView) continue
+      if (obj.id === activeId || obj.parentId === activeId) {
+        obj.meshView.showFull()
+      } else {
+        obj.meshView.hide()
+      }
+    }
+  }
+}

--- a/src/controller/handler/MeasurePlacementHandler.js
+++ b/src/controller/handler/MeasurePlacementHandler.js
@@ -1,0 +1,258 @@
+/**
+ * MeasurePlacementHandler — manages M-key / Add→Measure placement flow.
+ *
+ * Encapsulates all measure placement state and the start/confirmPoint/cancel
+ * lifecycle for the two-phase MeasureLine creation (click p1, click p2).
+ *
+ * Owned by AppController as this._measureHandler.
+ * Accesses parent controller via this._ctrl.
+ */
+
+import * as THREE from 'three'
+import { MeasureLine }     from '../../domain/MeasureLine.js'
+import { CoordinateFrame } from '../../domain/CoordinateFrame.js'
+import { collectSnapTargets } from '../../model/CuboidModel.js'
+import { S_MEASURE_PLACING } from '../../core/editorStates.js'
+
+export class MeasurePlacementHandler {
+  /**
+   * @param {import('../AppController.js').AppController} ctrl
+   */
+  constructor(ctrl) {
+    this._ctrl = ctrl
+
+    /**
+     * All mutable measure placement state — mirrored from AppController._measure.
+     * AppController._measure must point to this.state after construction.
+     * @type {object}
+     */
+    this.state = {
+      /** @type {import('three').Vector3|null} fixed first endpoint */
+      p1:            null,
+      /** @type {import('three').Vector3|null} live cursor position (snapped) */
+      p2:            null,
+      /** @type {{label:string, position:import('three').Vector3, type:string, objectId:string, elementId:string}[]} */
+      snapTargets:   [],
+      snapping:      false,
+      /** @type {{label:string, position:import('three').Vector3, type:string, objectId:string, elementId:string}|null} */
+      snappedTarget: null,
+      /** Anchor reference captured when p1 was confirmed (ADR-028).
+       *  @type {{ objectId:string, type:string, elementId:string }|null} */
+      p1Anchor:      null,
+      /** Three.js Line for preview before entity is created */
+      previewLine:   null,
+      /** True while the user is holding a pointer down to snap a point */
+      pressing:      false,
+      /** MeshView used for snap candidate display (may differ from _meshView when active obj is MeasureLine) */
+      snapMeshView:  null,
+    }
+  }
+
+  // ── Public operation lifecycle ─────────────────────────────────────────────
+
+  /**
+   * Enters measure placement mode: click p1, then p2 to create a MeasureLine.
+   * Exits edit mode if active, disables orbit on touch devices.
+   */
+  start() {
+    const { _ctrl: ctrl } = this
+    if (ctrl._scene.selectionMode === 'edit') ctrl.setMode('object')
+    ctrl._opState.send('BEGIN_MEASURE')
+    const s = this.state
+    s.p1            = null
+    s.p2            = null
+    s.p1Anchor      = null
+    s.snapTargets   = []
+    s.snapping      = false
+    s.snappedTarget = null
+    // Snap display requires a MeshView with THREE.Points infrastructure.
+    // MeasureLineView and CoordinateFrameView have no snap display infrastructure.
+    // Fall back to any real MeshView-backed object for snap candidate rendering.
+    const activeObj = ctrl._scene.activeObject
+    const _isSnapCapable = o => !(o instanceof MeasureLine) && !(o instanceof CoordinateFrame)
+    s.snapMeshView = (activeObj && _isSnapCapable(activeObj))
+      ? activeObj.meshView
+      : ([...ctrl._scene.objects.values()].find(_isSnapCapable)?.meshView ?? null)
+    // On touch devices, disable orbit so single-finger touch places measure
+    // points instead of orbiting the camera.  Use (pointer: coarse) rather
+    // than innerWidth so that tablets and landscape phones are also covered.
+    if (window.matchMedia('(pointer: coarse)').matches) ctrl._controls.enabled = false
+    ctrl._uiView.setCursor('crosshair')
+    this.updateStatus()
+    ctrl._updateMobileToolbar()
+  }
+
+  /**
+   * Cancels measure placement and restores normal view state.
+   */
+  cancel() {
+    const { _ctrl: ctrl } = this
+    if (!ctrl._opState.is(S_MEASURE_PLACING)) return
+    const s = this.state
+    s.p1            = null
+    s.p2            = null
+    s.p1Anchor      = null
+    s.snapping      = false
+    s.snappedTarget = null
+    s.snapTargets   = []
+    s.pressing      = false
+    if (s.previewLine) {
+      ctrl._sceneView.scene.remove(s.previewLine)
+      s.previewLine.geometry.dispose()
+      s.previewLine.material.dispose()
+      s.previewLine = null
+    }
+    s.snapMeshView?.clearSnapDisplay()
+    s.snapMeshView = null
+    ctrl._opState.send('CANCEL')
+    if (window.matchMedia('(pointer: coarse)').matches) ctrl._controls.enabled = true
+    ctrl._uiView.setCursor('default')
+    ctrl._refreshObjectModeStatus()
+    ctrl._updateMobileToolbar()
+  }
+
+  /**
+   * Confirms the current snapped cursor position as a measure point.
+   * Phase 1: sets p1. Phase 2: creates the MeasureLine entity.
+   * Called from _onPointerUp so mobile users can hold-to-snap before releasing.
+   */
+  confirmPoint() {
+    const { _ctrl: ctrl } = this
+    const s  = this.state
+    const pt = this.pickPoint()
+    if (!pt) return
+    if (!s.p1) {
+      // Phase 1 → Phase 2: record start point and its anchor (ADR-028)
+      s.p1 = pt.clone()
+      const t = s.snappedTarget
+      s.p1Anchor = (t?.objectId && t?.elementId)
+        ? { objectId: t.objectId, type: t.type, elementId: t.elementId }
+        : null
+      this.updateStatus()
+    } else {
+      // Phase 2: record end point → create entity
+      const p2 = pt.clone()
+      // Capture anchor refs before clearing state (ADR-028)
+      const t2       = s.snappedTarget
+      const p2Anchor = (t2?.objectId && t2?.elementId)
+        ? { objectId: t2.objectId, type: t2.type, elementId: t2.elementId }
+        : null
+      const p1Anchor = s.p1Anchor
+      if (s.previewLine) {
+        ctrl._sceneView.scene.remove(s.previewLine)
+        s.previewLine.geometry.dispose()
+        s.previewLine.material.dispose()
+        s.previewLine = null
+      }
+      s.snapMeshView?.clearSnapDisplay()
+      s.snapMeshView  = null
+      ctrl._opState.send('CONFIRM')
+      const p1            = s.p1
+      s.p1            = null
+      s.p2            = null
+      s.p1Anchor      = null
+      s.snapTargets   = []
+      s.snapping      = false
+      s.snappedTarget = null
+      const obj = ctrl._service.createMeasureLine(
+        p1, p2,
+        ctrl._camera,
+        ctrl._sceneView.renderer,
+        document.body,
+        { p1: p1Anchor, p2: p2Anchor },
+      )
+      ctrl._switchActiveObject(obj.id, true)
+      if (window.matchMedia('(pointer: coarse)').matches) ctrl._controls.enabled = true
+      ctrl._uiView.setCursor('default')
+      ctrl._refreshObjectModeStatus()
+      ctrl._updateMobileToolbar()
+    }
+  }
+
+  /**
+   * Updates the status bar text to reflect the current measure placement phase.
+   */
+  updateStatus() {
+    const { _ctrl: ctrl } = this
+    if (!ctrl._opState.is(S_MEASURE_PLACING)) return
+    const s = this.state
+    if (!s.p1) {
+      ctrl._uiView.setStatusRich([
+        { text: 'Measure', bold: true, color: '#f9a825' },
+        { text: 'Click to set start point', color: '#888' },
+        { text: 'ESC cancel', color: '#444' },
+      ])
+    } else {
+      const parts = [
+        { text: 'Measure', bold: true, color: '#f9a825' },
+        { text: 'Click to set end point', color: '#888' },
+      ]
+      if (s.p2) {
+        const d = s.p1.distanceTo(s.p2)
+        const f = d < 1 ? `${(d * 100).toFixed(1)} cm` : `${d.toFixed(3)} m`
+        parts.push({ text: f, bold: true, color: '#f9a825' })
+      }
+      if (s.snapping && s.snappedTarget) {
+        parts.push({ text: `Snap: ${s.snappedTarget.label}`, color: '#ff9800' })
+      }
+      parts.push({ text: 'ESC cancel', color: '#444' })
+      ctrl._uiView.setStatusRich(parts)
+    }
+  }
+
+  /**
+   * Finds the nearest V/E/F snap target to the current mouse cursor.
+   * Returns the snapped world position (or ground-plane fallback).
+   * Also updates this.state.snapping / snappedTarget / snapTargets.
+   * @returns {import('three').Vector3|null}
+   */
+  pickPoint() {
+    const { _ctrl: ctrl } = this
+    const s  = this.state
+    const mx = (ctrl._mouse.x + 1) / 2 * innerWidth
+    const my = (-ctrl._mouse.y + 1) / 2 * innerHeight
+
+    const targets = collectSnapTargets(ctrl._scene.objects, 'all')
+    s.snapTargets = targets
+
+    const bestTarget = ctrl._pickBestSnapTarget(targets, mx, my)
+
+    if (bestTarget) {
+      s.snapping      = true
+      s.snappedTarget = bestTarget
+      return bestTarget.position.clone()
+    }
+
+    // Fallback: intersect ground plane (Z=0)
+    s.snapping      = false
+    s.snappedTarget = null
+    ctrl._raycaster.setFromCamera(ctrl._mouse, ctrl._camera)
+    const pt = new THREE.Vector3()
+    if (ctrl._raycaster.ray.intersectPlane(ctrl._groundPlane, pt)) return pt
+    return null
+  }
+
+  /**
+   * Builds or updates the dashed preview line shown during measure placement phase 2.
+   * @param {import('three').Vector3} p1
+   * @param {import('three').Vector3} p2
+   */
+  updatePreview(p1, p2) {
+    const { _ctrl: ctrl } = this
+    const s   = this.state
+    const pts = [p1.x, p1.y, p1.z, p2.x, p2.y, p2.z]
+    if (!s.previewLine) {
+      const geo = new THREE.BufferGeometry()
+      const mat = new THREE.LineDashedMaterial({
+        color: 0xf9a825, dashSize: 0.15, gapSize: 0.08, depthTest: false,
+      })
+      s.previewLine = new THREE.Line(geo, mat)
+      s.previewLine.renderOrder = 1
+      ctrl._sceneView.scene.add(s.previewLine)
+    }
+    const geo = s.previewLine.geometry
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(pts, 3))
+    geo.attributes.position.needsUpdate = true
+    s.previewLine.computeLineDistances()
+  }
+}

--- a/src/controller/handler/RotationHandler.js
+++ b/src/controller/handler/RotationHandler.js
@@ -1,0 +1,423 @@
+/**
+ * RotationHandler — manages R-key CoordinateFrame / Solid rotation.
+ *
+ * Encapsulates all rotation state and the start/apply/confirm/cancel lifecycle
+ * for both CoordinateFrame (quaternion-based) and Solid (ADR-040 corner-baking).
+ *
+ * Owned by AppController as this._rotateHandler.
+ * Accesses parent controller via this._ctrl.
+ */
+
+import * as THREE from 'three'
+import { CoordinateFrame } from '../../domain/CoordinateFrame.js'
+import { Solid }           from '../../domain/Solid.js'
+import { RoleService }     from '../../service/RoleService.js'
+import { createFrameRotateCommand }  from '../../command/FrameRotateCommand.js'
+import { createSolidRotateCommand }  from '../../command/SolidRotateCommand.js'
+import { S_ROTATE_ACTIVE } from '../../core/editorStates.js'
+
+export class RotationHandler {
+  /**
+   * @param {import('../AppController.js').AppController} ctrl
+   */
+  constructor(ctrl) {
+    this._ctrl = ctrl
+
+    /**
+     * All mutable rotation state — accessed externally via .state or getters.
+     * @type {object}
+     */
+    this.state = {
+      /** World-space axis to rotate around: null = view-space Z, 'x'|'y'|'z' = world axes. */
+      axis:       null,
+      /** Screen-angle (radians) from projected pivot to mouse at start. */
+      startAngle: 0,
+      /** Saved rotation quaternion at the moment rotation begins (CoordinateFrame only). */
+      startRot:   new THREE.Quaternion(),
+      /** Numeric degree string typed by the user; empty when mouse-driven. */
+      inputStr:   '',
+      /** True when the user has typed at least one digit. */
+      hasInput:   false,
+      /** Degree increment for Ctrl snap. Cycled with Ctrl+Wheel. */
+      stepSize:   1,
+      /** True when startAngle should be captured from the next pointer position (mobile). */
+      needsStartAngle:      false,
+      /** Per-segment start angle; equals startAngle on PC (single drag). */
+      segmentStartAngle:    0,
+      /** Angle from pivot to cursor at the previous frame; used for incremental accumulation. */
+      prevCurrentAngle:     0,
+      /** Accumulated signed rotation (radians) for the current drag segment. */
+      accumulatedAngle:     0,
+      /** Per-segment quaternion for CoordinateFrame; equals startRot on PC. */
+      segmentStartRot:      new THREE.Quaternion(),
+      /** Solid orientation snapshot at rotate start — for undo. @type {import('three').Quaternion|null} */
+      startOrientation:    null,
+      /** Solid _position snapshot at rotate start — for undo. @type {import('three').Vector3|null} */
+      startPos:            null,
+      /** Solid orientation snapshot at segment start. @type {import('three').Quaternion|null} */
+      segStartOrientation: null,
+      /** Solid _position snapshot at segment start. @type {import('three').Vector3|null} */
+      segStartPos:         null,
+      /** Centroid of solid corners at segment start — rotation pivot + screen projection. @type {import('three').Vector3|null} */
+      segStartPivot:       null,
+      /** Display angle (radians) from last apply(); used by updateStatus(). */
+      displayAngle:        0,
+    }
+  }
+
+  // ── Convenience getters (used by AppController toolbars / wheel handler) ───
+
+  get axis()       { return this.state.axis }
+  get stepSize()   { return this.state.stepSize }
+  set stepSize(v)  { this.state.stepSize = v }
+
+  // ── Public operation lifecycle ─────────────────────────────────────────────
+
+  /**
+   * Centralised guard for any UI rotation entry point.
+   * Returns true and shows a toast when the frame must not be rotated because
+   * it is part of a fixed-joint source chain.
+   *
+   * @param {import('../../domain/CoordinateFrame.js').CoordinateFrame} frame
+   * @returns {boolean} true = blocked (caller should return early)
+   */
+  isFastenedRotationBlocked(frame) {
+    if (!this._ctrl._service.isInFixedJointSourceChain(frame.id)) return false
+    this._ctrl._uiView.showToast(
+      'This frame is part of a fixed-joint constraint chain. Unfasten it first to rotate it independently.',
+      { type: 'warn' },
+    )
+    return true
+  }
+
+  /**
+   * Starts rotate mode for the active CoordinateFrame or Solid.
+   * @param {boolean} [deferStartAngle=false] Mobile: capture start angle on first touch
+   */
+  start(deferStartAngle = false) {
+    const { _ctrl: ctrl } = this
+    const obj = ctrl._activeObj
+    if (!(obj instanceof CoordinateFrame) && !(obj instanceof Solid)) return
+
+    // Domain guards with user feedback — run before state transition
+    if (obj instanceof CoordinateFrame) {
+      if (!RoleService.canEdit(obj)) {
+        ctrl._uiView.showToast(`This frame was declared by a ${obj.declaredBy}. Switch to that role to edit it.`, { type: 'warn' })
+        return
+      }
+      if (this.isFastenedRotationBlocked(obj)) return
+    } else {
+      if (ctrl._service.hasFastenedChild(obj.id)) {
+        ctrl._uiView.showToast('This object is held by a fastened constraint. Unfasten it first to move it independently.', { type: 'warn' })
+        return
+      }
+    }
+
+    if (!ctrl._opState.send('BEGIN_ROTATE')) return
+
+    const s = this.state
+    s.axis     = null
+    s.inputStr = ''
+    s.hasInput = false
+
+    let projected
+    if (obj instanceof CoordinateFrame) {
+      s.startRot.copy(obj.rotation)
+      s.segmentStartRot.copy(obj.rotation)
+      projected = (ctrl._service.worldPoseOf(obj.id)?.position ?? obj.translation).clone().project(ctrl._camera)
+    } else {
+      s.startOrientation    = obj.orientation.clone()
+      s.startPos            = obj._position.clone()
+      s.segStartOrientation = obj.orientation.clone()
+      s.segStartPos         = obj._position.clone()
+      const pivot = obj._position.clone()
+      s.segStartPivot       = pivot.clone()
+      projected = pivot.clone().project(ctrl._camera)
+      obj.meshView.boxHelper.visible = false
+    }
+
+    if (deferStartAngle) {
+      s.needsStartAngle   = true
+      s.startAngle        = 0
+      s.segmentStartAngle = 0
+      s.prevCurrentAngle  = 0
+      s.accumulatedAngle  = 0
+    } else {
+      s.startAngle = Math.atan2(
+        ctrl._mouse.y - projected.y,
+        ctrl._mouse.x - projected.x,
+      )
+      s.segmentStartAngle = s.startAngle
+      s.prevCurrentAngle  = s.startAngle
+      s.accumulatedAngle  = 0
+      s.needsStartAngle   = false
+    }
+
+    this.refreshSectorPreview()
+    ctrl._controls.enabled = false
+    this.updateStatus()
+    if (window.matchMedia('(pointer: coarse)').matches) ctrl._updateMobileToolbar()
+  }
+
+  /**
+   * Confirms the current rotation and exits rotate mode.
+   */
+  confirm() {
+    const { _ctrl: ctrl } = this
+    if (!ctrl._opState.is(S_ROTATE_ACTIVE)) return
+    this.apply()
+    const s = this.state
+
+    if (ctrl._activeObj instanceof CoordinateFrame) {
+      const frame = ctrl._activeObj
+      const endQuat = frame.rotation.clone()
+      if (!endQuat.equals(s.startRot)) {
+        const cmd = createFrameRotateCommand(
+          frame, s.startRot.clone(), endQuat, ctrl._service,
+          () => ctrl._updateNPanel(),
+        )
+        ctrl._commandStack.push(cmd)
+      }
+    } else if (ctrl._activeObj instanceof Solid && s.startOrientation) {
+      const solid = ctrl._activeObj
+      if (!solid.orientation.equals(s.startOrientation)) {
+        const cmd = createSolidRotateCommand(
+          solid,
+          s.startOrientation.clone(), solid.orientation.clone(),
+          s.startPos.clone(),         solid._position.clone(),
+          ctrl._service, () => ctrl._updateNPanel(),
+        )
+        ctrl._commandStack.push(cmd)
+      }
+    }
+
+    if (ctrl._activeObj instanceof Solid) ctrl._activeObj.meshView.setObjectSelected(true)
+    this._resetState()
+    ctrl._rotateSectorPreview.hide()
+    ctrl._opState.send('CONFIRM')
+    ctrl._controls.enabled = true
+    ctrl._refreshObjectModeStatus()
+    ctrl._updateNPanel()
+    ctrl._hideAxisGuide()
+    if (window.matchMedia('(pointer: coarse)').matches) ctrl._updateMobileToolbar()
+  }
+
+  /**
+   * Cancels the rotation, restoring the object to its saved state.
+   */
+  cancel() {
+    const { _ctrl: ctrl } = this
+    if (!ctrl._opState.is(S_ROTATE_ACTIVE)) return
+    const s   = this.state
+    const obj = ctrl._activeObj
+    if (obj instanceof CoordinateFrame) {
+      obj.rotation.copy(s.startRot)
+      const parentWorldQuat = ctrl._service._getParentWorldQuat(obj)
+      obj.meshView.updateRotation(parentWorldQuat.clone().multiply(obj.rotation))
+    } else if (obj instanceof Solid && s.startOrientation) {
+      obj.restorePose(s.startPos, s.startOrientation)
+      obj.meshView.updateGeometry(obj.corners)
+      obj.meshView.setObjectSelected(true)
+    }
+    this._resetState()
+    ctrl._rotateSectorPreview.hide()
+    ctrl._opState.send('CANCEL')
+    ctrl._controls.enabled = true
+    ctrl._hideAxisGuide()
+    ctrl._refreshObjectModeStatus()
+    if (window.matchMedia('(pointer: coarse)').matches) ctrl._updateMobileToolbar()
+  }
+
+  /**
+   * Sets the world-axis constraint for the current rotation.
+   * Toggling the same axis clears the constraint (free rotation).
+   * @param {'x'|'y'|'z'} axis
+   */
+  setAxis(axis) {
+    const { _ctrl: ctrl } = this
+    const s  = this.state
+    s.axis     = (s.axis === axis) ? null : axis
+    s.inputStr = ''
+    s.hasInput = false
+    const obj  = ctrl._activeObj
+
+    // Re-snapshot current orientation/pivot as new segment start so accumulated
+    // rotation from the prior axis constraint is preserved (mirrors _setGrabAxis()
+    // segmentStart re-snapshot pattern).
+    if (obj instanceof CoordinateFrame) {
+      s.segmentStartRot.copy(obj.rotation)
+    } else if (obj instanceof Solid) {
+      s.segStartOrientation = obj.orientation.clone()
+      s.segStartPos         = obj._position.clone()
+      s.segStartPivot       = obj._position.clone()
+    }
+
+    let projected
+    let rotCenter = null
+    if (obj instanceof CoordinateFrame) {
+      rotCenter = ctrl._service.worldPoseOf(obj.id)?.position ?? obj.translation
+      projected = rotCenter.clone().project(ctrl._camera)
+    } else if (obj instanceof Solid && s.segStartPivot) {
+      rotCenter = s.segStartPivot
+      projected = rotCenter.clone().project(ctrl._camera)
+    }
+    if (projected) {
+      s.startAngle = Math.atan2(
+        ctrl._mouse.y - projected.y,
+        ctrl._mouse.x - projected.x,
+      )
+    }
+    s.segmentStartAngle = s.startAngle
+    s.prevCurrentAngle  = s.startAngle
+    s.accumulatedAngle  = 0
+    s.displayAngle      = 0
+
+    if (s.axis && rotCenter) {
+      ctrl._showAxisGuide(s.axis, rotCenter.clone(), 'rotate')
+    } else {
+      ctrl._hideAxisGuide()
+    }
+    this.refreshSectorPreview()
+    this.apply()
+    this.updateStatus()
+    if (window.matchMedia('(pointer: coarse)').matches) ctrl._updateMobileToolbar()
+  }
+
+  /**
+   * Applies the current rotation delta to the active CoordinateFrame or Solid.
+   * Called on every pointer move and on numeric input changes.
+   */
+  apply() {
+    const { _ctrl: ctrl } = this
+    const s   = this.state
+    const obj = ctrl._activeObj
+    if (!ctrl._opState.is(S_ROTATE_ACTIVE)) return
+    if (!(obj instanceof CoordinateFrame) && !(obj instanceof Solid)) return
+
+    let angle
+    if (s.hasInput) {
+      const parsed = parseFloat(s.inputStr)
+      angle = isNaN(parsed) ? 0 : parsed * (Math.PI / 180)
+    } else {
+      let pivotScreen
+      if (obj instanceof CoordinateFrame) {
+        pivotScreen = (ctrl._service.worldPoseOf(obj.id)?.position ?? obj.translation).clone().project(ctrl._camera)
+      } else {
+        pivotScreen = (s.segStartPivot ?? obj._position.clone()).clone().project(ctrl._camera)
+      }
+      const currentAngle = Math.atan2(
+        ctrl._mouse.y - pivotScreen.y,
+        ctrl._mouse.x - pivotScreen.x,
+      )
+      if (s.needsStartAngle) {
+        s.prevCurrentAngle = currentAngle
+        s.accumulatedAngle = 0
+        s.needsStartAngle  = false
+        return
+      }
+      let delta = currentAngle - s.prevCurrentAngle
+      if (delta > Math.PI)  delta -= 2 * Math.PI
+      if (delta < -Math.PI) delta += 2 * Math.PI
+      s.accumulatedAngle += delta
+      s.prevCurrentAngle  = currentAngle
+      angle = s.accumulatedAngle
+      if (ctrl._ctrlHeld) {
+        const stepRad = s.stepSize * (Math.PI / 180)
+        angle = Math.round(angle / stepRad) * stepRad
+      }
+    }
+
+    let axisVec
+    if (s.axis === 'x') axisVec = new THREE.Vector3(1, 0, 0)
+    else if (s.axis === 'y') axisVec = new THREE.Vector3(0, 1, 0)
+    else if (s.axis === 'z') axisVec = new THREE.Vector3(0, 0, 1)
+    else {
+      axisVec = new THREE.Vector3()
+      ctrl._camera.getWorldDirection(axisVec).negate()
+    }
+
+    // Sign correction for pointer-driven axis-constrained rotation (see CODE_CONTRACTS).
+    if (!s.hasInput && s.axis) {
+      const camFwd = new THREE.Vector3()
+      ctrl._camera.getWorldDirection(camFwd)
+      if (camFwd.dot(axisVec) > 0) angle = -angle
+    }
+
+    const deltaQ = new THREE.Quaternion().setFromAxisAngle(axisVec, angle)
+    ctrl._service.applyPreviewRotation(obj, {
+      segStartOrientation: obj instanceof CoordinateFrame
+        ? s.segmentStartRot
+        : s.segStartOrientation,
+      segStartPos: s.segStartPos,
+      pivot: s.segStartPivot ?? obj._position.clone(),
+    }, deltaQ)
+    s.displayAngle = angle
+    this.updateStatus()
+    ctrl._rotateSectorPreview.updateAngle(angle)
+  }
+
+  /**
+   * (Re)creates the 3D sector preview at the pivot with the current axis orientation.
+   */
+  refreshSectorPreview() {
+    const { _ctrl: ctrl } = this
+    const obj = ctrl._activeObj
+    if (!obj) return
+    const s = this.state
+
+    let center, radius
+    if (obj instanceof Solid) {
+      center = (s.segStartPivot ?? obj._position).clone()
+      const raw = Math.max(...obj.corners.map(c => c.distanceTo(center)))
+      radius = Math.max(raw, 0.5) * 1.1
+    } else if (obj instanceof CoordinateFrame) {
+      center = (ctrl._service.worldPoseOf(obj.id)?.position ?? obj.translation).clone()
+      radius = 0.8
+    } else {
+      return
+    }
+
+    ctrl._rotateSectorPreview.show(center, radius, s.axis, ctrl._camera)
+  }
+
+  /**
+   * Updates the status bar text to reflect the current rotate operation.
+   */
+  updateStatus() {
+    const { _ctrl: ctrl } = this
+    const s = this.state
+    const AXIS_COLORS = { x: '#e05252', y: '#6ab04c', z: '#4a9eed' }
+    const parts = [{ text: 'Rotate', bold: true, color: '#80b3ff' }]
+
+    if (s.axis) {
+      parts.push({ text: s.axis.toUpperCase(), bold: true, color: AXIS_COLORS[s.axis] })
+    }
+    if (s.hasInput) {
+      parts.push({ text: s.inputStr + '°_', color: '#ffeb3b' })
+    } else {
+      const deg = (s.displayAngle * 180 / Math.PI).toFixed(1)
+      parts.push({ text: `${deg}°`, color: '#546e7a' })
+      if (ctrl._ctrlHeld) {
+        parts.push({ text: `Step: ${s.stepSize}°`, bold: true, color: '#80cbc4' })
+        parts.push({ text: 'Scroll to change', color: '#444' })
+      }
+    }
+    parts.push({ text: 'Enter confirm  Esc cancel', color: '#444' })
+    ctrl._uiView.setStatusRich(parts)
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────────
+
+  _resetState() {
+    const s = this.state
+    s.axis                = null
+    s.inputStr            = ''
+    s.hasInput            = false
+    s.startOrientation    = null
+    s.startPos            = null
+    s.segStartOrientation = null
+    s.segStartPos         = null
+    s.segStartPivot       = null
+    s.needsStartAngle     = false
+  }
+}

--- a/src/controller/map/MapModeController.js
+++ b/src/controller/map/MapModeController.js
@@ -1,0 +1,827 @@
+/**
+ * MapModeController — owns all 2D Map Mode state and interaction logic.
+ *
+ * Entered via the "Map" header button. Uses an orthographic top-down camera
+ * for distortion-free 2D placement of AnnotatedLine / AnnotatedRegion /
+ * AnnotatedPoint entities.
+ *
+ * Three-state drawing model (ADR-031 §1):
+ *   idle     → no gesture in progress; tool may or may not be selected
+ *   drawing  → gesture in progress (rubber-band follows cursor)
+ *   pending  → geometry fully defined; static dashed preview; awaiting name + confirm
+ *
+ * Dependencies:
+ *   ctrl — the AppController instance (sceneView, uiView, service, scene, etc.)
+ *          accessed through the parent reference to avoid duplicating injections.
+ */
+
+import * as THREE from 'three'
+import { AnnotatedLine }   from '../../domain/AnnotatedLine.js'
+import { AnnotatedRegion } from '../../domain/AnnotatedRegion.js'
+import { AnnotatedPoint }  from '../../domain/AnnotatedPoint.js'
+import { getPlaceTypeEntry } from '../../domain/PlaceTypeRegistry.js'
+
+export class MapModeController {
+  /**
+   * @param {import('../AppController.js').AppController} ctrl
+   */
+  constructor(ctrl) {
+    this._ctrl = ctrl
+
+    /** @type {object} All mutable map-mode state */
+    this.state = {
+      /** Whether map mode is currently active */
+      active: false,
+      /** Active drawing tool: 'route'|'boundary'|'zone'|'hub'|'anchor'|null */
+      tool:   null,
+      /** 'idle'|'drawing'|'pending' (ADR-031 §1) */
+      drawState: 'idle',
+      /** @type {THREE.Vector3[]} vertex positions collected during drawing */
+      points: [],
+      /** @type {THREE.Vector3[]|null} frozen geometry entered when going pending */
+      pendingPoints: null,
+      /** Default name for the pending entity (e.g. "Route 1") */
+      pendingName: null,
+      /** @type {THREE.Vector3|null} live cursor world position */
+      cursor: null,
+      /** THREE.Line preview drawn while placing */
+      previewLine: null,
+      /** THREE.Mesh cursor dot */
+      cursorDot:   null,
+      /** Panning state */
+      isPanning:   false,
+      panStart:    null,   // { screenX, screenY, camX, camY }
+      /** Current orthographic frustum height (world units) */
+      frustumSize: 50,
+      /**
+       * Mobile drag start: set on pointerdown for Line/Region/Point tools.
+       * Cleared on pointerup.
+       * @type {{ pt: THREE.Vector3, screenX: number, screenY: number }|null}
+       */
+      mobileDragStart: null,
+      /**
+       * Per-type creation counters for default name generation ("Route 1", "Zone 2" …).
+       */
+      nameCounters: { Route: 0, Boundary: 0, Zone: 0, Hub: 0, Anchor: 0 },
+      /**
+       * Snap indicator ring (PC only) — shown at the snap-candidate world position.
+       * @type {THREE.Mesh|null}
+       */
+      snapRingMesh: null,
+      /**
+       * The world position of the active snap candidate (null when not snapping).
+       * @type {THREE.Vector3|null}
+       */
+      snapCandidate: null,
+    }
+  }
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  /** True when map mode is currently active. */
+  get isActive() { return this.state.active }
+
+  /** True when a drawing tool is selected (map pointerdown guard). */
+  get hasTool() { return !!this.state.tool }
+
+  /** Enters 2D Map Mode: switches to orthographic top-down camera, shows map toolbar. */
+  enter() {
+    const { _ctrl: ctrl, state } = this
+    if (state.active) return
+    if (ctrl._scene.selectionMode === 'edit') ctrl.setMode('object')
+    state.active          = true
+    state.tool            = null
+    state.drawState       = 'idle'
+    state.points          = []
+    state.pendingPoints   = null
+    state.pendingName     = null
+    state.cursor          = null
+    state.mobileDragStart = null
+    state.isPanning       = false
+    ctrl._sceneView.useOrthoCamera(true, state.frustumSize)
+    ctrl._uiView.setCursor('default')
+    ctrl._uiView.setStatus('Map Mode — select a type on the left to start drawing')
+    this._refreshToolbar()
+    ctrl._updateMobileToolbar()
+  }
+
+  /** Exits 2D Map Mode: restores perspective camera, removes map toolbar. */
+  exit() {
+    const { _ctrl: ctrl, state } = this
+    this._cancelDrawing()
+    state.active     = false
+    state.isPanning  = false
+    ctrl._sceneView.useOrthoCamera(false)
+    ctrl._uiView.hideMapToolbar()
+    ctrl._uiView.setCursor('default')
+    ctrl._refreshObjectModeStatus()
+    ctrl._updateMobileToolbar()
+  }
+
+  /**
+   * Handles wheel zoom event in map mode.
+   * @param {WheelEvent} e
+   * @returns {boolean} true if event was consumed
+   */
+  onWheel(e) {
+    if (!this.state.active) return false
+    e.preventDefault()
+    const factor = e.deltaY > 0 ? 1.15 : 1 / 1.15
+    this.state.frustumSize = Math.max(2, Math.min(500, this.state.frustumSize * factor))
+    this._ctrl._sceneView.setOrthoZoom(this.state.frustumSize)
+    return true
+  }
+
+  /**
+   * Handles pointermove in map mode (pan + drawing preview).
+   * @param {PointerEvent} e
+   * @returns {boolean} true if event was consumed
+   */
+  onPointerMove(e) {
+    const { state } = this
+    if (!state.active) return false
+
+    if (state.isPanning && state.panStart) {
+      const { frustumSize } = state
+      const aspect = innerWidth / innerHeight
+      const dx = (e.clientX - state.panStart.screenX) * (frustumSize * aspect / innerWidth)
+      const dy = (e.clientY - state.panStart.screenY) * (frustumSize / innerHeight)
+      this._ctrl._sceneView.panOrthoCamera(
+        state.panStart.camX - dx,
+        state.panStart.camY + dy,
+      )
+      return true
+    }
+
+    // Update preview in drawing state only; pending shows frozen dashed preview
+    if (state.tool && state.drawState === 'drawing') {
+      const pt = this._pickPoint(e)
+      state.cursor = pt
+      this._updatePreview()
+    }
+    return true
+  }
+
+  /**
+   * Handles pointerdown in map mode (pan start + drawing clicks).
+   * @param {PointerEvent} e
+   * @returns {boolean} true if event was consumed
+   */
+  onPointerDown(e) {
+    const { _ctrl: ctrl, state } = this
+    if (!state.active) return false
+
+    // Pan: middle button OR left button with no tool selected
+    if (e.button === 1 || (e.button === 0 && !state.tool)) {
+      state.isPanning = true
+      const cam = ctrl._sceneView.activeCamera
+      state.panStart = {
+        screenX: e.clientX, screenY: e.clientY,
+        camX: cam.position.x, camY: cam.position.y,
+      }
+      ctrl._uiView.setCursor('grabbing')
+      ctrl._activeDragPointerId = e.pointerId
+      return true
+    }
+
+    if (e.button === 0 && state.tool) {
+      const { drawState } = state
+
+      // In pending state: LMB on canvas confirms (keyboard-free fallback)
+      if (drawState === 'pending') {
+        this._confirmDrawing()
+        return true
+      }
+
+      const pt       = this._pickPoint(e)
+      const geometry = this._geometryForType(state.tool)
+
+      if (this._isMobile()) {
+        // Mobile: single drag gesture for all types (ADR-031 §2)
+        state.mobileDragStart = { pt: pt.clone(), screenX: e.clientX, screenY: e.clientY }
+        state.cursor          = pt.clone()
+        ctrl._activeDragPointerId = e.pointerId
+        this._updatePreview()
+        return true
+      }
+
+      // PC interaction
+      if (geometry === 'point') {
+        this._enterPendingState([pt])
+        return true
+      }
+
+      if (geometry === 'region') {
+        // Drag-to-rectangle: record drag start; pointerup enters pending
+        state.mobileDragStart = { pt: pt.clone(), screenX: e.clientX, screenY: e.clientY }
+        state.cursor          = pt.clone()
+        ctrl._activeDragPointerId = e.pointerId
+        const typeLabel = this._placeTypeForType(state.tool)
+        ctrl._uiView.setStatusRich([
+          { text: typeLabel, bold: true, color: '#80cbc4' },
+          { text: 'drag to draw rectangle', color: '#888' },
+          { text: '  ESC cancel', color: '#444' },
+        ])
+        return true
+      }
+
+      // Line (PC): each click adds a vertex; Enter/RMB transitions to pending
+      state.points.push(pt.clone())
+      state.cursor = pt.clone()
+      this._updatePreview()
+      this._updateStatus()
+      return true
+    }
+
+    if (e.button === 2 && state.tool) {
+      const { drawState, points, tool: currentTool } = state
+      if (drawState === 'pending') {
+        // RMB in pending → cancel back to drawing (re-select same tool)
+        this._cancelDrawing()
+        if (currentTool) this._setTool(currentTool)
+        return true
+      }
+      // RMB in drawing: for PC Line with ≥2 pts → enter pending; else cancel
+      const geometry = this._geometryForType(state.tool)
+      if (geometry === 'line' && points.length >= 2) {
+        this._enterPendingState(points)
+      } else {
+        this._cancelDrawing()
+      }
+      return true
+    }
+
+    return true  // always consume while map mode is active
+  }
+
+  /**
+   * Handles pointerup in map mode (end pan + drag gesture completion).
+   * @param {PointerEvent} e
+   * @returns {boolean} true if event was consumed
+   */
+  onPointerUp(e) {
+    const { _ctrl: ctrl, state } = this
+    if (!state.active) return false
+
+    if (state.isPanning) {
+      if (ctrl._activeDragPointerId === e.pointerId) {
+        ctrl._activeDragPointerId = null
+        state.isPanning  = false
+        state.panStart   = null
+        ctrl._uiView.setCursor(state.tool ? 'crosshair' : 'default')
+      }
+      return true
+    }
+
+    if (state.mobileDragStart && ctrl._activeDragPointerId === e.pointerId) {
+      const { pt: startPt, screenX: sx, screenY: sy } = state.mobileDragStart
+      state.mobileDragStart             = null
+      ctrl._activeDragPointerId         = null
+
+      const savedTool = state.tool
+      if (!savedTool) return true
+
+      const pt       = this._pickPoint(e)
+      const geometry = this._geometryForType(savedTool)
+      const moved    = Math.hypot(e.clientX - sx, e.clientY - sy)
+
+      if (geometry === 'point') {
+        this._enterPendingState([startPt])
+        return true
+      }
+
+      if (geometry === 'line') {
+        if (moved < 8) {
+          this._cancelDrawing()
+          this._setTool(savedTool)
+          return true
+        }
+        this._enterPendingState([startPt, pt])
+        return true
+      }
+
+      if (geometry === 'region') {
+        if (moved < 8) {
+          this._cancelDrawing()
+          this._setTool(savedTool)
+          return true
+        }
+        const p1 = startPt
+        const p2 = state.cursor ?? pt
+        this._enterPendingState([
+          new THREE.Vector3(p1.x, p1.y, 0),
+          new THREE.Vector3(p2.x, p1.y, 0),
+          new THREE.Vector3(p2.x, p2.y, 0),
+          new THREE.Vector3(p1.x, p2.y, 0),
+        ])
+        return true
+      }
+    }
+
+    return false
+  }
+
+  /**
+   * Handles keydown in map mode (Escape / Enter).
+   * @param {KeyboardEvent} e
+   * @returns {boolean} true if event was consumed
+   */
+  onKeyDown(e) {
+    const { state } = this
+    if (!state.active) return false
+
+    const { drawState, tool } = state
+
+    if (e.key === 'Escape') {
+      if (drawState === 'pending') {
+        const savedTool = tool
+        this._cancelDrawing()
+        if (savedTool) this._setTool(savedTool)
+      } else if (tool) {
+        this._cancelDrawing()
+      } else {
+        this.exit()
+      }
+      return true
+    }
+
+    if (e.key === 'Enter' && tool) {
+      if (drawState === 'pending') {
+        this._confirmDrawing()
+      } else {
+        const geometry = this._geometryForType(tool)
+        if (geometry === 'line' && state.points.length >= 2) {
+          this._enterPendingState(state.points)
+        }
+      }
+      return true
+    }
+
+    return true  // consume all keys while map mode is active
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────────────
+
+  /** Returns true when running on a coarse-pointer (touch) device. */
+  _isMobile() {
+    return window.matchMedia('(pointer: coarse)').matches
+  }
+
+  /**
+   * Returns the geometry kind for a place-type drawing tool.
+   * @param {string} type
+   * @returns {'line'|'region'|'point'}
+   */
+  _geometryForType(type) {
+    if (type === 'zone') return 'region'
+    if (type === 'hub' || type === 'anchor') return 'point'
+    return 'line'
+  }
+
+  /** Returns the place type name capitalised from a tool type string. */
+  _placeTypeForType(type) {
+    return type.charAt(0).toUpperCase() + type.slice(1)
+  }
+
+  /**
+   * Sets the active map drawing tool, resetting to drawing state.
+   * @param {string} type  PlaceType name lowercase: 'route'|'boundary'|'zone'|'hub'|'anchor'
+   */
+  _setTool(type) {
+    this._cancelDrawing()
+    const { state } = this
+    state.tool          = type
+    state.drawState     = 'drawing'
+    state.points        = []
+    state.pendingPoints = null
+    state.pendingName   = null
+    state.cursor        = null
+    this._ctrl._uiView.setCursor('crosshair')
+    this._refreshToolbar()
+    this._updateStatus()
+  }
+
+  /** Cancels the current drawing without creating an entity. */
+  _cancelDrawing() {
+    this._clearPreview()
+    const { state } = this
+    state.tool            = null
+    state.drawState       = 'idle'
+    state.points          = []
+    state.pendingPoints   = null
+    state.pendingName     = null
+    state.cursor          = null
+    state.mobileDragStart = null
+    state.snapCandidate   = null
+    this._ctrl._uiView.setCursor('default')
+    this._refreshToolbar()
+    if (state.active) {
+      this._ctrl._uiView.setStatus('Map Mode — select a type on the left to start drawing')
+    }
+  }
+
+  /**
+   * Transitions from drawing → pending state.
+   * @param {THREE.Vector3[]} points  the completed geometry vertices
+   */
+  _enterPendingState(points) {
+    const { state } = this
+    if (!state.tool) return
+    const placeType = this._placeTypeForType(state.tool)
+    const n = ++state.nameCounters[placeType]
+    state.drawState     = 'pending'
+    state.pendingPoints = points.map(p => p.clone())
+    state.pendingName   = `${placeType} ${n}`
+    state.cursor        = null
+    state.snapCandidate = null
+    this._clearPreview()
+    this._showPendingPreview()
+    this._refreshToolbar()
+    this._ctrl._uiView.setStatusRich([
+      { text: placeType, bold: true, color: '#80cbc4' },
+      { text: '— enter a name and confirm', color: '#888' },
+      { text: '  ESC = cancel', color: '#444' },
+    ])
+  }
+
+  /**
+   * Confirms the pending entity.
+   * Must only be called while drawState === 'pending'.
+   */
+  _confirmDrawing() {
+    const { _ctrl: ctrl, state } = this
+    const { tool, pendingPoints, pendingName } = state
+    if (!tool || !pendingPoints) return
+
+    const geometry  = this._geometryForType(tool)
+    const placeType = this._placeTypeForType(tool)
+    const renderer  = ctrl._sceneView.renderer
+
+    const name = ctrl._uiView.getMapPendingName() ?? pendingName ?? placeType
+
+    let created = false
+    try {
+      if (geometry === 'point' && pendingPoints.length >= 1) {
+        const obj = ctrl._service.createAnnotatedPoint(pendingPoints[0], name, {
+          camera: ctrl._sceneView.camera, renderer, container: document.body,
+        })
+        ctrl._service.setPlaceType(obj.id, placeType)
+        created = true
+      } else if (geometry === 'line' && pendingPoints.length >= 2) {
+        const obj = ctrl._service.createAnnotatedLine(pendingPoints, name, {
+          camera: ctrl._sceneView.camera, renderer, container: document.body,
+        })
+        ctrl._service.setPlaceType(obj.id, placeType)
+        created = true
+      } else if (geometry === 'region' && pendingPoints.length >= 3) {
+        const obj = ctrl._service.createAnnotatedRegion(pendingPoints, name, {
+          camera: ctrl._sceneView.camera, renderer, container: document.body,
+        })
+        ctrl._service.setPlaceType(obj.id, placeType)
+        created = true
+      }
+    } catch (err) {
+      console.error('[MapMode] entity creation failed:', err)
+    } finally {
+      this._clearPreview()
+      state.drawState     = 'drawing'
+      state.points        = []
+      state.pendingPoints = null
+      state.pendingName   = null
+      state.cursor        = null
+      this._refreshToolbar()
+    }
+
+    if (created) {
+      ctrl._uiView.setStatus(`Map Mode — ${placeType} placed. Draw another or select a different type.`)
+    }
+  }
+
+  /** Removes preview line, cursor dot, and snap ring from the Three.js scene. */
+  _clearPreview() {
+    const scene = this._ctrl._sceneView.scene
+    const state = this.state
+    if (state.previewLine) {
+      scene.remove(state.previewLine)
+      state.previewLine.geometry.dispose()
+      state.previewLine.material.dispose()
+      state.previewLine = null
+    }
+    if (state.cursorDot) {
+      scene.remove(state.cursorDot)
+      state.cursorDot.geometry.dispose()
+      state.cursorDot.material.dispose()
+      state.cursorDot = null
+    }
+    if (state.snapRingMesh) {
+      scene.remove(state.snapRingMesh)
+      state.snapRingMesh.geometry.dispose()
+      state.snapRingMesh.material.dispose()
+      state.snapRingMesh = null
+    }
+    state.snapCandidate = null
+  }
+
+  /**
+   * Picks the ground-plane (Z=0) world position under the pointer in Map Mode.
+   * Applies grid snapping (1-unit grid) then, on PC only, endpoint snapping.
+   * @param {PointerEvent|MouseEvent} e
+   * @returns {THREE.Vector3}
+   */
+  _pickPoint(e) {
+    const ctrl = this._ctrl
+    const ndcX =  (e.clientX / innerWidth)  * 2 - 1
+    const ndcY = -(e.clientY / innerHeight) * 2 + 1
+    ctrl._raycaster.setFromCamera(new THREE.Vector2(ndcX, ndcY), ctrl._sceneView.activeCamera)
+    const pt = new THREE.Vector3()
+    ctrl._raycaster.ray.intersectPlane(ctrl._groundPlane, pt)
+    pt.z = 0
+
+    const GRID = 1.0
+    pt.x = Math.round(pt.x / GRID) * GRID
+    pt.y = Math.round(pt.y / GRID) * GRID
+
+    if (!this._isMobile()) {
+      const { snapped, point } = this._snapToEndpoint(pt, e.clientX, e.clientY)
+      this.state.snapCandidate = snapped
+      return point
+    }
+
+    this.state.snapCandidate = null
+    return pt
+  }
+
+  /**
+   * Snaps a grid-snapped world point to a nearby annotated entity vertex (PC only).
+   * @param {THREE.Vector3} gridPt
+   * @param {number} screenX
+   * @param {number} screenY
+   * @param {number} [snapPx=20]
+   * @returns {{ snapped: THREE.Vector3|null, point: THREE.Vector3 }}
+   */
+  _snapToEndpoint(gridPt, screenX, screenY, snapPx = 20) {
+    const ctrl = this._ctrl
+    const cam  = ctrl._sceneView.activeCamera
+    let bestDist = snapPx
+    let bestPt   = null
+
+    for (const obj of ctrl._scene.objects.values()) {
+      const verts = (obj instanceof AnnotatedLine || obj instanceof AnnotatedRegion || obj instanceof AnnotatedPoint)
+        ? obj.vertices.map(v => v.position)
+        : null
+      if (!verts) continue
+
+      for (const vert of verts) {
+        const sv = ctrl._projectToScreen(vert, cam)
+        const d  = Math.hypot(screenX - sv.x, screenY - sv.y)
+        if (d < bestDist) { bestDist = d; bestPt = vert.clone() }
+      }
+    }
+
+    return bestPt
+      ? { snapped: bestPt, point: bestPt }
+      : { snapped: null,   point: gridPt }
+  }
+
+  /**
+   * Updates the live preview during map drawing (drawing state only).
+   * In pending state use _showPendingPreview() instead.
+   */
+  _updatePreview() {
+    const { state } = this
+    const { tool, points, cursor, mobileDragStart, drawState } = state
+    if (!tool || drawState !== 'drawing') return
+    if (!cursor) return
+
+    const scene    = this._ctrl._sceneView.scene
+    const geometry = this._geometryForType(tool)
+    const entry    = getPlaceTypeEntry(this._placeTypeForType(tool))
+    const color    = entry ? parseInt(entry.color.slice(1), 16) : 0x80cbc4
+
+    // Cursor dot — shown only in drawing state
+    if (!state.cursorDot) {
+      const g = new THREE.SphereGeometry(0.08, 8, 8)
+      const m = new THREE.MeshBasicMaterial({ color, depthTest: false })
+      state.cursorDot = new THREE.Mesh(g, m)
+      state.cursorDot.renderOrder = 3
+      scene.add(state.cursorDot)
+    }
+    state.cursorDot.position.copy(cursor)
+    state.cursorDot.material.color.setHex(color)
+
+    this._updateSnapRing(state.snapCandidate, color)
+
+    let previewPts = null
+
+    if (geometry === 'region' && mobileDragStart) {
+      const p1 = mobileDragStart.pt
+      const p2 = cursor
+      previewPts = [
+        new THREE.Vector3(p1.x, p1.y, 0),
+        new THREE.Vector3(p2.x, p1.y, 0),
+        new THREE.Vector3(p2.x, p2.y, 0),
+        new THREE.Vector3(p1.x, p2.y, 0),
+        new THREE.Vector3(p1.x, p1.y, 0),
+      ]
+    } else if (geometry === 'line' && mobileDragStart) {
+      previewPts = [mobileDragStart.pt, cursor]
+    } else if (geometry !== 'point' && points.length > 0) {
+      previewPts = [...points, cursor]
+      if (geometry === 'region' && previewPts.length >= 3) previewPts.push(previewPts[0])
+    }
+
+    if (previewPts) {
+      const flat = []
+      for (const p of previewPts) flat.push(p.x, p.y, p.z)
+
+      if (!state.previewLine) {
+        const geo = new THREE.BufferGeometry()
+        const mat = new THREE.LineBasicMaterial({
+          color, depthTest: false, transparent: true, opacity: 0.70,
+        })
+        state.previewLine = new THREE.Line(geo, mat)
+        state.previewLine.renderOrder = 2
+        scene.add(state.previewLine)
+      }
+      state.previewLine.geometry.setAttribute(
+        'position', new THREE.Float32BufferAttribute(new Float32Array(flat), 3),
+      )
+      state.previewLine.geometry.attributes.position.needsUpdate = true
+      state.previewLine.material.color.setHex(color)
+    } else if (state.previewLine) {
+      scene.remove(state.previewLine)
+      state.previewLine.geometry.dispose()
+      state.previewLine.material.dispose()
+      state.previewLine = null
+    }
+  }
+
+  /**
+   * Creates or updates the static dashed preview for the pending state (ADR-031 §3).
+   */
+  _showPendingPreview() {
+    const { state } = this
+    const { tool, pendingPoints } = state
+    if (!tool || !pendingPoints) return
+
+    const scene    = this._ctrl._sceneView.scene
+    const geometry = this._geometryForType(tool)
+    const entry    = getPlaceTypeEntry(this._placeTypeForType(tool))
+    const color    = entry ? parseInt(entry.color.slice(1), 16) : 0x80cbc4
+
+    if (state.cursorDot) {
+      scene.remove(state.cursorDot)
+      state.cursorDot.geometry.dispose()
+      state.cursorDot.material.dispose()
+      state.cursorDot = null
+    }
+    this._updateSnapRing(null, color)
+
+    let previewPts = [...pendingPoints]
+    if (geometry === 'region' && previewPts.length >= 3) previewPts.push(previewPts[0])
+
+    if (previewPts.length < 2) {
+      if (state.previewLine) {
+        scene.remove(state.previewLine)
+        state.previewLine.geometry.dispose()
+        state.previewLine.material.dispose()
+        state.previewLine = null
+      }
+      if (previewPts.length === 1) {
+        const g = new THREE.SphereGeometry(0.15, 12, 12)
+        const m = new THREE.MeshBasicMaterial({ color, depthTest: false, transparent: true, opacity: 0.85 })
+        const dot = new THREE.Mesh(g, m)
+        dot.position.copy(previewPts[0])
+        dot.renderOrder = 3
+        scene.add(dot)
+        state.previewLine = dot
+      }
+      return
+    }
+
+    const flat = []
+    for (const p of previewPts) flat.push(p.x, p.y, p.z)
+
+    if (state.previewLine) {
+      scene.remove(state.previewLine)
+      state.previewLine.geometry.dispose()
+      state.previewLine.material.dispose()
+      state.previewLine = null
+    }
+    const geo = new THREE.BufferGeometry()
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(new Float32Array(flat), 3))
+    const mat = new THREE.LineDashedMaterial({
+      color,
+      dashSize:    0.40,
+      gapSize:     0.20,
+      depthTest:   false,
+      transparent: true,
+      opacity:     0.90,
+    })
+    const line = new THREE.Line(geo, mat)
+    line.computeLineDistances()
+    line.renderOrder = 2
+    scene.add(line)
+    state.previewLine = line
+  }
+
+  /**
+   * Shows or hides the endpoint snap indicator ring (PC only, ADR-031 §6).
+   * @param {THREE.Vector3|null} snapPt
+   * @param {number} color
+   */
+  _updateSnapRing(snapPt, color) {
+    const { state } = this
+    const scene = this._ctrl._sceneView.scene
+
+    if (!snapPt) {
+      if (state.snapRingMesh) state.snapRingMesh.visible = false
+      return
+    }
+
+    if (!state.snapRingMesh) {
+      const geo = new THREE.RingGeometry(0.18, 0.30, 16)
+      const mat = new THREE.MeshBasicMaterial({
+        depthTest:   false,
+        transparent: true,
+        opacity:     0.85,
+        side:        THREE.DoubleSide,
+      })
+      const mesh = new THREE.Mesh(geo, mat)
+      mesh.renderOrder = 5
+      scene.add(mesh)
+      state.snapRingMesh = mesh
+    }
+
+    state.snapRingMesh.visible = true
+    state.snapRingMesh.material.color.setHex(color)
+    state.snapRingMesh.position.copy(snapPt)
+    state.snapRingMesh.position.z = 0
+  }
+
+  /** Updates the status bar text during map drawing. */
+  _updateStatus() {
+    const { state } = this
+    const { tool, points, drawState } = state
+    if (!tool) return
+    if (drawState === 'pending') return
+
+    const geometry  = this._geometryForType(tool)
+    const typeLabel = this._placeTypeForType(tool)
+    const n      = points.length
+    const mobile = this._isMobile()
+
+    if (geometry === 'point') {
+      this._ctrl._uiView.setStatusRich([
+        { text: typeLabel, bold: true, color: '#80cbc4' },
+        { text: mobile ? 'Tap to place' : 'Click to place', color: '#888' },
+        { text: '  ESC cancel', color: '#444' },
+      ])
+    } else if (geometry === 'line') {
+      if (mobile) {
+        this._ctrl._uiView.setStatusRich([
+          { text: typeLabel, bold: true, color: '#80cbc4' },
+          { text: 'Drag to draw a straight line', color: '#888' },
+          { text: '  ESC cancel', color: '#444' },
+        ])
+      } else {
+        this._ctrl._uiView.setStatusRich([
+          { text: typeLabel, bold: true, color: '#80cbc4' },
+          { text: `${n} pts`, color: '#aaa' },
+          { text: 'click to add vertex', color: '#888' },
+          { text: n >= 2 ? '  Enter / RMB = done' : '', color: '#aaa' },
+          { text: '  ESC cancel', color: '#444' },
+        ])
+      }
+    } else {
+      this._ctrl._uiView.setStatusRich([
+        { text: typeLabel, bold: true, color: '#80cbc4' },
+        { text: 'Drag to draw rectangle', color: '#888' },
+        { text: '  ESC cancel', color: '#444' },
+      ])
+    }
+  }
+
+  /**
+   * Rebuilds the Map toolbar to reflect current state.
+   * In pending state: shows name input + Confirm + Cancel.
+   * In drawing state: shows tool buttons + (Confirm if ready) + Cancel.
+   */
+  _refreshToolbar() {
+    const { state } = this
+    if (!state.active) return
+    const { tool, drawState, pendingName } = state
+
+    const isPending  = drawState === 'pending'
+    const canConfirm = isPending
+
+    this._ctrl._uiView.showMapToolbar(
+      tool,
+      (t) => this._setTool(t),
+      canConfirm ? () => this._confirmDrawing() : null,
+      tool       ? () => this._cancelDrawing()  : null,
+      ()         => this.exit(),
+      isPending ? (pendingName ?? '') : null,
+    )
+  }
+}


### PR DESCRIPTION
All 2D Map Mode state and interaction logic (enter/exit, draw tools,
preview rendering, pointer/keyboard handlers, snap ring) moved to
src/controller/map/MapModeController.js.

AppController delegates via this._mapModeCtrl.{enter,exit,onWheel,
onPointerMove,onPointerDown,onPointerUp,onKeyDown} — replacing ~560
lines of inline code with 5 single-line delegate calls.

AppController: 7386 → 6625 lines (-761)
MapModeController: 827 lines (new)