### PR TITLE
ci: bump GitHub Pages workflow to Node 22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       # ubuntu-latest ships with Rust; we just need the wasm32 target + wasm-pack.


### PR DESCRIPTION
Node 20 is deprecated on GitHub Actions runners; the deploy workflow
emitted a deprecation warning. Bump setup-node to Node 22 (active LTS).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012avD9mmXoH8rpgb3oB5nAh