### PR TITLE
feat(robot): UR5e-shaped skeleton + seed TCP at the flange (ADR-088 Proposed)

### DIFF
--- a/docs/adr/ADR-088-tcp-seed-derived-from-urdf-fk.md
+++ b/docs/adr/ADR-088-tcp-seed-derived-from-urdf-fk.md
@@ -1,0 +1,119 @@
+# 088. robot_base→tcp の既定 seed を URDF スケルトンの FK から導出する（真実の源を URDF に一本化）
+
+- Status: Proposed
+- Date: 2026-07-23
+- Deciders: yuubae215, Claude
+- Supersedes / Superseded by: なし（ADR-084 §2 / ADR-085 の tcp seed 実装を精緻化）
+
+## Context — Goal と力学（§1.2 Goal）
+
+**達成したい性質**: 「ロボットの工具点（tcp フレーム）の既定位置は、可視化されている
+アームの手先（フランジ）と常に一致する」を、**人手の同期に依存せず**構造的に保証する。
+
+現状（ADR-084 §2 / ADR-085 の実装、本ブランチで tcp をベースから手先へ移した直後）は
+この性質を **手作業で** 満たしている：
+
+- スケルトンの運動学は `public/robot/skeleton_arm.urdf`（UR5e リンク変換）に在る。
+- レストポーズ（関節角）は view 層の `RobotStage._applyRestPose` に在る。
+- tcp の既定ローカル位置は `ROBOT_FRAME_DEFAULTS[tcp] = (-0.717,-0.133,0.346)` という
+  **定数**で、これは上二つから私がオフラインで計算した順運動学（FK）の**出力を書き写した値**。
+
+ここに §1.1（真実の源は一つ）違反の芽がある。フランジ位置という一つの事実が
+「URDF＋レストポーズ（本来の源）」と「手写しの定数（第二の源）」の二箇所に在り、
+**URDF かレストポーズを変えると定数が黙ってズレる**（tcp が手先から外れるが、テストも型も
+検知しない — silent drift、PHILOSOPHY #11 の構造的失敗形）。コメントで「coupled pair、
+変えたら再計算」と縛っているのは、規律を人手に外注している状態にほかならない。
+
+**この決定が許される前提（ガードの正確な読み）**: FK を `src/` で計算することは
+スコープ内である。CLAUDE.md の AI 向けガード「解法は `core/`」が守るのは
+**grasp-search の判定エンジン**（候補生成→段階フィルタ〔リーチ/IK/把持性/可視性/干渉〕→
+加重スコア、decide/propose の動詞境界）であって、**可視化のための FK 一般ではない**。
+純粋 FK は既に `src/robotics/Kinematics.js`（`forwardKinematics(chain, q)`）に存在し、
+ADR-053 §3 が「初期形はこれ」と明示的に bless している（重い総当たり/Monte-Carlo は
+BFF `ComputeBackend`、FK・可視化ループはフロント、という ADR-053 の非対称）。本 ADR は
+その FK を seed 導出に再利用するだけで、新しい解法を `src/` に持ち込まない。
+
+**層マップ上の位置**: 影響は フロント（`src/`）内に閉じる。契約（`packages/grasp-contract`）は
+不変 — tcp の**向き**だけがワイヤに載る（`tcpOrientation`、GraspController）ため、既定
+**位置**の導出方法を変えても response/request いずれのスキーマにも触れない。
+
+## Options considered
+
+- **A: レストポーズ + スケルトン運動学を JS の `chain` データとして持ち、`forwardKinematics`
+  で毎回導出。** tradeoff: URDF の関節原点を JS 側にも書くことになり、**URDF と JS chain の
+  二重管理**が生まれる。手写し定数を消す代わりに、より広い（全関節原点の）第二の源を作る
+  ので §1.1 違反がむしろ悪化。**却下。**
+
+- **B: 真実の源を URDF に一本化し、URDF を解析して `chain` を得て `forwardKinematics` で
+  導出。**（本命） tradeoff: URDF テキストの解析経路と、レストポーズの置き場所の整理が要る
+  （下記コストへ）。ただし関節運動学の権威は URDF ただ一つに保たれる。
+
+- **C: 現状維持（定数 + 「変えたら再計算」コメント）。** tradeoff: 実装ゼロだが §1.1 の
+  silent drift 芽が残る。将来 URDF やレストポーズを触る人（＝ロボットを差し替える最も
+  自然な変更）が、無関係に見える定数を直し忘れて tcp が手先から外れる。**却下。**
+
+## Decision — Strategy（§1.2 Strategy）
+
+**B を採る。tcp の既定 seed を「URDF（唯一の運動学ソース）＋共有レストポーズ」からの
+純粋 FK として導出し、書き写しの定数を廃する。**
+
+1. **URDF を単一ソースに保つ。** `public/robot/skeleton_arm.urdf` をビルド時に文字列として
+   バンドル（Vite `?raw` import）し、実行時 fetch を避ける。RobotStage は従来どおり
+   urdf-loader で同じファイルを描画に使う（描画も seed も同一ソースから導出 — §1.1）。
+
+2. **純粋な URDF→chain パーサを `src/robotics/` に新設。** URDF の `<joint>` 群を
+   `forwardKinematics` が要求する `{ joints:[{type,axis,origin:{xyz,rpy}}], tcp? }` 形へ
+   写す小さな純関数（THREE 非依存・DOM 非依存 = `node --test` 可）。urdf-loader は THREE
+   オブジェクトを生むため test lane で使えない＝この用途には別の純パーサが正しい。対象は
+   自前の統制された URDF サブセットのみ（box/cylinder/revolute）なので小さく保てる。
+
+3. **レストポーズを共有データへ持ち上げる。** 現在 `RobotStage._applyRestPose` にのみ在る
+   関節角を、両者（RobotStage の描画・seed の FK）が読む一つの定数（`robotFrames.js` 近傍の
+   ロボット構成データ）にする。これでフランジの二入力（運動学＝URDF、姿勢＝レストポーズ）が
+   それぞれ単一ソースになる。
+
+4. **seed を導出値として明示する。** `SceneService.ensureRobotFrames` は
+   `forwardKinematics(parseUrdfChain(urdfText), restPose)` の位置を tcp のローカル
+   translation に設定する。`ROBOT_FRAME_DEFAULTS[tcp].position` の**手写し定数は削除**
+   （向きは identity のまま — ワイヤ契約不変）。導出はバンドル文字列の同期パースで済み、
+   ensureRobotFrames の同期性を壊さない。
+
+## Consequences — Evidence と tradeoff（§1.2 Evidence）
+
+- **肯定的**: フランジ位置の権威が URDF＋レストポーズの一箇所に戻る。ロボットを差し替える
+  （URDF 変更）／レストポーズを変える、いずれでも tcp が自動追従し、手写し定数の再計算義務が
+  消える。将来 UR5e→他機種の URDF 差し替えが「ファイル 1 つの入れ替え＋レストポーズ調整」で
+  完結し、離れた定数を直し忘れるクラスのバグが**構造的に**発生しなくなる。
+
+- **受け入れるコスト / 否定的**: (1) 小さな URDF パーサを新規に持つ保守対象が増える
+  （ただし自前サブセット限定）。(2) レストポーズを view から共有データへ移す小リファクタが要る。
+  (3) パーサは自前 URDF の書式前提なので、外部の任意 URDF には未対応（意図的スコープ — 
+  一般 URDF 対応は非目標）。
+
+- **検証（証拠、実装フェーズで満たす）**:
+  - `parseUrdfChain` の単体テスト（`skeleton_arm.urdf` → 期待 chain）＋
+    `forwardKinematics(chain, restPose)` のフランジ位置が現行 seed `(-0.717,-0.133,0.346)` と
+    一致（本ブランチで urdf-loader 実レンダリングと一致を実測済 — この値が回帰の基準）。
+  - レストポーズを変えた fixture で「seed が追従し、手写し定数が残っていない」ことを固定。
+  - 既存 `GraspController.test`（`tcpOrientation:[0,0,0,1]` / `base:[-2,2,0]`）が不変で
+    通ること＝ワイヤ契約への非波及の証拠。
+  - 全 JS スイート green + `vite build` クリーン。
+  - ※ 現時点では上記は未実行（Proposed）。Accepted 後に実装フェーズで満たす。
+
+- **波及（blast radius）**: `src/robotics/`（新パーサ）, `src/domain/robotFrames.js`
+  （tcp 定数削除＋レストポーズ定数化）, `src/view/RobotStage.js`（共有レストポーズを読む）,
+  `src/service/SceneService.js`（ensureRobotFrames の seed 導出）。契約パッケージ・BFF・
+  `core/`・response/request スキーマには**非波及**。
+
+## Lens notes
+
+- **§1.1（真実の源は一つ）が本 ADR の主レンズ。** 決定の全体が「フランジ位置の第二の源
+  （手写し定数）を消し、URDF＋レストポーズという本来の源に一本化する」の一点。Option A が
+  却下なのは、第二の源を狭い定数からより広い JS chain へ**移すだけで消していない**ため。
+- **依存方向（Clean Arch）**: 導出を service 層の純関数呼び出しに置くことで、domain（tcp 実体）が
+  view（THREE スケルトン）に依存する矢印を作らずに済む。FK は純粋計算なので domain 純度も保つ。
+- **黒箱**: `forwardKinematics` の入力→出力（chain＋q → SE(3) pose）と不変条件は既存テストで
+  特性化済み。本 ADR はその境界の内側に手を入れない（再利用のみ）。
+- **ガード明確化の記録**: 「FK-for-visualization はフロント可、grasp-search の解法は `core/`」の
+  区別を Context に明記した（ADR-053 の非対称の再確認）。これは CLAUDE.md ガードの*読み*の
+  精緻化であり、ガード自体の緩和ではない（PHILOSOPHY #19 documentation drift の是正）。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -99,6 +99,7 @@ This directory records the project's design decisions.
 | [ADR-085](ADR-085-robot-tf-tree-selectable-fast-grasp-entry.md) | **ロボットを TF 親子ツリー (world→robot_base→tcp) で接地 + 骨格を直接選択可能に + grasp-search を無フォームで開く** | Accepted (全 3 点 実装済) | 2026-07-22 | ADR-084, ADR-083, ADR-055, ADR-051, ADR-018, ADR-034 |
 | [ADR-086](ADR-086-deterministic-boot-slice-in-required-gate.md) | **e2e は非必須のまま、boot 保証の決定的スライス (起動時 ReferenceError 不在) だけを必須 gate に落とす** | Accepted (実装済 — PR #341) | 2026-07-22 | ADR-064, ADR-085 |
 | [ADR-087](ADR-087-cf-grounded-object-model-robot-visibility-outliner.md) | **CF 接地オブジェクトモデルの統一 + ロボット可視性を Outliner の所有下へ (ヘッダートグル撤去)** | Accepted | 2026-07-22 | ADR-037, ADR-084, ADR-085 |
+| [ADR-088](ADR-088-tcp-seed-derived-from-urdf-fk.md) | **robot_base→tcp の既定 seed を URDF スケルトンの FK から導出 — フランジ位置の真実の源を URDF に一本化し手写し定数を廃す** | Proposed | 2026-07-23 | ADR-084, ADR-085, ADR-053, ADR-018 |
 
 ## How to Add a New ADR
 

--- a/public/robot/skeleton_arm.urdf
+++ b/public/robot/skeleton_arm.urdf
@@ -1,28 +1,49 @@
 <?xml version="1.0"?>
 <!--
-  Self-contained 6-DOF "skeleton" arm for in-app visualization/verification of
+  UR5e-shaped 6-DOF "skeleton" arm for in-app visualization/verification of
   grasp-search results (see CLAUDE.md AI 向けガード: this app never solves IK —
-  it only displays poses/joint angles it receives). All links use primitive
-  <geometry> (box/cylinder) so no external mesh assets are required; URDFLoader
-  builds THREE.BoxGeometry/CylinderGeometry directly from this file. World
-  frame follows ROS REP-103 (+X forward, +Y left, +Z up).
+  it only DISPLAYS poses/joint angles it receives).
+
+  KINEMATICS: the joint origins reproduce the Universal Robots UR5e link
+  transforms (the published DH parameters d1=0.1625, a2=-0.425, a3=-0.3922,
+  d4=0.1333, d5=0.0997, d6=0.0996), so the chain has the recognizable UR
+  silhouette — the two offset arm links + the three-axis wrist cluster — rather
+  than a coaxial totem pole. Every joint axis is the link's local +Z, exactly
+  as in the official UR URDF; the rpy on shoulder_lift / wrist_2 / wrist_3 sets
+  up the elbow and wrist planes.
+
+  GEOMETRY: no external mesh assets. We are not shipping the UR visual meshes
+  (they need STL/DAE files and a `packages` mapping); instead each link draws a
+  primitive-<geometry> "bone + knuckle" skeleton — a cylinder around each joint
+  axis plus a cylinder spanning to the next joint. URDFLoader builds
+  THREE.CylinderGeometry directly from this, so the file stays self-contained
+  and GitHub-Pages friendly. World frame follows ROS REP-103 (+X forward,
+  +Y left, +Z up).
+
+  Joint names match the UR convention (shoulder_pan/lift, elbow, wrist_1/2/3)
+  so RobotStage._applyRestPose and any future grasp-contract joint payload key
+  against the same names.
 -->
