### PR TITLE
fix: restore 7 methods lost in AppController refactoring phases

### DIFF
--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -847,6 +847,176 @@ export class AppController {
     return sum.divideScalar(cs.length)
   }
 
+  /**
+   * Projects a world-space position to CSS pixel coordinates.
+   * @param {import('three').Vector3} position
+   * @param {import('three').Camera} [camera]
+   * @returns {{ x: number, y: number }}
+   */
+  _projectToScreen(position, camera = this._camera) {
+    const v = position.clone().project(camera)
+    return {
+      x: (v.x + 1) / 2 * innerWidth,
+      y: (-v.y + 1) / 2 * innerHeight,
+    }
+  }
+
+  /**
+   * Runs semantic inference after a grab/drag confirms, showing a SpatialLink
+   * suggestion banner when the moved Solid lands near another object (ADR-041).
+   */
+  _runSemanticInference() {
+    if (this._selectedIds.size !== 1) return
+    const [movedId] = this._selectedIds
+    const moved = this._scene.getObject(movedId)
+    if (!(moved instanceof Solid)) return
+
+    const existingPairs = new Set(
+      this._service.getLinks().map(l => `${l.sourceId}|${l.targetId}`),
+    )
+    const suggestions = inferSemanticRelationships(
+      moved, this._scene.objects.values(), existingPairs,
+    )
+    if (suggestions.length === 0) return
+
+    const top    = suggestions[0]
+    const source = this._scene.getObject(top.sourceId)
+    const target = this._scene.getObject(top.targetId)
+    this._uiView.showSemanticSuggestion({
+      sourceId:     top.sourceId,
+      targetId:     top.targetId,
+      semanticType: top.semanticType,
+      label:        top.label,
+      sourceName:   source?.name ?? '?',
+      targetName:   target?.name ?? '?',
+    }, () => {
+      this._linkHandler.createDirect(top.sourceId, top.targetId, top)
+    })
+  }
+
+  /**
+   * Duplicates the active Solid, makes the copy active, and immediately
+   * starts a grab so the user can position it (Blender Shift+D behaviour).
+   */
+  _duplicateObject() {
+    const id = this._scene.activeId
+    if (!id) return
+    if (this._activeObj instanceof SpatialLink) {
+      this._uiView.showToast('SpatialLink cannot be duplicated', { type: 'warn' })
+      return
+    }
+    if (this._scene.selectionMode === 'edit') this.setMode('object')
+    const copy = this._service.duplicateSolid(id)
+    if (!copy) return
+    this._selectedIds.clear()
+    this._selectedIds.add(copy.id)
+    this._switchActiveObject(copy.id, true)
+    this._grabHandler.start()
+  }
+
+  /**
+   * Deletes an entity by id with all safety guards (Origin frame protection,
+   * minimum geometry count, provenance check, dangling-link confirmation).
+   * @param {string} id
+   */
+  _deleteObject(id) {
+    const target = this._scene.getObject(id)
+    if (!target) return
+
+    if (target instanceof CoordinateFrame && target.name === 'Origin') {
+      this._uiView.showToast('Origin frame cannot be deleted', { type: 'warn' })
+      return
+    }
+
+    if (!(target instanceof CoordinateFrame)) {
+      const geometryCount = [...this._scene.objects.values()]
+        .filter(o => !(o instanceof CoordinateFrame)).length
+      if (geometryCount <= 1) {
+        this._uiView.showToast('Scene must contain at least one object', { type: 'warn' })
+        return
+      }
+    }
+
+    if (target instanceof CoordinateFrame && !RoleService.canEdit(target)) {
+      this._uiView.showToast(
+        `This frame was declared by a ${target.declaredBy}. Switch to that role to edit it.`,
+        { type: 'warn' },
+      )
+      return
+    }
+
+    if (target instanceof CoordinateFrame) {
+      const links = this._service.getLinksOf(id)
+      if (links.length > 0) {
+        const n = links.length
+        this._uiView.showConfirmDialog(
+          `Frame "${target.name}" is referenced by ${n} spatial link${n > 1 ? 's' : ''}.\n` +
+          `Deleting it will leave those links dangling. Delete anyway?`,
+          (confirmed) => { if (confirmed) this._execDeleteObject(id, target) },
+          { title: 'Delete Frame', confirmLabel: 'Delete', danger: true },
+        )
+        return
+      }
+    }
+
+    this._execDeleteObject(id, target)
+  }
+
+  /** Performs the actual soft-delete after all guards in _deleteObject have passed. */
+  _execDeleteObject(id, target) {
+    if (!target) target = this._scene.getObject(id)
+    if (!target) return
+
+    if (id === this._scene.activeId && this._scene.selectionMode === 'edit') {
+      this.setMode('object')
+    }
+
+    const wasActive = this._scene.activeId === id
+
+    if (wasActive && target instanceof CoordinateFrame && this._activeFrameChain.size > 0) {
+      this._selMgr.hideFrameChain()
+    }
+    if (wasActive && !(target instanceof CoordinateFrame)) {
+      this._selMgr.setChildFramesVisible(id, false)
+    }
+
+    const nextId = wasActive
+      ? (
+          [...this._scene.objects.entries()].find(
+            ([k, o]) => k !== id && !(o instanceof CoordinateFrame),
+          )?.[0]
+          ?? [...this._scene.objects.keys()].find(k => k !== id)
+          ?? null
+        )
+      : null
+
+    const childrenRefs = [...this._selMgr.collectAllDescendantFrames(id)]
+      .map(fid => this._scene.getObject(fid)).filter(Boolean)
+
+    for (let i = childrenRefs.length - 1; i >= 0; i--) {
+      this._service.detachObject(childrenRefs[i].id)
+    }
+    this._service.detachObject(id)
+    target.meshView.setVisible(false)
+
+    const cmd = createDeleteCommand(
+      target, childrenRefs, this._service,
+      (restoredId) => this._switchActiveObject(restoredId, true),
+      (deletedId) => {
+        const nxt = [...this._scene.objects.entries()]
+          .find(([k, o]) => k !== deletedId && !(o instanceof CoordinateFrame))?.[0]
+          ?? [...this._scene.objects.keys()].find(k => k !== deletedId)
+          ?? null
+        if (nxt) this._switchActiveObject(nxt, true)
+      },
+    )
+    this._commandStack.push(cmd)
+
+    if (wasActive && nextId) {
+      this._switchActiveObject(nextId, true)
+    }
+  }
+
   // ─── Object management ────────────────────────────────────────────────────
 
   /**

--- a/src/controller/handler/GrabOperationHandler.js
+++ b/src/controller/handler/GrabOperationHandler.js
@@ -30,6 +30,7 @@ import {
   collectWorldSnapTargets,
 } from '../../model/CuboidModel.js'
 import { computeApproachWarmth } from '../../service/SemanticInferencer.js'
+import { projectToScreen, pickBestSnapTarget } from '../snap/SnapSystem.js'
 
 /**
  * Returns the appropriate handles array for grab/move operations.
@@ -791,9 +792,9 @@ export class GrabOperationHandler {
     if (!ctrl._raycaster.ray.intersectPlane(s.dragPlane, pt)) return
     let delta = pt.clone().sub(s.startPoint)
     if (s.autoSnap) {
-      delta = ctrl._trySnapToGeometry(delta)
+      delta = this._trySnapToGeometry(delta)
     } else if (ctrl._ctrlHeld) {
-      delta = ctrl._applyGridSnapToDelta(delta)
+      delta = this._applyGridSnapToDelta(delta)
       s.snapping      = false
       s.snappedTarget = null
     } else {
@@ -852,7 +853,7 @@ export class GrabOperationHandler {
 
     if (s.autoSnap) {
       const delta        = new THREE.Vector3().addScaledVector(axisVec, dist)
-      const snappedDelta = ctrl._trySnapToGeometry(delta)
+      const snappedDelta = this._trySnapToGeometry(delta)
       this._applyDeltaToAll(snappedDelta)
     } else if (ctrl._ctrlHeld) {
       s.snapping      = false
@@ -867,5 +868,42 @@ export class GrabOperationHandler {
       const _acDist    = _acTension > 0 ? dist * Math.max(0.15, 1.0 - Math.min(_acTension, 1.0) * 0.85) : dist
       this._applyDeltaToAll(axisVec.clone().multiplyScalar(_acDist))
     }
+  }
+
+  /**
+   * Snaps `delta` to the nearest geometry snap target within SNAP_PX pixels.
+   * Returns a corrected delta pointing at the snap target, or the original delta.
+   */
+  _trySnapToGeometry(delta) {
+    const { _ctrl: ctrl } = this
+    const s = this.state
+    const pivotAfter = s.pivot.clone().add(delta)
+    const pScreen    = projectToScreen(pivotAfter, ctrl._camera)
+
+    const grabbedIds   = new Set(s.allStartCorners.keys())
+    const geoTargets   = collectSnapTargets(ctrl._scene.objects, s.snapMode, grabbedIds)
+    const worldTargets = collectWorldSnapTargets(pivotAfter)
+    const targets      = [...geoTargets, ...worldTargets]
+    s.snapTargets      = targets
+    const bestTarget   = pickBestSnapTarget(targets, pScreen.x, pScreen.y, ctrl._camera)
+
+    if (bestTarget) {
+      s.snapping      = true
+      s.snappedTarget = bestTarget
+      return bestTarget.position.clone().sub(s.pivot)
+    }
+    s.snapping      = false
+    s.snappedTarget = null
+    return delta
+  }
+
+  /** Rounds each component of `delta` to the current grid size. */
+  _applyGridSnapToDelta(delta) {
+    const g = this.state.gridSize
+    return new THREE.Vector3(
+      Math.round(delta.x / g) * g,
+      Math.round(delta.y / g) * g,
+      Math.round(delta.z / g) * g,
+    )
   }
 }


