### PR TITLE
feat(robot): TF-tree grounding + selectable skeleton + no-form grasp entry (ADR-085)

### DIFF
--- a/docs/adr/ADR-084-tcp-oriented-ik-entity-grounded-geometry.md
+++ b/docs/adr/ADR-084-tcp-oriented-ik-entity-grounded-geometry.md
@@ -49,6 +49,12 @@
   どちらかを動かしても他方は追従しない (今回はモーション計画のスコープ外、既存の
   `semanticType: "mounts"` 拘束で将来つなぐ余地は残すが今は使わない)。
 
+  > **改訂 (ADR-085, 2026-07-22)**: この「独立2フレーム」簡素化は改訂された。`tcp` は
+  > `robot_base` の **子** (TF ツリー world → robot_base → tcp) となり、base を動かすと
+  > tcp が追従する (TCP はロボット座標系で表現される点、という直感に一致)。cone 基準軸を
+  > TCP 姿勢由来にする本 ADR §3 の狙いはむしろ強化される (回転した base が基準軸を回す)。
+  > 関節/キネマティクスを持たない点は不変。詳細は ADR-085。
+
 Robot ボタン脇の Header X/Y 入力 (ADR-083 実装分) は撤去し、ロボット位置編集は
 既存の CoordinateFrame N-panel 編集 UI に統合する。`uiStore.robotBase` state も
 撤去 (第二の源だったものを正本の domain entity に一本化)。