-<robot name="skeleton_arm">
+<robot name="ur5e_skeleton">
 
   <material name="base_gray">
-    <color rgba="0.25 0.27 0.30 1"/>
+    <color rgba="0.28 0.30 0.33 1"/>
   </material>
   <material name="link_blue">
-    <color rgba="0.35 0.55 0.85 1"/>
+    <color rgba="0.38 0.56 0.86 1"/>
+  </material>
+  <material name="joint_dark">
+    <color rgba="0.20 0.22 0.26 1"/>
   </material>
   <material name="flange_orange">
     <color rgba="0.95 0.55 0.15 1"/>
   </material>
 
+  <!-- ── base_link: mounting can, up to the shoulder-pan joint (d1) ── -->
   <link name="base_link">
     <visual>
-      <origin xyz="0 0 0.04" rpy="0 0 0"/>
-      <geometry><box size="0.16 0.16 0.08"/></geometry>
+      <origin xyz="0 0 0.0815" rpy="0 0 0"/>
+      <geometry><cylinder radius="0.075" length="0.163"/></geometry>
       <material name="base_gray"/>
     </visual>
   </link>
@@ -30,15 +51,16 @@
   <joint name="shoulder_pan_joint" type="revolute">
     <parent link="base_link"/>
     <child link="shoulder_link"/>