### PR DESCRIPTION
Methods were deleted during Phase 1-A through Phase 3 extraction but their
call sites remained, causing silent TypeError on every invocation.

AppController.js — restored with updated delegation:
  - _projectToScreen()          (MapModeController:575 uses ctrl._projectToScreen)
  - _runSemanticInference()     (ADR-041 post-drag suggestion banner)
  - _duplicateObject()          (Shift+D / context menu / toolbar)
  - _deleteObject()             (Delete key / toolbar / context menu / outliner)
  - _execDeleteObject()         (inner helper for _deleteObject)
  API updates: _createSpatialLinkDirect → _linkHandler.createDirect;
               _startGrab → _grabHandler.start;
               _hideFrameChain/_setChildFramesVisible/_collectAllDescendantFrames
               → this._selMgr.* equivalents (moved to SelectionManager in Phase 2-D)

GrabOperationHandler.js — moved snap helpers from AppController:
  - _trySnapToGeometry()        (snap during free/axis-constrained drag)
  - _applyGridSnapToDelta()     (Ctrl+drag grid snap)
  Callers changed from ctrl._xxx() → this._xxx() since state lives on the handler.
  Added import { projectToScreen, pickBestSnapTarget } from SnapSystem.js.

https://claude.ai/code/session_018wZRENPnK9xpPPxh9o7ZWB