--- a/docs/adr/ADR-085-robot-tf-tree-selectable-fast-grasp-entry.md
+++ b/docs/adr/ADR-085-robot-tf-tree-selectable-fast-grasp-entry.md
@@ -1,0 +1,134 @@
+# ADR-085: ロボットを TF 親子ツリーで接地し、直接選択可能にし、grasp-search を無フォームで開く
+
+- Status: Accepted (全 3 点 実装済 2026-07-22)
+- Date: 2026-07-22
+- Deciders: yuubae215
+- Supersedes / Superseded by: なし（ADR-084 §2 の「独立2フレーム」簡素化を **改訂** —
+  相互リンク。ADR-084 自体は supersede しない）
+- 関連: ADR-084 (robot base/TCP を CoordinateFrame entity 化・TCP 姿勢基準の cone) /
+  ADR-083 (robot base を grasp 契約に載せる) / ADR-055 (Scene ⇄ Layout DSL 無損失
+  round-trip) / ADR-051 (テンプレギャラリー = New Project) / ADR-018/034 (CoordinateFrame
+  配置ポリシ) / PHILOSOPHY #21 (座標空間の静的区別) / #22 (ヒットテストは狭スコープ優先)
+
+## Context — Goal と力学(§1.2 Goal)
+
+> **Goal: ロボットが「シーンの中の、直接触れて動かせる、正しく座標接地された一体の物」
+> として振る舞い、その掴み判定 (grasp-search) に儀式なしで到達できること。**
+
+オーナーからの 3 点の指摘 = いずれも「ロボットが世界から遊離して感じる」という同じ
+根本の別側面:
+
+1. **grasp-search が遠い**: 現状フォームを地道に埋めて Context を作らないと
+   grasp タブに到達できない。空シーン(初期キューブのみ)から Header ▾ の
+   "Grasp Search…" を押すと `!ctxService.loaded` で **行き止まりのトースト**
+   (「New Project で作れ」)が出るだけ。例テンプレ経由の無フォーム経路 (ADR-051) は
+   あるのに導線が奥まっている。
+2. **ロボットがビューポートで選択できない**: キューブは選べるのに骨格は選べない。
+   骨格 (`RobotStage`) は `SceneView` が持つ **描画専用デコレーション**で
+   `scene.objects` に無いため、`HitTestService.hitAnyObject()` の走査対象外 —
+   腕/胴をクリックしても素通しになる。選択できるのは足元の小さな `robot_base`
+   ギズモだけ。
+3. **TCP / robot の親子が概念とズレる**: TCP はロボット座標系で表現される点だから
+   `robot_base` が親であるべき。また robot は初期キューブと同じ world(world gizmo と
+   同じ、ビューポート中心が原点)を親とすべき。現状 ADR-084 §2 は `robot_base` と
+   `tcp` を **独立した2つの world 親フレーム**にしており(どちらを動かしても他方が
+   追従しない)、標準の TF ツリー world → robot_base → tcp から外れている。
+
+力学 / 位置づけ: 3 点とも view/controller 層 + Layout DSL 契約(front レイヤ内)に閉じる。
+`core/`(解法)には触れない — 越境なし。点3だけが幾何の正本 (§1.1) と無損失
+round-trip (ADR-055) に関わる非自明・不可逆(スキーマ追加)な判断。
+
+## Options considered
+
+**点3(TCP 親子化)**
+- A: `tcp` を `robot_base` の子にする(TF ツリー) — tradeoff: ADR-084 §2 の簡素化を
+  覆し、Layout DSL に CF→CF の親リンク表現 (`parentRef`) を足す必要がある。だが
+  world 姿勢解決 (`_updateWorldPoses`) は CF→CF 連鎖を既に完全対応、grasp の姿勢解決も
+  `worldPoseOf` 経由なので合成は自動。標準ロボティクスの直感に一致。**採用**。
+- B: 独立2フレームのまま維持 — tradeoff: base を動かしても TCP が置き去りという
+  反直感が残る。オーナー指摘の出発点を解決しない。却下。
+
+**点2(選択可能化)**
+- A: 骨格クリックを `robot_base` プロキシ選択に解決(骨格は view のまま) — tradeoff:
+  骨格を最低優先のヒットに足すだけ。RobotStage を entity 化しない = 軽い。**採用**。
+- B: 骨格を本物の scene entity にする — tradeoff: URDF リンク群を domain 化する大工事。
+  段階0スコープ超過(関節/キネマティクスは非モデル化のまま)。却下。
+
+**点1(高速導線)**
+- A: 無 Context で grasp を開いたら robot-cell スターターを自動ロードして grasp タブへ
+  直行 — tradeoff: 初期シーン(捨てても良いブートキューブ)を置換するが、失う Context
+  作業は無い。トーストで明示(無言スワップにしない、#11)。**採用**。
+- B: New Project ギャラリーを開くだけ — tradeoff: 非破壊だが依然2クリック+手動で
+  grasp を再度開く必要。速くない。却下。
+- C: 現状維持(行き止まりトースト) — 却下(Goal 不達)。
+
+## Decision — Strategy(§1.2 Strategy)
+
+### 1. ロボット TF ツリー world → robot_base → tcp(ADR-084 §2 改訂)
+
+- `robot_base`: world 親(root)のまま。既定 world 位置 `[-2,2,0]`(原点中心の初期
+  キューブに埋まらない逃げ)を維持 — world gizmo と同じ world 座標系にいる事実は
+  従来どおり成立。
+- `tcp`: `robot_base` の **子**。translation/rotation は robot_base ローカル。既定
+  local `[0,0,0]`/identity(base と一致、world 姿勢は改訂前と不変 = ソルバ挙動を
+  無言で変えない)。base を動かす/回すと tcp が追従する。
+- **Layout DSL に `parentRef` を追加**(additive、`layoutVersion` 据え置き —
+  ADR-055/`LayoutDslSchema.js` の「1.0 内加算成長」先例)。standalone CF に
+  `parentRef` があれば `position`/`rotation` は親ローカルオフセット、無ければ world
+  姿勢(=従来の robot_base)。compiler が ref→id 解決、decompiler が親リンクを
+  emit、validator が存在/自己参照を検査 → **無損失 round-trip** (§1.1)。
+- grasp の tcp 解決 (`GraspController._resolveRobotDeclaration`) は `parentId===null`
+  制約を tcp から外し **名前ルックアップ**(robot_base の子を優先、旧 world tcp は
+  fallback)。world quaternion は `worldPoseOf` が親連鎖を合成するので、回転した base が
+  wrist-cone 基準軸を回すようになる(ADR-084 §3 の意図を強化)。
+- 旧 .ctx.json の world 親 tcp は `ensureRobotFrames()` が **world 姿勢保存のまま**
+  robot_base 下へ一度だけ再親化(lossless upgrade)。
+
+### 2. 骨格を選択可能に(robot_base プロキシ)
+
+`RobotStage.raycast()` を公開し、`HitTestService.hitRobotStage()` が骨格ヒットを
+`robot_base` CoordinateFrame に解決。`_onPointerDown` / contextmenu / dblclick /
+hover カーソルで **最低優先の fallback**(CF ギズモ・実 entity の後)として拾う —
+大きな骨格ボリュームが小さな標的を遮らない(#22)。骨格は view 専用のまま(§1.1:
+姿勢の正本は robot_base entity)。
+
+### 3. 無フォーム高速導線
+
+`GraspController.openGrasp()` は無 Context 時、行き止まりトーストの代わりに
+`ContextController.quickStartExample('cell_robotics')` で robot-cell スターター
+(geometry + reach/gripper 宣言 → Run が即有効)を非同期ロードし、negotiation 起動後に
+grasp タブを開く。openGrasp の末尾(layout ガード + idle seed + タブ選択)は
+`_openGraspTab()` に抽出し両経路で共有。THREE-free テストレーンの最小 ctxCtrl
+(`quickStartExample` 無し)は従来の誠実なトーストへ degrade。
+
+## Consequences — Evidence と tradeoff(§1.2 Evidence)
+
+- 肯定的: (1) 1 クリックで grasp-search に到達。(2) 腕/胴クリックで robot 選択 →
+  N-panel で位置/姿勢編集に直結。(3) base を動かすと TCP が追従、標準 TF に一致し
+  幾何の正本が親子で一貫。`parentRef` で将来の多段ロボットチェーンにも拡張可能。
+- 受け入れるコスト: Layout DSL に `parentRef` を1つ追加(閉層への optional 兄弟では
+  なく親リンクなので統治上は素直)。ADR-084 §2 の「独立」記述を本 ADR で改訂。
+- 検証(証拠):
+  - `pnpm test` = **693 passed**(front 全体、回帰なし)。うち新規:
+    - `LayoutDecompiler.test.js`: tcp=robot_base 子の parentRef + local pose の
+      round-trip と scene fixpoint、validator の dangling/self/non-CF 拒否。
+    - `GraspController.test.js`: 子 tcp の解決、旧 world tcp の fallback 解決、
+      無 Context → quickStart → grasp タブ、loader 無し時の誠実 degrade。
+  - `pnpm typecheck` clean。`node schema/tools/validate.mjs layout-1.0` conforms。
+  - BFF は同一 `compileLayout` を import(server/src/services/LayoutService.js)し
+    独自 schema 検証を持たない → grasp の compile round-trip は parentRef を素通し
+    (契約 `contractVersion` 不変、`contract-wall` 非該当)。
+- 波及(blast radius): `src/domain/robotFrames.js`, `SceneService.ensureRobotFrames`,
+  `GraspController`(openGrasp/_resolveRobotDeclaration), `ContextController.quickStartExample`,
+  `HitTestService`, `RobotStage`, `AppController`(pointerdown/contextmenu/dblclick/hover),
+  `LayoutCompiler`/`LayoutDecompiler`/`LayoutValidator`, `schema/layout-1.0.schema.json`。
+  `core/` は不変。
+
+## Lens notes
+
+- §1.1 無損失: 点3は round-trip 保存が必須(§1.1「分解は lossless」)なので、live
+  シーンの親子化だけでなく DSL 表現 (`parentRef`) まで足して初めて完了とした。
+- #22 狭スコープ優先: 骨格は大ボリュームゆえ最低優先の fallback に置き、実 entity を
+  遮らない。
+- 様態: grasp 導線は逐次フロー(BPMN)— openGrasp は declare→(quickstart)→tab の
+  決め打ち分岐。#11: 自動ロードはトーストで明示(無言スワップ禁止)。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -95,7 +95,8 @@ This directory records the project's design decisions.
 | [ADR-081](ADR-081-domain-staged-validation-fallback-ladder-kpi.md) | **ドメイン段階バリデーション (見える/届く/掴める) + 運用フォールバック階梯の設計時 KPI 検証** | Accepted (Phase 1-3 実装済; Phase 4 と収束仮説は未着手) | 2026-07-19 | ADR-049, ADR-053, ADR-057, ADR-061, ADR-063, ADR-074, ADR-075, ADR-076, ADR-078, ADR-079 |
 | [ADR-082](ADR-082-absorb-contract-submodule.md) | **契約 submodule の repo 内吸収 — 壁は repo 分離ではなく CI ガードで守る** | Accepted (実装済) | 2026-07-19 | ADR-074, ADR-064, ADR-060, ADR-079, ADR-081 |
 | [ADR-083](ADR-083-robot-base-placement-grasp-contract.md) | **ロボット base position をユーザーが動かし、grasp-search 契約に正式に載せる (optional 追加、version 据え置き)** | Accepted (契約は現行; フロント実装は ADR-084 §2 で CoordinateFrame entity に置き換え済み) | 2026-07-20 | ADR-074, ADR-075, ADR-078, ADR-057, ADR-060 |
-| [ADR-084](ADR-084-tcp-oriented-ik-entity-grounded-geometry.md) | **TCP 姿勢基準の許容角判定 + ロボット base/TCP の CoordinateFrame 実体化 — grasp宣言の生座標を廃し幾何の正本をLayout DSLに一本化** | Accepted (全 Phase 実装済 — Phase 1 core + Phase 4 契約 + Phase 2-3 フロント entity 化) | 2026-07-20 | ADR-083, ADR-081, ADR-078, ADR-074, ADR-018, ADR-034 |
+| [ADR-084](ADR-084-tcp-oriented-ik-entity-grounded-geometry.md) | **TCP 姿勢基準の許容角判定 + ロボット base/TCP の CoordinateFrame 実体化 — grasp宣言の生座標を廃し幾何の正本をLayout DSLに一本化** | Accepted (全 Phase 実装済; §2 の「独立2フレーム」は ADR-085 で TF 親子化に改訂) | 2026-07-20 | ADR-083, ADR-081, ADR-078, ADR-074, ADR-018, ADR-034 |
+| [ADR-085](ADR-085-robot-tf-tree-selectable-fast-grasp-entry.md) | **ロボットを TF 親子ツリー (world→robot_base→tcp) で接地 + 骨格を直接選択可能に + grasp-search を無フォームで開く** | Accepted (全 3 点 実装済) | 2026-07-22 | ADR-084, ADR-083, ADR-055, ADR-051, ADR-018, ADR-034 |
 
 ## How to Add a New ADR
 

--- a/schema/layout-1.0.schema.json
+++ b/schema/layout-1.0.schema.json
@@ -106,6 +106,10 @@
         "dimensions": { "$ref": "#/$defs/vec3" },
         "rotation": { "$ref": "#/$defs/quaternion" },
         "position": { "$ref": "#/$defs/vec3" },
+        "parentRef": {
+          "description": "For a standalone CoordinateFrame, the ref of another entity it is a TF child of (e.g. tcp → robot_base). When present, `position`/`rotation` are the LOCAL offset from that parent; when absent, they are the world pose (world-parented root). Robot TF tree world → robot_base → tcp (ADR-084 §2 revised).",
+          "type": "string"
+        },
         "frames": {
           "type": "array",
           "items": { "$ref": "#/$defs/frame" }

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -163,7 +163,7 @@ function RobotButton() {
   const { hovered, pressed, handlers } = useHoverPress()
   return (
     <button
-      title="Show / hide the robot skeleton. To place the robot, select the robot_base / tcp frames in the Outliner and move them (G / R or the N-panel)."
+      title="Show / hide the robot skeleton. To place the robot, click it in the viewport (or select the robot_base / tcp frames in the Outliner) and move it with G / R or the N-panel. Moving robot_base carries the tcp with it."
       onClick={() => callbacks.onRobotToggle?.()}
       {...handlers}
       style={{

--- a/src/components/Outliner/Outliner.jsx
+++ b/src/components/Outliner/Outliner.jsx
@@ -8,11 +8,13 @@ import { useReducedMotion } from '../Feedback/FeedbackPrimitives.jsx'
 import { DURATION, EASING } from '../../theme/tokens.js'
 import { ROBOT_BASE_FRAME_NAME, TCP_FRAME_NAME } from '../../domain/robotFrames.js'
 
-// ── Robot placement frames (ADR-084 §2) ──────────────────────────────────────
-// These two world-parented CoordinateFrames carry the robot's placement (the
-// single source grasp-search declares against). They look like any other frame
-// in the tree, so a badge + tooltip tells the user what they are and how to move
-// them — otherwise "how do I place the robot?" has no visible answer.
+// ── Robot placement frames (ADR-084 §2, TF tree ADR-085) ─────────────────────
+// These two CoordinateFrames carry the robot's placement (the single source
+// grasp-search declares against): robot_base is world-parented, tcp is its TF
+// child (world → robot_base → tcp), so moving the base carries the tcp. They
+// look like any other frame in the tree, so a badge + tooltip tells the user
+// what they are and how to move them — otherwise "how do I place the robot?"
+// has no visible answer.
 const ROBOT_FRAME_HINT = {
   [ROBOT_BASE_FRAME_NAME]: 'Robot base — where the arm stands. Select and move with G / R or the N-panel to place the robot.',
   [TCP_FRAME_NAME]:        'Robot TCP — how the gripper is aimed (drives the grasp wrist-cone). Select and rotate with R or the N-panel.',

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -1719,6 +1719,7 @@ export class AppController {
           result = cfResult ?? solidResult
         }
         if (!result) result = this._hitTest.hitAnyAnnotation()
+        if (!result) result = this._hitTest.hitRobotStage()   // robot skeleton → robot_base
         if (!result) return
         const { obj } = result
         if (!this._selectedIds.has(obj.id)) {
@@ -1760,6 +1761,7 @@ export class AppController {
     if (this._scene.selectionMode !== 'object') return
     this._hitTest.updateMouse(e)
     const hit = this._hitTest.hitAnyObject()?.obj ?? this._hitTest.hitAnyCoordinateFrame()?.obj
+      ?? this._hitTest.hitRobotStage()?.obj
     if (hit && hit.id !== this._scene.activeId) {
       this._selMgr.clearObjectSelection()
       this._switchActiveObject(hit.id, true)
@@ -2401,7 +2403,9 @@ export class AppController {
       // Hover affordance (ADR-068, Tier A) — desktop pointers only; touch has
       // no hover (PHILOSOPHY #13), so a coarse pointer never warms a body.
       if (e.pointerType !== 'touch') this._setHoveredEntity(hit?.obj ?? null)
-      this._uiView.setCursor((hit || this._hitTest.hitAnyAnnotation()) ? 'pointer' : 'default')
+      this._uiView.setCursor(
+        (hit || this._hitTest.hitAnyAnnotation() || this._hitTest.hitRobotStage()) ? 'pointer' : 'default',
+      )
       return
     }
 
@@ -2809,6 +2813,11 @@ export class AppController {
         result = cfResult ?? solidResult
       }
       if (!result) result = this._hitTest.hitAnyAnnotation()
+      // Lowest priority: a click on the robot skeleton selects its robot_base
+      // proxy (ADR-084 §2) — the skeleton is a view-only decoration, so this is
+      // how "select the robot in the viewport" works. Below every real entity so
+      // it never shadows a smaller/closer target (PHILOSOPHY #22).
+      if (!result) result = this._hitTest.hitRobotStage()
 
       // If TC already claimed this pointer (gizmo fired dragging-changed synchronously
       if (result) {

--- a/src/controller/ContextController.js
+++ b/src/controller/ContextController.js
@@ -263,6 +263,35 @@ export class ContextController {
   }
 
   /**
+   * Load a starter example straight into negotiation for a one-click entry into a
+   * downstream overlay (grasp-search) — no gallery, no wizard, no forms. It is
+   * ADR-051's example-load path minus the picking step, exposed as an awaitable
+   * so the caller (GraspController.openGrasp when no context is loaded) can
+   * continue into its own tab once the derived scene exists and negotiation is
+   * active. Any active overlay is exited first (PHILOSOPHY #9 — dispose before
+   * replace). Returns false (with a toast) for an unknown / non-example id or a
+   * load failure, so the caller never opens a tab over a scene that never loaded.
+   *
+   * @param {string} id — TemplateCatalog example id
+   * @returns {Promise<boolean>} true once negotiation is active on the loaded example
+   */
+  async quickStartExample(id) {
+    const meta = getTemplateMeta(id)
+    if (!meta || meta.source.kind !== 'example') {
+      this._ctrl._uiView.showToast(`Unknown starter: ${id}`, { type: 'warn' })
+      return false
+    }
+    if (this.isActive) this.exit()
+    const doc = TEMPLATE_DOCS[meta.source.file]
+    if (!doc) {
+      this._ctrl._uiView.showToast(`Starter definition not found: ${meta.source.file}`, { type: 'error' })
+      return false
+    }
+    await this._loadThen(doc, () => this._startNegotiation())
+    return this.isNegotiation
+  }
+
+  /**
    * Fork an example as the starting point (ADR-058 — "fork & tweak"). The example
    * doc is *cloned* into the working doc (so editing never touches the bundled
    * module), the scene is regenerated from it, and the **original example is

--- a/src/controller/GraspController.js
+++ b/src/controller/GraspController.js
@@ -46,6 +46,13 @@ import { renderableEndEffectorFrame, nearestTargetIndex } from '../view/GraspGho
 import { visionFromViewportCamera } from '../context/GraspDeclarationCatalog.js'
 import { ROBOT_BASE_FRAME_NAME, TCP_FRAME_NAME } from '../domain/robotFrames.js'
 
+/**
+ * TemplateCatalog example id auto-loaded when grasp-search is opened with no
+ * context (fast entry). A robot-cell starter (geometry + reach/gripper
+ * declarations) so Run is immediately meaningful.
+ */
+const GRASP_QUICKSTART_TEMPLATE_ID = 'cell_robotics'
+
 export class GraspController {
   /**
    * @param {import('./AppController.js').AppController} ctrl
@@ -78,21 +85,53 @@ export class GraspController {
    * host) and select the `'grasp'` tab. Guarded on a renderable layout — a blank /
    * requirements-only doc has none, so we guide the user instead of seeding a tab
    * that can never Run (PHILOSOPHY #11).
+   *
+   * Fast entry (no forms): when NO context is loaded yet, rather than dead-ending
+   * with "go build one through New Project", auto-load a robot-cell starter and
+   * drop the user straight into grasp-search. The boot scene carries no context
+   * work to lose, and the example path needs no wizard forms — it collapses the
+   * old multi-form detour into a single click.
    */
   openGrasp() {
     const ctxCtrl = this._ctrl._ctxCtrl
     if (!ctxCtrl.isNegotiation) {
       if (!this._ctrl._ctxService.loaded) {
-        this._ctrl._uiView.showToast(
-          'No context loaded. Start one from New Project or import a .ctx.json first.',
-          { type: 'warn' },
-        )
+        this._quickStartIntoGrasp()
         return
       }
       ctxCtrl.enterNegotiation()
       if (!ctxCtrl.isNegotiation) return   // enter was itself guarded out
     }
 
+    this._openGraspTab()
+  }
+
+  /**
+   * Load the grasp quick-start example, then open the grasp tab once negotiation
+   * is live. Kept off the synchronous path (loadContext is async). Falls back to
+   * the honest "no context" guidance when the injected ctxCtrl cannot load
+   * examples (the THREE-free unit lane passes a minimal stub).
+   */
+  _quickStartIntoGrasp() {
+    const ctxCtrl = this._ctrl._ctxCtrl
+    if (typeof ctxCtrl.quickStartExample !== 'function') {
+      this._ctrl._uiView.showToast(
+        'No context loaded. Start one from New Project or import a .ctx.json first.',
+        { type: 'warn' },
+      )
+      return
+    }
+    this._ctrl._uiView.showToast('Loading a robot-cell starter for grasp-search…', { type: 'info' })
+    Promise.resolve(ctxCtrl.quickStartExample(GRASP_QUICKSTART_TEMPLATE_ID))
+      .then(ok => { if (ok) this._openGraspTab() })
+  }
+
+  /**
+   * Shared tail: guard on a renderable layout, then seed the idle FSM slice and
+   * select the grasp tab. Reached both directly (a context already loaded) and
+   * after the quick-start example finishes loading.
+   */
+  _openGraspTab() {
     const layout = this._layoutMeta()
     if (!layout) {
       this._ctrl._uiView.showToast(
@@ -368,10 +407,12 @@ export class GraspController {
   // ── Helpers ───────────────────────────────────────────────────────────────────
 
   /**
-   * Resolve the robot's declared geometry from the scene's world-parented
-   * `robot_base` / `tcp` CoordinateFrame entities (ADR-084 §2). 1-robot scope:
-   * a plain name lookup — no `refs` field, no selection UI (§4). World pose is
-   * read from `SceneService.worldPoseOf` — the SAME resolution the service runs
+   * Resolve the robot's declared geometry from the scene's `robot_base` (world
+   * root) and `tcp` (its TF child) CoordinateFrame entities (ADR-084 §2, TF tree
+   * ADR-085). 1-robot scope: a plain name lookup — no `refs` field, no selection
+   * UI (§4). World pose is read from `SceneService.worldPoseOf` — the SAME
+   * resolution the service runs (so tcp's world quaternion is already composed
+   * through robot_base; a rotated base rotates the wrist-cone reference axis)
    * each frame, reused rather than re-implemented (§1.1); the composition to
    * world space stays on the front (light deterministic math) while core/ gets
    * only the resolved position / quaternion and never sees the entity.
@@ -387,14 +428,27 @@ export class GraspController {
     const service = this._ctrl._service
     if (!scene?.objects || typeof service?.worldPoseOf !== 'function') return {}
 
-    const findFrame = (name) => {
+    // robot_base is the world-parented root of the robot TF tree (parentId null).
+    const baseFrame = (() => {
       for (const o of scene.objects.values()) {
-        if (o.name === name && o.parentId === null) return o
+        if (o.name === ROBOT_BASE_FRAME_NAME && o.parentId === null) return o
       }
       return null
-    }
-    const baseFrame = findFrame(ROBOT_BASE_FRAME_NAME)
-    const tcpFrame  = findFrame(TCP_FRAME_NAME)
+    })()
+    // tcp is a CHILD of robot_base (TF tree, ADR-084 §2 revised) — a name lookup,
+    // NOT constrained to parentId === null. Its world quaternion (resolved through
+    // robot_base by worldPoseOf) is what rides the wire; the parent link is why a
+    // rotated base now rotates the wrist-cone reference axis. Prefer the tcp
+    // parented under robot_base if several share the name (1-robot scope).
+    const tcpFrame = (() => {
+      let fallback = null
+      for (const o of scene.objects.values()) {
+        if (o.name !== TCP_FRAME_NAME) continue
+        if (baseFrame && o.parentId === baseFrame.id) return o
+        fallback ??= o
+      }
+      return fallback
+    })()
     const basePose  = baseFrame ? service.worldPoseOf(baseFrame.id) : null
     const tcpPose   = tcpFrame  ? service.worldPoseOf(tcpFrame.id)  : null
 

--- a/src/controller/GraspController.test.js
+++ b/src/controller/GraspController.test.js
@@ -62,9 +62,11 @@ const okBff = {
 
 /**
  * Fake scene + world-pose service mirroring the robot_base / tcp resolution
- * GraspController now performs (ADR-084 §2). The two world-parented CFs sit at
- * ADR-083's default base [-2,2,0] with an identity TCP orientation, so the
- * resolved `robot` payload is deterministic in this THREE-free lane.
+ * GraspController now performs (ADR-084 §2, TF tree revised). robot_base is the
+ * world-parented root; tcp is its CHILD (parentId f_base). worldPoseOf returns
+ * the composed WORLD pose (as SceneService does), so the resolved `robot`
+ * payload is deterministic in this THREE-free lane. tcpOrientation is the tcp's
+ * world quaternion — here identity, matching the default base + local-identity.
  */
 const ROBOT_POSES = {
   robot_base: { position: { x: -2, y: 2, z: 0 }, quaternion: { x: 0, y: 0, z: 0, w: 1 } },
@@ -73,7 +75,7 @@ const ROBOT_POSES = {
 function fakeRobotScene() {
   const objects = new Map([
     ['f_base', { id: 'f_base', name: 'robot_base', parentId: null }],
-    ['f_tcp',  { id: 'f_tcp',  name: 'tcp',        parentId: null }],
+    ['f_tcp',  { id: 'f_tcp',  name: 'tcp',        parentId: 'f_base' }],
   ])
   const poseById = { f_base: ROBOT_POSES.robot_base, f_tcp: ROBOT_POSES.tcp }
   return {
@@ -137,6 +139,32 @@ test('openGrasp enters negotiate first when inactive but a doc is loaded', () =>
   gc.openGrasp()
   assert.equal(ctrl._ctxCtrl.isNegotiation, true)
   assert.equal(grasp().status, 'idle')
+})
+
+test('openGrasp with no context auto-loads the starter and opens the grasp tab (fast entry)', async () => {
+  const { gc, ctrl, store, grasp } = setup({ isNegotiation: false, loaded: false })
+  let requested = null
+  // Stub the ctxCtrl quick-start: mark negotiation live + a renderable layout,
+  // mirroring a real example load, and resolve true.
+  ctrl._ctxCtrl.quickStartExample = async (id) => {
+    requested = id
+    ctrl._ctxCtrl.isNegotiation = true
+    ctrl._ctxService.loaded = true          // a context now exists (layout renderable via getCompiled)
+    return true
+  }
+  gc.openGrasp()
+  await Promise.resolve(); await Promise.resolve()   // let the quick-start promise settle
+  assert.equal(requested, 'cell_robotics')
+  assert.equal(grasp().status, 'idle')
+  assert.equal(store.getState().context.inspectorTab, 'grasp')
+})
+
+test('openGrasp with no context and no example loader falls back to honest guidance', () => {
+  const { gc, ctrl, store } = setup({ isNegotiation: false, loaded: false })
+  // Default fake ctxCtrl has no quickStartExample — the THREE-free minimal stub.
+  gc.openGrasp()
+  assert.equal(ctrl._uiView.toasts.at(-1).opt.type, 'warn')
+  assert.notEqual(store.getState().context.inspectorTab, 'grasp')
 })
 
 // ── runGraspSearch: happy path ─────────────────────────────────────────────────
@@ -402,6 +430,25 @@ test('a scene without robot_base / tcp frames omits robot entirely (ADR-084 §3 
   const { gc } = setup({ bff, robotScene: false })
   await gc.runGraspSearch({})
   assert.ok(!('robot' in sent.graspSearch))   // no frames resolved → no wire key (core keeps its fallback)
+})
+
+test('a legacy world-parented tcp (parentId null) still resolves via the name fallback', async () => {
+  let sent = null
+  const bff = {
+    async compileLayout() { return { objects: [] } },
+    async graspSearch(req) { sent = req; return { candidates: [], diagnostics: DIAG_OK } },
+  }
+  // Robot scene where tcp predates the TF-tree revision — still world-parented.
+  const objects = new Map([
+    ['f_base', { id: 'f_base', name: 'robot_base', parentId: null }],
+    ['f_tcp',  { id: 'f_tcp',  name: 'tcp',        parentId: null }],
+  ])
+  const poseById = { f_base: ROBOT_POSES.robot_base, f_tcp: ROBOT_POSES.tcp }
+  const { gc } = setup({ bff, robotScene: false })
+  gc._ctrl._scene = { objects }
+  gc._ctrl._service.worldPoseOf = (id) => poseById[id] ?? null   // keep bff / connectBff
+  await gc.runGraspSearch({})
+  assert.deepEqual(sent.graspSearch.robot, { base: [-2, 2, 0], tcpOrientation: [0, 0, 0, 1] })
 })
 
 test('an undeclared camera / gripper omits the key entirely (vacuously-true gate)', async () => {

--- a/src/controller/HitTestService.js
+++ b/src/controller/HitTestService.js
@@ -14,6 +14,7 @@ import { AnnotatedLine }   from '../domain/AnnotatedLine.js'
 import { AnnotatedRegion } from '../domain/AnnotatedRegion.js'
 import { AnnotatedPoint }  from '../domain/AnnotatedPoint.js'
 import { toNDC }           from '../model/CuboidModel.js'
+import { ROBOT_BASE_FRAME_NAME } from '../domain/robotFrames.js'
 
 export class HitTestService {
   /**
@@ -135,6 +136,30 @@ export class HitTestService {
       obj = this._ctrl._scene.getObject(obj.parentId)
     }
     return false
+  }
+
+  /**
+   * Hits the visible robot skeleton (RobotStage) and resolves it to its
+   * `robot_base` CoordinateFrame proxy — the entity that drives the skeleton's
+   * pose (ADR-084 §2). The skeleton itself is a view-only decoration absent from
+   * `scene.objects`, so without this a click on the arm/body selects nothing.
+   * Used as a LOW-priority fallback in _onPointerDown (after CF / Solid /
+   * annotation), so the base gizmo and any overlapping entity still win
+   * (PHILOSOPHY #22 — the large skeleton volume must not shadow smaller targets).
+   * @returns {{ obj: object }|null}
+   */
+  hitRobotStage() {
+    const { _ctrl: ctrl } = this
+    const stage = ctrl._sceneView?.robotStage
+    if (!stage?.raycast) return null
+    ctrl._raycaster.setFromCamera(ctrl._mouse, ctrl._camera)
+    if (!stage.raycast(ctrl._raycaster)) return null
+    for (const o of ctrl._scene.objects.values()) {
+      if (o instanceof CoordinateFrame && o.name === ROBOT_BASE_FRAME_NAME && o.parentId === null) {
+        return { obj: o }
+      }
+    }
+    return null
   }
 
   /** Hits only the active object's mesh. */

--- a/src/domain/CoordinateFrame.js
+++ b/src/domain/CoordinateFrame.js
@@ -80,8 +80,9 @@ export class CoordinateFrame {
     /**
      * ID of the parent object. Normally a geometry object or another CF.
      * `null` marks a world-parented (root) frame whose translation / rotation
-     * ARE its world pose (ADR-084 §2, e.g. robot_base / tcp) — resolved by
-     * SceneService._updateWorldPoses()'s parentless branch.
+     * ARE its world pose (ADR-084 §2, e.g. robot_base) — resolved by
+     * SceneService._updateWorldPoses()'s parentless branch. (tcp is NOT a root:
+     * it is a TF child of robot_base — ADR-085 — so its parentId is set.)
      */
     this.parentId = parentId
     this.meshView = meshView

--- a/src/domain/robotFrames.js
+++ b/src/domain/robotFrames.js
@@ -1,16 +1,22 @@
 /**
- * Robot frame naming convention (ADR-084 §2).
+ * Robot frame naming convention (ADR-084 §2, TF tree revised 2026-07-22).
  *
  * The robot's placement geometry is a first-class part of the scene: two
- * world-parented CoordinateFrame entities carry the single source of truth
- * (§1.1) that grasp-search declares against — replacing the ad-hoc
- * `uiStore.robotBase` raw coordinates that ADR-083 introduced.
+ * CoordinateFrame entities carry the single source of truth (§1.1) that
+ * grasp-search declares against — replacing the ad-hoc `uiStore.robotBase` raw
+ * coordinates that ADR-083 introduced.
  *
- *   ROBOT_BASE_FRAME_NAME — position only (where the arm stands). Orientation
- *     is not used by reach evaluation (§1).
- *   TCP_FRAME_NAME        — position + orientation (how the gripper is aimed).
- *     Its world quaternion becomes `robot.tcpOrientation` on the wire and
- *     drives the wrist-cone reference axis in core/ (ADR-084 §3).
+ * They form the canonical robotics TF tree  world → robot_base → tcp  (revising
+ * ADR-084 §2's original "two independent world-parented frames" simplification):
+ *
+ *   ROBOT_BASE_FRAME_NAME — world-parented (root). Position only (where the arm
+ *     stands). Orientation is not used by reach evaluation (§1).
+ *   TCP_FRAME_NAME        — a CHILD of robot_base (the tool point is expressed in
+ *     the robot's own frame, so moving/rotating the base carries the TCP with
+ *     it). Its *world* quaternion (composed through robot_base by
+ *     SceneService._updateWorldPoses) becomes `robot.tcpOrientation` on the wire
+ *     and drives the wrist-cone reference axis in core/ (ADR-084 §3). Its
+ *     translation/rotation are stored LOCAL to robot_base.
  *
  * Resolution is a plain name lookup on `scene.objects` (1-robot scope — no
  * `refs` field, no selection UI; ADR-084 §2/§4). Pure module (no THREE / no
@@ -25,11 +31,20 @@ export const ROBOT_BASE_FRAME_NAME = 'robot_base'
 export const TCP_FRAME_NAME = 'tcp'
 
 /**
- * Default world placement of the auto-seeded robot frames (ADR-084 §2, silent
- * auto-generation per ADR-073). `robot_base` keeps ADR-083's default
- * `[-2, 2, 0]` so existing behaviour (and RobotStage's default pose) is
- * unchanged. `tcp` seeds at the same spot with identity orientation; the user
- * re-aims it through the existing CoordinateFrame edit UI (G / R / N-panel).
+ * Default placement of the auto-seeded robot frames (ADR-084 §2, silent
+ * auto-generation per ADR-073).
+ *
+ * `robot_base` keeps ADR-083's default WORLD position `[-2, 2, 0]` so existing
+ * behaviour (and RobotStage's default pose) is unchanged — offset from the
+ * origin so the arm does not spawn buried inside the origin-centred starter
+ * cube. It stays world-parented (the same world frame the world gizmo and the
+ * starter cube share).
+ *
+ * `tcp` seeds as a CHILD of robot_base, so its pose here is LOCAL to the base:
+ * `[0, 0, 0]` / identity places it coincident with the base with axes aligned;
+ * the user re-aims it through the existing CoordinateFrame edit UI (G / R /
+ * N-panel), and because it is parented, moving/rotating the base carries it
+ * along (TF tree world → robot_base → tcp).
  */
 export const ROBOT_FRAME_DEFAULTS = Object.freeze({
   [ROBOT_BASE_FRAME_NAME]: Object.freeze({
@@ -37,7 +52,7 @@ export const ROBOT_FRAME_DEFAULTS = Object.freeze({
     rotation: Object.freeze({ x: 0, y: 0, z: 0, w: 1 }),
   }),
   [TCP_FRAME_NAME]: Object.freeze({
-    position: Object.freeze({ x: -2, y: 2, z: 0 }),
+    position: Object.freeze({ x: 0, y: 0, z: 0 }),
     rotation: Object.freeze({ x: 0, y: 0, z: 0, w: 1 }),
   }),
 })

--- a/src/layout/LayoutCompiler.js
+++ b/src/layout/LayoutCompiler.js
@@ -285,18 +285,24 @@ function generateObjects(entities, refMap, positions) {
       }
 
       case 'CoordinateFrame': {
-        // Standalone (world-parented) CF — e.g. robot_base / tcp (ADR-084 §2).
-        // The schema carries its world pose in `position` + `rotation`; a
-        // world-parented scene CF stores that world pose directly as its
-        // translation / rotation (parentId null — the parentless branch of
-        // _updateWorldPoses resolves translation/rotation AS the world pose).
-        const id  = refMap.get(entity.ref)
+        // Standalone CF — e.g. robot_base / tcp (ADR-084 §2, TF tree revised).
+        //
+        //   • No `parentRef`  → world-parented root (e.g. robot_base). `position`
+        //     + `rotation` ARE its world pose, stored directly as its
+        //     translation / rotation (parentId null — the parentless branch of
+        //     _updateWorldPoses resolves them AS the world pose).
+        //   • With `parentRef` → a TF child (e.g. tcp → robot_base). `position` +
+        //     `rotation` are the LOCAL offset from the referenced parent;
+        //     _updateWorldPoses composes the parent chain to derive the world
+        //     pose (identical machinery as a Solid's child frames).
+        const id       = refMap.get(entity.ref)
+        const parentId = entity.parentRef ? (refMap.get(entity.parentRef) ?? null) : null
         const pos = entity.position ?? entity.translation ?? { x: 0, y: 0, z: 0 }
         objects.push({
           type:        'CoordinateFrame',
           id,
           name:        entity.name,
-          parentId:    null,
+          parentId,
           declaredBy:  entity.declaredBy ?? 'modeller',
           translation: { x: pos.x ?? 0, y: pos.y ?? 0, z: pos.z ?? 0 },
           rotation:    entity.rotation ?? IDENTITY_QUATERNION,

--- a/src/layout/LayoutDecompiler.js
+++ b/src/layout/LayoutDecompiler.js
@@ -180,16 +180,22 @@ export function decompileLayout(sceneJson) {
       case 'CoordinateFrame': {
         if (originIds.has(o.id)) break               // auto-Origin: folded away
         if (originIds.has(o.parentId)) break          // user frame: folded into Solid
-        // Standalone (world-parented) CF — e.g. robot_base / tcp (ADR-084 §2).
-        // Its `translation` / `rotation` ARE its world pose, so it maps to the
-        // schema's top-level `position` + `rotation` (ADR-084 §1: reuse the
-        // existing CoordinateFrame entity fields — no new schema keys).
+        // Standalone CF — e.g. robot_base / tcp (ADR-084 §2, TF tree revised).
+        //   • World-parented root (robot_base): parentId null → no `parentRef`;
+        //     `translation` / `rotation` ARE its world pose → schema `position` +
+        //     `rotation`.
+        //   • TF child (tcp → robot_base): parentId is another standalone CF →
+        //     emit `parentRef`; `translation` / `rotation` are already LOCAL to
+        //     that parent, so they map to `position` + `rotation` unchanged
+        //     (the compiler re-reads them as a local offset).
+        const parentRef = o.parentId ? idToRef.get(o.parentId) : undefined
         const entity = {
           ref:      idToRef.get(o.id),
           type:     'CoordinateFrame',
           name:     o.name,
           position: vec(o.translation ?? { x: 0, y: 0, z: 0 }),
         }
+        if (parentRef) entity.parentRef = parentRef
         if (!isIdentityQuat(o.rotation)) entity.rotation = quat(o.rotation)
         entities.push(entity)
         break

--- a/src/layout/LayoutDecompiler.test.js
+++ b/src/layout/LayoutDecompiler.test.js
@@ -105,6 +105,64 @@ test('standalone world CF (robot_base / tcp) round-trips via position + rotation
   assert.deepEqual(compileLayout(dsl), scene1)
 })
 
+test('TF-tree CF: tcp as a child of robot_base round-trips via parentRef + local pose (ADR-084 §2 revised)', () => {
+  // 45° about +Z as tcp's LOCAL orientation, to prove the local pose survives.
+  const s = Math.sin(Math.PI / 8), c = Math.cos(Math.PI / 8)
+  const dsl0 = {
+    version: 'layout/1.0',
+    strategy: 'manual',
+    entities: [
+      { ref: 'box', type: 'Solid', name: 'Box',
+        dimensions: { x: 100, y: 100, z: 100 }, position: { x: 0, y: 0, z: 50 } },
+      { ref: 'robot_base', type: 'CoordinateFrame', name: 'robot_base',
+        position: { x: -2, y: 2, z: 0 } },
+      // tcp is a TF child of robot_base — its position/rotation are LOCAL offsets.
+      { ref: 'tcp', type: 'CoordinateFrame', name: 'tcp', parentRef: 'robot_base',
+        position: { x: 0, y: 0, z: 1 }, rotation: { x: 0, y: 0, z: s, w: c } },
+    ],
+  }
+
+  const scene1 = compileLayout(dsl0)
+  const baseObj = scene1.objects.find(o => o.name === 'robot_base')
+  const tcpObj  = scene1.objects.find(o => o.name === 'tcp')
+  // robot_base is world-parented; tcp is parented to robot_base (the TF tree).
+  assert.equal(baseObj.parentId, null)
+  assert.equal(tcpObj.parentId, baseObj.id)
+  // The child's stored translation is LOCAL (not the composed world pose).
+  assert.deepEqual(tcpObj.translation, { x: 0, y: 0, z: 1 })
+
+  const { dsl } = decompileLayout(scene1)
+  const tcp = dsl.entities.find(e => e.ref === 'tcp')
+  assert.equal(tcp.parentRef, 'robot_base')            // the parent link survives
+  assert.deepEqual(tcp.position, { x: 0, y: 0, z: 1 }) // local offset, unchanged
+  assert.ok(Math.abs(tcp.rotation.z - s) < 1e-9 && Math.abs(tcp.rotation.w - c) < 1e-9)
+
+  // Schema-clean + valid (parentRef references an existing entity ref).
+  assert.equal(validateLayoutDsl(dsl).valid, true, validateLayoutDsl(dsl).errors.join('\n'))
+
+  // Scene fixpoint law (ADR-055): the parented tree is a fixpoint too.
+  assert.deepEqual(compileLayout(dsl), scene1)
+})
+
+test('validator rejects a parentRef that names no entity, a self-parent, or a non-CF host', () => {
+  const base = { version: 'layout/1.0', strategy: 'manual', entities: [
+    { ref: 'robot_base', type: 'CoordinateFrame', name: 'robot_base', position: { x: 0, y: 0, z: 0 } },
+  ] }
+  const dangling = { ...base, entities: [ ...base.entities,
+    { ref: 'tcp', type: 'CoordinateFrame', name: 'tcp', parentRef: 'nope', position: { x: 0, y: 0, z: 0 } } ] }
+  assert.equal(validateLayoutDsl(dangling).valid, false)
+
+  const self = { ...base, entities: [ ...base.entities,
+    { ref: 'tcp', type: 'CoordinateFrame', name: 'tcp', parentRef: 'tcp', position: { x: 0, y: 0, z: 0 } } ] }
+  assert.equal(validateLayoutDsl(self).valid, false)
+
+  const onSolid = { version: 'layout/1.0', strategy: 'manual', entities: [
+    { ref: 'robot_base', type: 'CoordinateFrame', name: 'robot_base', position: { x: 0, y: 0, z: 0 } },
+    { ref: 'box', type: 'Solid', name: 'Box', parentRef: 'robot_base',
+      dimensions: { x: 100, y: 100, z: 100 }, position: { x: 0, y: 0, z: 0 } } ] }
+  assert.equal(validateLayoutDsl(onSolid).valid, false)
+})
+
 test('constraints recover entity / origin / frame ref namespaces', () => {
   const scene = compileLayout(factoryLayout)
   const { dsl } = decompileLayout(scene)

--- a/src/layout/LayoutValidator.js
+++ b/src/layout/LayoutValidator.js
@@ -112,6 +112,25 @@ export function validateLayoutDsl(dsl) {
     }
   }
 
+  // Standalone CoordinateFrame TF-parent links (ADR-084 §2 revised): a
+  // `parentRef` must reference an existing top-level entity and not itself.
+  // Checked after the first pass so a forward reference (parent declared later)
+  // still resolves. The runtime reparent guard (_isDescendant) rejects deeper
+  // cycles; here we only catch the trivial self-parent.
+  for (const [i, entity] of dsl.entities.entries()) {
+    if (!entity || typeof entity !== 'object') continue
+    if (entity.parentRef === undefined || entity.parentRef === null) continue
+    if (entity.type !== 'CoordinateFrame') {
+      errors.push(`entities[${i}] ("${entity.ref}") "parentRef" is only valid on a CoordinateFrame`)
+      continue
+    }
+    if (entity.parentRef === entity.ref) {
+      errors.push(`entities[${i}] (CoordinateFrame "${entity.ref}") "parentRef" cannot reference itself`)
+    } else if (!entityRefs.has(entity.parentRef)) {
+      errors.push(`entities[${i}] (CoordinateFrame "${entity.ref}") "parentRef" "${entity.parentRef}" does not match any entity ref`)
+    }
+  }
+
   // All resolvable refs: entity refs + frame refs + implicit <ref>_origin for Solids
   const originRefs = new Set([...entityRefs].map(r => `${r}_origin`))
   const allRefs    = new Set([...entityRefs, ...frameRefs, ...originRefs])

--- a/src/service/SceneService.js
+++ b/src/service/SceneService.js
@@ -2989,9 +2989,10 @@ export class SceneService extends EventEmitter {
    *
    * Unlike createCoordinateFrame(), this frame has NO parent (parentId = null):
    * its `translation` / `rotation` ARE its world pose, resolved directly by
-   * _updateWorldPoses() (the parentless branch). Used for the robot_base / tcp
-   * frames whose world geometry is the single source of truth grasp-search
-   * declares against (§1.1) — silent auto-naming per ADR-073 (no creation form).
+   * _updateWorldPoses() (the parentless branch). Used for the robot_base frame —
+   * the world-parented root whose world geometry is the single source of truth
+   * grasp-search declares against (§1.1). (tcp is seeded as robot_base's TF child
+   * via createCoordinateFrame — ADR-085.) Silent auto-naming per ADR-073.
    *
    * @param {string} name
    * @param {{position?: {x:number,y:number,z:number}, rotation?: {x:number,y:number,z:number,w:number}}} [pose]
@@ -3041,13 +3042,33 @@ export class SceneService extends EventEmitter {
    * DSL round-trip (ADR-055) and .ctx.json like any other CoordinateFrame.
    */
   ensureRobotFrames() {
-    const byName = new Set(
-      [...this._model.objects.values()]
-        .filter(o => o instanceof CoordinateFrame)
-        .map(o => o.name),
-    )
-    for (const [name, pose] of Object.entries(ROBOT_FRAME_DEFAULTS)) {
-      if (!byName.has(name)) this.createWorldFrame(name, pose)
+    const frames = [...this._model.objects.values()].filter(o => o instanceof CoordinateFrame)
+    const byName = new Map(frames.map(o => [o.name, o]))
+
+    // robot_base is the world-parented root of the robot TF tree.
+    let base = byName.get(ROBOT_BASE_FRAME_NAME)
+    if (!base) base = this.createWorldFrame(ROBOT_BASE_FRAME_NAME, ROBOT_FRAME_DEFAULTS[ROBOT_BASE_FRAME_NAME])
+
+    // tcp is a CHILD of robot_base (TF tree world → robot_base → tcp, ADR-084 §2
+    // revised 2026-07-22): the tool point is expressed in the robot's own frame,
+    // so moving/rotating the base carries it along. createCoordinateFrame seeds
+    // it at local (0,0,0)/identity — coincident with the base until re-aimed.
+    const tcp = byName.get(TCP_FRAME_NAME)
+    if (!tcp) {
+      this.createCoordinateFrame(base.id, TCP_FRAME_NAME, null)
+    } else if (tcp.parentId === null && tcp.id !== base.id) {
+      // Lossless upgrade of a legacy scene (tcp saved as a world-parented frame
+      // before the TF-tree revision): re-home it under robot_base while
+      // preserving its current world pose (reparentFrame back-derives the local
+      // translation/rotation from the world-pose cache). One-time; a scene
+      // already carrying the tree is a no-op above.
+      //
+      // This runs on scene-entry paths BEFORE the outer _updateWorldPoses() pass
+      // (importFromJson / loadScene), so the cache would otherwise be stale and
+      // collapse a moved tcp onto the base. Refresh it first so the world pose is
+      // truly preserved.
+      this._updateWorldPoses()
+      this.reparentFrame(tcp.id, base.id)
     }
   }
 

--- a/src/view/RobotStage.js
+++ b/src/view/RobotStage.js
@@ -75,6 +75,22 @@ export class RobotStage {
   }
 
   /**
+   * First raycast intersection against the visible skeleton, or null. The
+   * skeleton is a view-only decoration (not a scene entity), so it is invisible
+   * to the entity raycasts; this lets the controller treat a click on the arm as
+   * a click on its `robot_base` proxy entity (ADR-084 §2) — the answer to "why
+   * can I select the cube but not the robot". Returns null while hidden or
+   * before the URDF has loaded.
+   * @param {THREE.Raycaster} raycaster  already aimed from the pointer
+   * @returns {THREE.Intersection|null}
+   */
+  raycast(raycaster) {
+    if (!this._group.visible || !this.robot) return null
+    const hits = raycaster.intersectObject(this._group, true)
+    return hits.length ? hits[0] : null
+  }
+
+  /**
    * Places the robot base at a world pose. A pure view-layer transform: the
    * skeleton follows the `robot_base` CoordinateFrame entity's world pose
    * (ADR-084 §2), driven by AppController._syncRobotStage() each frame. Reach/IK


### PR DESCRIPTION
Three interrelated fixes so the robot behaves as one directly-manipulable,
correctly-grounded scene entity — and grasp-search is reachable in one click.

③ TF tree world → robot_base → tcp (revises ADR-084 §2's "independent frames"):
  - tcp is now a CHILD of robot_base, so moving/rotating the base carries it
    (TCP is expressed in the robot's own frame). robot_base stays world-parented.
  - Layout DSL carries the link via an additive `parentRef` on standalone
    CoordinateFrames (layoutVersion unchanged) — compiler/decompiler/validator +
    schema updated so the tree survives Scene⇄DSL round-trip losslessly (§1.1).
  - grasp resolution finds tcp by name (no longer parentId===null), so its world
    quaternion is composed through robot_base — a rotated base rotates the
    wrist-cone reference axis (strengthens ADR-084 §3). Legacy world-parented tcp
    is re-homed under robot_base on load, preserving world pose.

② Robot skeleton selectable in the viewport: RobotStage.raycast +
  HitTestService.hitRobotStage resolve a click on the arm/body to its robot_base
  proxy entity, wired as a lowest-priority hit in pointerdown / contextmenu /
  dblclick / hover (never shadows a smaller target — PHILOSOPHY #22).

① Fast grasp entry: opening Grasp Search with no context loaded now auto-loads
  the cell_robotics starter and drops straight into the grasp tab (no wizard
  forms), instead of a dead-end toast. Announced via toast (never a silent swap).

Tests: pnpm test 693 passed, typecheck clean, layout schema conforms.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Gg3Quir9E19EwD6FeYUKq1