-    <origin xyz="0 0 0.08" rpy="0 0 0"/>
+    <origin xyz="0 0 0.1625" rpy="0 0 0"/>
     <axis xyz="0 0 1"/>
-    <limit lower="-2.967" upper="2.967" effort="150" velocity="3.14"/>
+    <limit lower="-6.2832" upper="6.2832" effort="150" velocity="3.14"/>
   </joint>
 
+  <!-- shoulder_link: the vertical pan barrel; local +Z = pan axis -->
   <link name="shoulder_link">
     <visual>
-      <origin xyz="0 0 0.06" rpy="0 0 0"/>
-      <geometry><cylinder radius="0.055" length="0.12"/></geometry>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry><cylinder radius="0.062" length="0.14"/></geometry>
       <material name="link_blue"/>
     </visual>
   </link>
@@ -46,15 +68,21 @@
   <joint name="shoulder_lift_joint" type="revolute">
     <parent link="shoulder_link"/>
     <child link="upper_arm_link"/>
-    <origin xyz="0 0 0.12" rpy="0 0 0"/>
-    <axis xyz="0 1 0"/>
-    <limit lower="-2.0944" upper="2.0944" effort="150" velocity="3.14"/>
+    <origin xyz="0 0 0" rpy="1.570796327 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-6.2832" upper="6.2832" effort="150" velocity="3.14"/>
   </joint>
 
+  <!-- upper_arm_link: horizontal shoulder knuckle + bone spanning a2 along -X -->
   <link name="upper_arm_link">
     <visual>
-      <origin xyz="0 0 0.15" rpy="0 0 0"/>
-      <geometry><cylinder radius="0.045" length="0.30"/></geometry>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry><cylinder radius="0.058" length="0.13"/></geometry>
+      <material name="joint_dark"/>
+    </visual>
+    <visual>
+      <origin xyz="-0.2125 0 0" rpy="0 1.570796327 0"/>
+      <geometry><cylinder radius="0.05" length="0.425"/></geometry>
       <material name="link_blue"/>
     </visual>
   </link>
@@ -62,15 +90,27 @@
   <joint name="elbow_joint" type="revolute">
     <parent link="upper_arm_link"/>
     <child link="forearm_link"/>
-    <origin xyz="0 0 0.30" rpy="0 0 0"/>
-    <axis xyz="0 1 0"/>
-    <limit lower="-2.618" upper="2.618" effort="100" velocity="3.14"/>
+    <origin xyz="-0.425 0 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-3.1416" upper="3.1416" effort="150" velocity="3.14"/>
   </joint>
 
+  <!-- forearm_link: elbow knuckle + bone spanning a3 along -X, plus the d4
+       wrist-plane offset that rises in +Z toward wrist_1 -->
   <link name="forearm_link">
     <visual>
-      <origin xyz="0 0 0.125" rpy="0 0 0"/>
-      <geometry><cylinder radius="0.035" length="0.25"/></geometry>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry><cylinder radius="0.046" length="0.11"/></geometry>
+      <material name="joint_dark"/>
+    </visual>
+    <visual>
+      <origin xyz="-0.1961 0 0" rpy="0 1.570796327 0"/>
+      <geometry><cylinder radius="0.04" length="0.3922"/></geometry>
+      <material name="link_blue"/>
+    </visual>
+    <visual>
+      <origin xyz="-0.3922 0 0.06665" rpy="0 0 0"/>
+      <geometry><cylinder radius="0.038" length="0.1333"/></geometry>
       <material name="link_blue"/>
     </visual>
   </link>
@@ -78,47 +118,65 @@
   <joint name="wrist_1_joint" type="revolute">
     <parent link="forearm_link"/>
     <child link="wrist_1_link"/>
-    <origin xyz="0 0 0.25" rpy="0 0 0"/>
-    <axis xyz="0 1 0"/>
-    <limit lower="-3.14159" upper="3.14159" effort="30" velocity="6.28"/>
+    <origin xyz="-0.3922 0 0.1333" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-6.2832" upper="6.2832" effort="28" velocity="6.28"/>
   </joint>
 
+  <!-- wrist_1_link: knuckle + bone spanning d5 along -Y to wrist_2 -->
   <link name="wrist_1_link">
     <visual>
-      <origin xyz="0 0 0.04" rpy="0 0 0"/>
-      <geometry><cylinder radius="0.03" length="0.08"/></geometry>
-      <material name="base_gray"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry><cylinder radius="0.042" length="0.09"/></geometry>
+      <material name="joint_dark"/>
+    </visual>
+    <visual>
+      <origin xyz="0 -0.04985 0" rpy="1.570796327 0 0"/>
+      <geometry><cylinder radius="0.038" length="0.0997"/></geometry>
+      <material name="link_blue"/>
     </visual>
   </link>
 
   <joint name="wrist_2_joint" type="revolute">
     <parent link="wrist_1_link"/>
     <child link="wrist_2_link"/>
-    <origin xyz="0 0 0.08" rpy="0 0 0"/>
-    <axis xyz="1 0 0"/>
-    <limit lower="-3.14159" upper="3.14159" effort="30" velocity="6.28"/>
+    <origin xyz="0 -0.0997 0" rpy="1.570796327 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-6.2832" upper="6.2832" effort="28" velocity="6.28"/>
   </joint>
 
+  <!-- wrist_2_link: knuckle + bone spanning d6 along +Y to wrist_3 -->
   <link name="wrist_2_link">
     <visual>
-      <origin xyz="0 0 0.03" rpy="0 0 0"/>
-      <geometry><cylinder radius="0.025" length="0.06"/></geometry>
-      <material name="base_gray"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry><cylinder radius="0.04" length="0.085"/></geometry>
+      <material name="joint_dark"/>
+    </visual>
+    <visual>
+      <origin xyz="0 0.0498 0" rpy="1.570796327 0 0"/>
+      <geometry><cylinder radius="0.036" length="0.0996"/></geometry>
+      <material name="link_blue"/>
     </visual>
   </link>
 
   <joint name="wrist_3_joint" type="revolute">
     <parent link="wrist_2_link"/>
-    <child link="flange"/>
-    <origin xyz="0 0 0.06" rpy="0 0 0"/>
+    <child link="wrist_3_link"/>
+    <origin xyz="0 0.0996 0" rpy="1.570796327 3.141592654 3.141592654"/>
     <axis xyz="0 0 1"/>
-    <limit lower="-3.14159" upper="3.14159" effort="30" velocity="6.28"/>
+    <limit lower="-6.2832" upper="6.2832" effort="28" velocity="6.28"/>
   </joint>
 
-  <link name="flange">
+  <!-- wrist_3_link: the tool flange (tool0). +Z points out of the flange face. -->
+  <link name="wrist_3_link">
     <visual>
-      <origin xyz="0 0 0.01" rpy="0 0 0"/>
-      <geometry><box size="0.05 0.05 0.02"/></geometry>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry><cylinder radius="0.038" length="0.05"/></geometry>
+      <material name="joint_dark"/>
+    </visual>
+    <visual>
+      <origin xyz="0 0 0.03" rpy="0 0 0"/>
+      <geometry><cylinder radius="0.031" length="0.02"/></geometry>
       <material name="flange_orange"/>
     </visual>
   </link>

--- a/src/domain/robotFrames.js
+++ b/src/domain/robotFrames.js
@@ -55,11 +55,19 @@ export function isRobotBaseFrame(obj) {
  * cube. It stays world-parented (the same world frame the world gizmo and the
  * starter cube share).
  *
- * `tcp` seeds as a CHILD of robot_base, so its pose here is LOCAL to the base:
- * `[0, 0, 0]` / identity places it coincident with the base with axes aligned;
- * the user re-aims it through the existing CoordinateFrame edit UI (G / R /
- * N-panel), and because it is parented, moving/rotating the base carries it
- * along (TF tree world → robot_base → tcp).
+ * `tcp` seeds as a CHILD of robot_base, so its pose here is LOCAL to the base.
+ * The tool point belongs at the arm's *hand*, not on the mounting base — so its
+ * default LOCAL translation is the UR5e skeleton's flange (tool0) position at
+ * RobotStage's rest pose, forward-kinematics of `public/robot/skeleton_arm.urdf`
+ * (base-frame `(-0.717, -0.133, 0.346)`). This is why the TCP marker now sits at
+ * the wrist instead of buried in the base. Keep this in sync with
+ * RobotStage._applyRestPose: the two are a coupled pair (skeleton FK ⇄ tcp seed)
+ * documented in both places — changing the rest pose means recomputing this.
+ * Orientation stays identity (axes world-aligned): only `tcpOrientation` rides
+ * the grasp-search wire (GraspController._resolveRobotDeclaration), and the
+ * identity default keeps that contract unchanged until the user re-aims it
+ * through the CoordinateFrame edit UI (G / R / N-panel). Being parented, moving
+ * or rotating the base carries the tcp along (TF tree world → robot_base → tcp).
  */
 export const ROBOT_FRAME_DEFAULTS = Object.freeze({
   [ROBOT_BASE_FRAME_NAME]: Object.freeze({
@@ -67,7 +75,7 @@ export const ROBOT_FRAME_DEFAULTS = Object.freeze({
     rotation: Object.freeze({ x: 0, y: 0, z: 0, w: 1 }),
   }),
   [TCP_FRAME_NAME]: Object.freeze({
-    position: Object.freeze({ x: 0, y: 0, z: 0 }),
+    position: Object.freeze({ x: -0.717, y: -0.133, z: 0.346 }),
     rotation: Object.freeze({ x: 0, y: 0, z: 0, w: 1 }),
   }),
 })

--- a/src/service/SceneService.js
+++ b/src/service/SceneService.js
@@ -3052,10 +3052,16 @@ export class SceneService extends EventEmitter {
     // tcp is a CHILD of robot_base (TF tree world → robot_base → tcp, ADR-084 §2
     // revised 2026-07-22): the tool point is expressed in the robot's own frame,
     // so moving/rotating the base carries it along. createCoordinateFrame seeds
-    // it at local (0,0,0)/identity — coincident with the base until re-aimed.
+    // it at local (0,0,0); we then place it at the skeleton's flange (tool0) so
+    // the tool point defaults to the arm's HAND, not buried in the base — the
+    // ROBOT_FRAME_DEFAULTS[tcp] local translation is the UR5e flange FK at
+    // RobotStage's rest pose. _updateWorldPoses (each frame / entry paths)
+    // composes it through robot_base into the world pose the marker renders at.
     const tcp = byName.get(TCP_FRAME_NAME)
     if (!tcp) {
-      this.createCoordinateFrame(base.id, TCP_FRAME_NAME, null)
+      const created = this.createCoordinateFrame(base.id, TCP_FRAME_NAME, null)
+      const seed = ROBOT_FRAME_DEFAULTS[TCP_FRAME_NAME].position
+      if (created) created.translation.set(seed.x, seed.y, seed.z)
     } else if (tcp.parentId === null && tcp.id !== base.id) {
       // Lossless upgrade of a legacy scene (tcp saved as a world-parented frame
       // before the TF-tree revision): re-home it under robot_base while

--- a/src/view/RobotStage.js
+++ b/src/view/RobotStage.js
@@ -15,10 +15,11 @@ import URDFLoader from 'urdf-loader'
  * there), same pattern as `SceneStage` — no MotionGovernor involvement since
  * nothing here animates on its own.
  *
- * The robot model is a self-contained synthetic 6-DOF "skeleton" URDF
- * (`public/robot/skeleton_arm.urdf`) built entirely from primitive
- * <geometry> (box/cylinder) — no external mesh assets, so URDFLoader needs no
- * `packages` mapping or mesh loader override.
+ * The robot model is a self-contained 6-DOF "skeleton" URDF
+ * (`public/robot/skeleton_arm.urdf`) whose joint origins reproduce the
+ * Universal Robots UR5e link transforms (recognizable UR silhouette), drawn
+ * from primitive <geometry> (cylinder) bones — no external mesh assets, so
+ * URDFLoader needs no `packages` mapping or mesh loader override.
  */
 export class RobotStage {
   /**
@@ -47,13 +48,19 @@ export class RobotStage {
     })
   }
 
-  /** A visually legible bent-elbow rest pose instead of a straight totem pole. */
+  /**
+   * A legible bent-elbow UR rest pose (not a straight totem pole). These angles
+   * are a COUPLED PAIR with ROBOT_FRAME_DEFAULTS[tcp]: that constant is the
+   * forward-kinematics flange (tool0) position of THIS pose, so the tcp marker
+   * seeds at the skeleton's hand. Change one → recompute the other.
+   */
   _applyRestPose() {
     if (!this.robot) return
     this.setJointValues({
-      shoulder_lift_joint: -0.6,
-      elbow_joint: 1.0,
-      wrist_1_joint: -0.4,
+      shoulder_lift_joint: -1.0,
+      elbow_joint: 1.2,
+      wrist_1_joint: -1.8,
+      wrist_2_joint: -1.5708,
     })
   }
 


### PR DESCRIPTION
## What & why

Two user-reported issues with the robot display:

1. **TCP overlapped the robot base.** The `tcp` CoordinateFrame was seeded at local `(0,0,0)` relative to `robot_base` — coincident with the base — because `ROBOT_FRAME_DEFAULTS[tcp]` was a dead constant never wired into `ensureRobotFrames`. The tool point now seeds at the arm's **hand (flange/tool0)** instead: base-frame `(-0.717, -0.133, 0.346)`, the forward kinematics of RobotStage's rest pose. Orientation stays identity, so the grasp-search wire contract (`tcpOrientation`) is unchanged until the user re-aims it.

2. **The skeleton was a coaxial "totem pole", not UR-like.** Replaced `public/robot/skeleton_arm.urdf` with one whose joint origins reproduce the Universal Robots **UR5e** link transforms (`d1/a2/a3/d4/d5/d6`), giving the recognizable UR silhouette — two offset arm links + a three-axis wrist cluster. Still self-contained: primitive cylinder "bone + knuckle" geometry, **no external mesh assets** (GitHub-Pages friendly, no `packages` mapping). Joint names keep the UR convention so `RobotStage._applyRestPose` and any grasp-contract joint payload key against them.

## Changes

- `public/robot/skeleton_arm.urdf` — UR5e kinematics, primitive-cylinder skeleton.
- `src/domain/robotFrames.js` — `ROBOT_FRAME_DEFAULTS[tcp]` = flange position (was `(0,0,0)`).
- `src/service/SceneService.js` — `ensureRobotFrames` applies the tcp seed to the created frame (wires up the previously-dead constant).
- `src/view/RobotStage.js` — rest pose matched to the seed (a documented coupled pair), doc comment updated.

## Follow-up decision (docs-only, not implemented here)

- `docs/adr/ADR-088` (**Proposed**) records replacing the hand-written tcp constant with a value **derived** from the URDF (single kinematics source) + a shared rest pose, via the existing pure `forwardKinematics()`. Left Proposed for separate review — no code change in this PR beyond the docs. It also records the precise reading of the CLAUDE.md guard (FK-for-visualization is front-side per ADR-053 §3; the grasp-search decision engine stays in `core/`) — a clarification, not a relaxation.

## Verification

- urdf-loader renders the flange at exactly the seeded `(-0.717, -0.133, 0.346)` (matches the FK).
- Full JS suite **701/701** green; `vite build` clean.

[UR5e skeleton with TCP marker at the flange — verified in a headless urdf-loader render]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYJ8QG6njDHRVCXo4SWe57)_