### PR TITLE
feat(robot): derive tcp seed from URDF FK — single-source the flange on the URDF (ADR-088)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,54 @@
+<!--
+  easy-extrude PR テンプレート — 核 §1.2（正当化の鎖）と #19（doc drift はバグ）を
+  PR 記述に落とすための骨組み。各節を埋める（該当しない節は「N/A」を残す、削除しない）。
+  見出しはそのまま、中身を差し替える。AI が起票する PR も同じ様式で書く。
+-->
+
+## What & Why（Goal ← Strategy）
+
+<!-- 何を変えたか（1-2 行）と、それがどの Goal（欲しい性質）にどう効くか。
+     要件が解の形で来ていたら Goal へ一段持ち上げてから書く（核 §1.2）。 -->
+
+-
+
+## ADR / 設計判断
+
+<!-- 非自明・不可逆な設計選択がある PR は ADR 必須（新規 or 参照）。
+     例: `ADR-088`（Accepted）。ADR が無く自明なら「自明変更 — ADR 不要」と明記。 -->
+
+- 参照/新規 ADR:
+- `docs/adr/README.md` インデックス更新: [ ] 済 / [ ] 不要
+
+## Layer & Blast radius（波及範囲）
+
+<!-- 触ったレイヤ（フロント `src/` / 契約 `packages/grasp-contract` / BFF `server/` /
+     core `core/`）と、変更が届く範囲を一言で。越境（`src/`→`core/` の解法、
+     決定的 core への提案ロジック混入）が無いことを確認。 -->
+
+- 触ったレイヤ:
+- 波及するモジュール:
+- 契約（response/request スキーマ・`contractVersion`）への影響: なし / あり（版上げ済）
+
+## Evidence（証拠 — 鎖を閉じる）
+
+<!-- 完了はループの閉じ＋証拠を要する（核 §5）。実行した検証にチェック。 -->
+
+- [ ] `pnpm test`（JS スイート）green
+- [ ] `pnpm typecheck` クリーン
+- [ ] `pnpm build` クリーン
+- [ ] `pnpm test:context` / `pnpm test:contract` / `pnpm test:core`（該当時）
+- [ ] 追加/更新したテスト:
+
+## Docs / Rules drift（#19）
+
+<!-- バグ修正・設計判断のたび、欠けていた暗黙ルール/理由を反映してから commit。 -->
+
+- [ ] `docs/code_contracts/*.md`（+ index）更新 / 不要
+- [ ] `docs/PHILOSOPHY.md` 原則の追加・研磨 / 不要
+- [ ] 関連ドキュメント（NAVIGATION の Design change impact 表）更新 / 不要
+
+## Notes for reviewers
+
+<!-- レビュアが最初に見るべきファイル、既知の残課題、意図的スコープ外など。 -->
+
+-

--- a/docs/adr/ADR-088-tcp-seed-derived-from-urdf-fk.md
+++ b/docs/adr/ADR-088-tcp-seed-derived-from-urdf-fk.md
@@ -1,6 +1,6 @@
 # 088. robot_base→tcp の既定 seed を URDF スケルトンの FK から導出する（真実の源を URDF に一本化）
 
-- Status: Proposed
+- Status: Accepted (実装済)
 - Date: 2026-07-23
 - Deciders: yuubae215, Claude
 - Supersedes / Superseded by: なし（ADR-084 §2 / ADR-085 の tcp seed 実装を精緻化）
@@ -90,15 +90,16 @@ BFF `ComputeBackend`、FK・可視化ループはフロント、という ADR-05
   (3) パーサは自前 URDF の書式前提なので、外部の任意 URDF には未対応（意図的スコープ — 
   一般 URDF 対応は非目標）。
 
-- **検証（証拠、実装フェーズで満たす）**:
-  - `parseUrdfChain` の単体テスト（`skeleton_arm.urdf` → 期待 chain）＋
-    `forwardKinematics(chain, restPose)` のフランジ位置が現行 seed `(-0.717,-0.133,0.346)` と
-    一致（本ブランチで urdf-loader 実レンダリングと一致を実測済 — この値が回帰の基準）。
-  - レストポーズを変えた fixture で「seed が追従し、手写し定数が残っていない」ことを固定。
-  - 既存 `GraspController.test`（`tcpOrientation:[0,0,0,1]` / `base:[-2,2,0]`）が不変で
-    通ること＝ワイヤ契約への非波及の証拠。
-  - 全 JS スイート green + `vite build` クリーン。
-  - ※ 現時点では上記は未実行（Proposed）。Accepted 後に実装フェーズで満たす。
+- **検証（証拠 — 実装フェーズで充足済）**:
+  - `src/robotics/UrdfChain.test.js`: `parseUrdfChain(skeleton_arm.urdf)` が期待 6-joint chain
+    （base→flange 順）を返し、`forwardKinematics(chain, ROBOT_REST_POSE)` のフランジ位置が
+    旧 seed `(-0.717,-0.133,0.346)` に 3dp 一致（回帰の基準）。**✓ 実行済**。
+  - 同テストのレストポーズ改変 fixture（base yaw を 90° 回す）で「seed が追従し（x/y が
+    90° 回転・z 不変）、手写し定数が残っていない」ことを固定。**✓ 実行済**。
+  - 既存 `GraspController.test`（`tcpOrientation:[0,0,0,1]` / `base:[-2,2,0]`）が不変で通る
+    ＝ワイヤ契約への非波及の証拠。**✓（全 708 JS テスト green、うち BootWiring 型解決 gate 含む）**。
+  - `pnpm typecheck` クリーン + `vite build` クリーン（URDF は `?raw` でバンドルへインライン、
+    実行時 fetch なし）。**✓ 実行済**。
 
 - **波及（blast radius）**: `src/robotics/`（新パーサ）, `src/domain/robotFrames.js`
   （tcp 定数削除＋レストポーズ定数化）, `src/view/RobotStage.js`（共有レストポーズを読む）,

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -99,7 +99,7 @@ This directory records the project's design decisions.
 | [ADR-085](ADR-085-robot-tf-tree-selectable-fast-grasp-entry.md) | **ロボットを TF 親子ツリー (world→robot_base→tcp) で接地 + 骨格を直接選択可能に + grasp-search を無フォームで開く** | Accepted (全 3 点 実装済) | 2026-07-22 | ADR-084, ADR-083, ADR-055, ADR-051, ADR-018, ADR-034 |
 | [ADR-086](ADR-086-deterministic-boot-slice-in-required-gate.md) | **e2e は非必須のまま、boot 保証の決定的スライス (起動時 ReferenceError 不在) だけを必須 gate に落とす** | Accepted (実装済 — PR #341) | 2026-07-22 | ADR-064, ADR-085 |
 | [ADR-087](ADR-087-cf-grounded-object-model-robot-visibility-outliner.md) | **CF 接地オブジェクトモデルの統一 + ロボット可視性を Outliner の所有下へ (ヘッダートグル撤去)** | Accepted | 2026-07-22 | ADR-037, ADR-084, ADR-085 |
-| [ADR-088](ADR-088-tcp-seed-derived-from-urdf-fk.md) | **robot_base→tcp の既定 seed を URDF スケルトンの FK から導出 — フランジ位置の真実の源を URDF に一本化し手写し定数を廃す** | Proposed | 2026-07-23 | ADR-084, ADR-085, ADR-053, ADR-018 |
+| [ADR-088](ADR-088-tcp-seed-derived-from-urdf-fk.md) | **robot_base→tcp の既定 seed を URDF スケルトンの FK から導出 — フランジ位置の真実の源を URDF に一本化し手写し定数を廃す** | Accepted (実装済) | 2026-07-23 | ADR-084, ADR-085, ADR-053, ADR-018 |
 
 ## How to Add a New ADR
 

--- a/src/controller/AppController.js
+++ b/src/controller/AppController.js
@@ -177,7 +177,10 @@ export class AppController {
     this._rotateSectorPreview = new RotateSectorPreview(sceneView.scene)
 
     // ── Application service (owns SceneModel aggregate root) ─────────────
-    this._service = new SceneService(sceneView.scene)
+    // Inject the DERIVED tcp seed (URDF flange FK at the shared rest pose,
+    // ADR-088) from the view that renders the skeleton, so the tool point seeds
+    // at the drawn flange from one source instead of a hand-copied constant.
+    this._service = new SceneService(sceneView.scene, { tcpSeed: sceneView.robotTcpSeed })
     this._service.setViewContext({
       camera:    sceneView.camera,
       renderer:  sceneView.renderer,

--- a/src/domain/robotConfig.js
+++ b/src/domain/robotConfig.js
@@ -1,0 +1,31 @@
+/**
+ * robotConfig — shared robot-arm configuration data (ADR-088).
+ *
+ * Pure module (no THREE / no DOM) so both the render side (`RobotStage`) and the
+ * seed-derivation side (`view/robotSkeleton.js` → `SceneService`) read ONE
+ * definition of the rest pose. Before ADR-088 the rest pose lived only in
+ * `RobotStage._applyRestPose`, and the tcp seed was a hand-copied constant of its
+ * forward kinematics — two places encoding one fact (§1.1 violation). Lifting the
+ * pose here makes the flange's two inputs each single-source:
+ *
+ *   kinematics  ← public/robot/skeleton_arm.urdf   (the URDF, one source)
+ *   rest pose   ← ROBOT_REST_POSE                   (this constant, one source)
+ *
+ * The tcp default seed is then DERIVED from the pair (deriveFlangeSeed), never
+ * written down, so changing either input carries the tcp along automatically.
+ */
+
+/**
+ * The legible bent-elbow UR rest pose (radians), keyed by URDF joint name. Not a
+ * straight totem pole — a recognizable arm silhouette. Joints omitted here rest
+ * at 0. Changing this now moves BOTH the rendered skeleton and the derived tcp
+ * seed together (that coupling is the whole point of ADR-088).
+ *
+ * @type {Readonly<Record<string, number>>}
+ */
+export const ROBOT_REST_POSE = Object.freeze({
+  shoulder_lift_joint: -1.0,
+  elbow_joint: 1.2,
+  wrist_1_joint: -1.8,
+  wrist_2_joint: -1.5708,
+})

--- a/src/domain/robotFrames.js
+++ b/src/domain/robotFrames.js
@@ -55,27 +55,18 @@ export function isRobotBaseFrame(obj) {
  * cube. It stays world-parented (the same world frame the world gizmo and the
  * starter cube share).
  *
- * `tcp` seeds as a CHILD of robot_base, so its pose here is LOCAL to the base.
- * The tool point belongs at the arm's *hand*, not on the mounting base — so its
- * default LOCAL translation is the UR5e skeleton's flange (tool0) position at
- * RobotStage's rest pose, forward-kinematics of `public/robot/skeleton_arm.urdf`
- * (base-frame `(-0.717, -0.133, 0.346)`). This is why the TCP marker now sits at
- * the wrist instead of buried in the base. Keep this in sync with
- * RobotStage._applyRestPose: the two are a coupled pair (skeleton FK ⇄ tcp seed)
- * documented in both places — changing the rest pose means recomputing this.
- * Orientation stays identity (axes world-aligned): only `tcpOrientation` rides
- * the grasp-search wire (GraspController._resolveRobotDeclaration), and the
- * identity default keeps that contract unchanged until the user re-aims it
- * through the CoordinateFrame edit UI (G / R / N-panel). Being parented, moving
- * or rotating the base carries the tcp along (TF tree world → robot_base → tcp).
+ * The `tcp` frame's default LOCAL translation is NO LONGER a constant here
+ * (ADR-088): it is the UR5e flange (tool0) position at the shared rest pose,
+ * DERIVED by forward kinematics of `public/robot/skeleton_arm.urdf` and injected
+ * into `SceneService` (see `view/robotSkeleton.js` → `TCP_LOCAL_SEED`). The
+ * flange fact now has one authority — the URDF + `ROBOT_REST_POSE` — so it can no
+ * longer silently drift from a hand-copied number when either input changes.
+ * (The tcp seed's orientation stays identity, keeping the `tcpOrientation` wire
+ * contract unchanged until the user re-aims it through the CF edit UI.)
  */
 export const ROBOT_FRAME_DEFAULTS = Object.freeze({
   [ROBOT_BASE_FRAME_NAME]: Object.freeze({
     position: Object.freeze({ x: -2, y: 2, z: 0 }),
-    rotation: Object.freeze({ x: 0, y: 0, z: 0, w: 1 }),
-  }),
-  [TCP_FRAME_NAME]: Object.freeze({
-    position: Object.freeze({ x: -0.717, y: -0.133, z: 0.346 }),
     rotation: Object.freeze({ x: 0, y: 0, z: 0, w: 1 }),
   }),
 })

--- a/src/robotics/UrdfChain.js
+++ b/src/robotics/UrdfChain.js
@@ -1,0 +1,172 @@
+/**
+ * UrdfChain — pure URDF → forward-kinematics `chain` parser (ADR-088).
+ *
+ * Pure computation: no I/O, no Three.js, no DOM (no `DOMParser`). (PHILOSOPHY #3)
+ * Deliberately hand-parses the small, self-authored URDF subset with string /
+ * regex extraction so the whole module loads under bare `node --test` — the same
+ * discipline `Kinematics.js` follows by writing its own SE(3) math. `urdf-loader`
+ * is the render path's parser but it produces THREE objects and needs a DOM, so
+ * it is the wrong tool for the seed-derivation lane; this is its pure twin.
+ *
+ * WHY (ADR-088, §1.1): the robot flange (tool0) position is one fact with one
+ * authority — the URDF kinematics + the shared rest pose. `parseUrdfChain` turns
+ * the URDF text into the `{ joints:[{type,axis,origin}] }` shape
+ * `forwardKinematics` consumes, so `SceneService` can DERIVE the tcp seed instead
+ * of carrying a hand-copied constant that silently drifts when the URDF or the
+ * rest pose changes.
+ *
+ * SCOPE (intentional, ADR-088 Consequences): this parses only the controlled
+ * skeleton subset this repo ships (serial chain, revolute/continuous/prismatic/
+ * fixed joints, no `<mimic>`, single kinematic branch). General third-party URDF
+ * support is a non-goal — feed those through `urdf-loader` on the render side.
+ *
+ * @module robotics/UrdfChain
+ */
+
+import { forwardKinematics, movableJoints } from './Kinematics.js'
+
+/** Thrown when the URDF text does not form a single serial chain we can walk. */
+export class MalformedUrdf extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'MalformedUrdf'
+  }
+}
+
+/** First `name="…"` / `type="…"` style attribute value, or null. */
+function attr(source, name) {
+  const m = source.match(new RegExp(`${name}\\s*=\\s*"([^"]*)"`))
+  return m ? m[1] : null
+}
+
+/** Whitespace-separated number list ("0 0 0.1625" → [0,0,0.1625]), or null. */
+function nums(value) {
+  if (value == null) return null
+  const parts = value.trim().split(/\s+/).map(Number)
+  return parts.some(Number.isNaN) ? null : parts
+}
+
+/**
+ * Parse the URDF text into a forward-kinematics `chain`, joints ordered from the
+ * base link out to the tool flange.
+ *
+ * @param {string} urdfText  the full URDF document as a string
+ * @returns {{ joints: Array<{ name:string, type:string, axis?:number[],
+ *   origin?:{ xyz?:number[], rpy?:number[] }, limit?:{lower:number,upper:number} }> }}
+ */
+export function parseUrdfChain(urdfText) {
+  if (typeof urdfText !== 'string' || urdfText.length === 0) {
+    throw new MalformedUrdf('parseUrdfChain: urdfText must be a non-empty string')
+  }
+
+  // Extract every <joint …>…</joint> block (self-authored subset — all joints
+  // here use the block form with parent/child/origin children).
+  const parsed = []
+  const jointRe = /<joint\b([^>]*)>([\s\S]*?)<\/joint>/g
+  let match
+  while ((match = jointRe.exec(urdfText)) !== null) {
+    const [, head, body] = match
+    const name = attr(head, 'name')
+    const type = attr(head, 'type') ?? 'fixed'
+    const parentEl = body.match(/<parent\b[^>]*>/)
+    const childEl = body.match(/<child\b[^>]*>/)
+    const originEl = body.match(/<origin\b[^>]*>/)
+    const axisEl = body.match(/<axis\b[^>]*>/)
+    const limitEl = body.match(/<limit\b[^>]*>/)
+    if (!name || !parentEl || !childEl) {
+      throw new MalformedUrdf(`joint missing name/parent/child near "${head.trim()}"`)
+    }
+
+    const joint = { name, type, parent: attr(parentEl[0], 'link'), child: attr(childEl[0], 'link') }
+    if (originEl) {
+      const xyz = nums(attr(originEl[0], 'xyz'))
+      const rpy = nums(attr(originEl[0], 'rpy'))
+      joint.origin = {}
+      if (xyz) joint.origin.xyz = xyz
+      if (rpy) joint.origin.rpy = rpy
+    }
+    if (axisEl) {
+      const xyz = nums(attr(axisEl[0], 'xyz'))
+      if (xyz) joint.axis = xyz
+    }
+    if (limitEl) {
+      const lower = Number(attr(limitEl[0], 'lower'))
+      const upper = Number(attr(limitEl[0], 'upper'))
+      if (!Number.isNaN(lower) && !Number.isNaN(upper)) joint.limit = { lower, upper }
+    }
+    parsed.push(joint)
+  }
+
+  if (parsed.length === 0) {
+    throw new MalformedUrdf('parseUrdfChain: no <joint> elements found')
+  }
+
+  // Order the joints into a serial chain: the root link is the one that is some
+  // joint's parent but never a child. Walk parent→child from there.
+  const byParent = new Map()
+  const childLinks = new Set()
+  for (const j of parsed) {
+    if (byParent.has(j.parent)) {
+      throw new MalformedUrdf(`link "${j.parent}" drives two joints — not a serial chain`)
+    }
+    byParent.set(j.parent, j)
+    childLinks.add(j.child)
+  }
+  const roots = [...byParent.keys()].filter(link => !childLinks.has(link))
+  if (roots.length !== 1) {
+    throw new MalformedUrdf(`expected exactly one root link, found ${roots.length}`)
+  }
+
+  const ordered = []
+  const seen = new Set()
+  let link = roots[0]
+  while (byParent.has(link)) {
+    const j = byParent.get(link)
+    if (seen.has(j.name)) throw new MalformedUrdf(`cycle detected at joint "${j.name}"`)
+    seen.add(j.name)
+    ordered.push(j)
+    link = j.child
+  }
+  if (ordered.length !== parsed.length) {
+    throw new MalformedUrdf(`chain walked ${ordered.length} of ${parsed.length} joints — kinematic tree is not a single serial chain`)
+  }
+
+  // Project to the FK chain shape (drop parent/child bookkeeping, keep name so a
+  // named rest pose can be mapped to an ordered q vector).
+  const joints = ordered.map(j => {
+    const out = { name: j.name, type: j.type }
+    if (j.axis) out.axis = j.axis
+    if (j.origin) out.origin = j.origin
+    if (j.limit) out.limit = j.limit
+    return out
+  })
+  return { joints }
+}
+
+/**
+ * Ordered `q` vector (one value per movable joint, in chain order) for a rest
+ * pose given as a { jointName: angle } map. Joints absent from the map are 0.
+ *
+ * @param {{joints:Array<{name:string,type?:string}>}} chain
+ * @param {Record<string, number>} restPose
+ * @returns {number[]}
+ */
+export function restPoseToQ(chain, restPose = {}) {
+  return movableJoints(chain).map(j => restPose[j.name] ?? 0)
+}
+
+/**
+ * DERIVE the tcp flange seed: the base-frame position of the tool flange (the
+ * last link's origin) at the given rest pose, by forward kinematics of the URDF.
+ * This is the single-source replacement for ADR-084's hand-copied
+ * `ROBOT_FRAME_DEFAULTS[tcp]` constant (ADR-088).
+ *
+ * @param {string} urdfText
+ * @param {Record<string, number>} restPose  { jointName: angle(rad) }
+ * @returns {{ x:number, y:number, z:number }}  base-frame flange position
+ */
+export function deriveFlangeSeed(urdfText, restPose) {
+  const chain = parseUrdfChain(urdfText)
+  const { position } = forwardKinematics(chain, restPoseToQ(chain, restPose))
+  return { x: position.x, y: position.y, z: position.z }
+}

--- a/src/robotics/UrdfChain.test.js
+++ b/src/robotics/UrdfChain.test.js
@@ -1,0 +1,88 @@
+/**
+ * UrdfChain.test.js — pure URDF→chain parser + derived tcp seed (ADR-088).
+ *
+ * These tests are the EVIDENCE (§1.2) that the tcp flange seed is single-sourced
+ * on the URDF + rest pose: parsing the shipped skeleton and running FK at the
+ * rest pose reproduces the position ADR-084 hand-copied as a constant, and
+ * changing the rest pose makes the seed follow with no constant left to edit.
+ *
+ * THREE-free / DOM-free — runs under bare `node --test`.
+ *
+ * Run with:  node --test src/robotics/UrdfChain.test.js
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+import { parseUrdfChain, restPoseToQ, deriveFlangeSeed, MalformedUrdf } from './UrdfChain.js'
+import { forwardKinematics } from './Kinematics.js'
+import { ROBOT_REST_POSE } from '../domain/robotConfig.js'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const URDF = readFileSync(join(HERE, '../../public/robot/skeleton_arm.urdf'), 'utf8')
+
+test('parses the skeleton into the 6-joint UR serial chain, base→flange order', () => {
+  const chain = parseUrdfChain(URDF)
+  assert.deepEqual(
+    chain.joints.map(j => j.name),
+    ['shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint'],
+  )
+  // origins / axes / limits carried through for FK
+  const lift = chain.joints[1]
+  assert.equal(lift.type, 'revolute')
+  assert.deepEqual(lift.origin.rpy, [1.570796327, 0, 0])
+  assert.deepEqual(lift.axis, [0, 0, 1])
+  assert.deepEqual(chain.joints[0].limit, { lower: -6.2832, upper: 6.2832 })
+})
+
+test('restPoseToQ maps named angles to an ordered q vector (absent joints = 0)', () => {
+  const chain = parseUrdfChain(URDF)
+  // pan (0) lift (-1.0) elbow (1.2) wrist_1 (-1.8) wrist_2 (-1.5708) wrist_3 (0)
+  assert.deepEqual(restPoseToQ(chain, ROBOT_REST_POSE), [0, -1.0, 1.2, -1.8, -1.5708, 0])
+})
+
+test('derived flange seed reproduces ADR-084 hand-copied constant (regression baseline)', () => {
+  const seed = deriveFlangeSeed(URDF, ROBOT_REST_POSE)
+  // The old constant was (-0.717, -0.133, 0.346), read off the real urdf-loader
+  // render — matched here to 3dp straight from the URDF FK.
+  assert.ok(Math.abs(seed.x - (-0.717)) < 5e-4, `x=${seed.x}`)
+  assert.ok(Math.abs(seed.y - (-0.133)) < 5e-4, `y=${seed.y}`)
+  assert.ok(Math.abs(seed.z - 0.346) < 5e-4, `z=${seed.z}`)
+})
+
+test('the seed FOLLOWS the rest pose — no hand-copied constant survives (ADR-088)', () => {
+  // A different rest pose must move the seed. If a constant were still the source
+  // of truth this would keep returning the old flange position.
+  const restA = ROBOT_REST_POSE
+  const restB = { ...ROBOT_REST_POSE, shoulder_pan_joint: Math.PI / 2 }
+  const seedA = deriveFlangeSeed(URDF, restA)
+  const seedB = deriveFlangeSeed(URDF, restB)
+  assert.notDeepEqual(seedB, seedA)
+  // pan is the base yaw: it rotates the (x,y) flange offset about world +Z, so a
+  // 90° pan must swap the base-frame x/y roughly (x→y, y→-x), z unchanged.
+  assert.ok(Math.abs(seedB.z - seedA.z) < 1e-9, 'z is invariant under base yaw')
+  assert.ok(Math.abs(seedB.x - (-seedA.y)) < 1e-9 && Math.abs(seedB.y - seedA.x) < 1e-9, 'x/y rotate 90°')
+})
+
+test('the seed derivation equals a straight FK call (no hidden transform)', () => {
+  const chain = parseUrdfChain(URDF)
+  const { position } = forwardKinematics(chain, restPoseToQ(chain, ROBOT_REST_POSE))
+  assert.deepEqual(deriveFlangeSeed(URDF, ROBOT_REST_POSE), { x: position.x, y: position.y, z: position.z })
+})
+
+test('rejects malformed / empty URDF input (no silent 0,0,0)', () => {
+  assert.throws(() => parseUrdfChain(''), MalformedUrdf)
+  assert.throws(() => parseUrdfChain('<robot></robot>'), MalformedUrdf)
+  assert.throws(() => parseUrdfChain(null), MalformedUrdf)
+})
+
+test('rejects a branching (non-serial) kinematic tree — outside the shipped subset', () => {
+  const branching = `<robot>
+    <joint name="a" type="fixed"><parent link="root"/><child link="l1"/></joint>
+    <joint name="b" type="fixed"><parent link="root"/><child link="l2"/></joint>
+  </robot>`
+  assert.throws(() => parseUrdfChain(branching), MalformedUrdf)
+})

--- a/src/service/SceneService.js
+++ b/src/service/SceneService.js
@@ -116,11 +116,19 @@ function _xyPointInPolygon(px, py, poly) {
 export class SceneService extends EventEmitter {
   /**
    * @param {import('three').Scene} threeScene  Three.js scene used for MeshView creation/disposal
+   * @param {{ tcpSeed?: {x:number,y:number,z:number}|null }} [opts]  ADR-088: the
+   *   tcp frame's default LOCAL translation, DERIVED from the URDF flange FK at the
+   *   shared rest pose and injected by the browser composition root (AppController
+   *   ← view/robotSkeleton.js). Absent in headless/test contexts (no skeleton is
+   *   rendered), where tcp then seeds at the base origin — the correct "no arm"
+   *   default. Never a hand-copied constant (§1.1).
    */
-  constructor(threeScene) {
+  constructor(threeScene, opts = {}) {
     super()
     this._threeScene = threeScene
     this._model      = new SceneModel()
+    /** @type {{x:number,y:number,z:number}|null} */
+    this._tcpSeed    = opts.tcpSeed ?? null
     /** @type {BffClient|null} */
     this._bff        = null
     /** Server-assigned scene id when synced with the BFF. */
@@ -3053,15 +3061,16 @@ export class SceneService extends EventEmitter {
     // revised 2026-07-22): the tool point is expressed in the robot's own frame,
     // so moving/rotating the base carries it along. createCoordinateFrame seeds
     // it at local (0,0,0); we then place it at the skeleton's flange (tool0) so
-    // the tool point defaults to the arm's HAND, not buried in the base — the
-    // ROBOT_FRAME_DEFAULTS[tcp] local translation is the UR5e flange FK at
-    // RobotStage's rest pose. _updateWorldPoses (each frame / entry paths)
-    // composes it through robot_base into the world pose the marker renders at.
+    // the tool point defaults to the arm's HAND, not buried in the base. The
+    // flange position is the injected `_tcpSeed` — DERIVED from the URDF FK at the
+    // shared rest pose (ADR-088), no longer a hand-copied constant. When absent
+    // (headless/test, no skeleton drawn), tcp stays at the base origin.
+    // _updateWorldPoses (each frame / entry paths) composes it through robot_base
+    // into the world pose the marker renders at.
     const tcp = byName.get(TCP_FRAME_NAME)
     if (!tcp) {
       const created = this.createCoordinateFrame(base.id, TCP_FRAME_NAME, null)
-      const seed = ROBOT_FRAME_DEFAULTS[TCP_FRAME_NAME].position
-      if (created) created.translation.set(seed.x, seed.y, seed.z)
+      if (created && this._tcpSeed) created.translation.set(this._tcpSeed.x, this._tcpSeed.y, this._tcpSeed.z)
     } else if (tcp.parentId === null && tcp.id !== base.id) {
       // Lossless upgrade of a legacy scene (tcp saved as a world-parented frame
       // before the TF-tree revision): re-home it under robot_base while

--- a/src/view/RobotStage.js
+++ b/src/view/RobotStage.js
@@ -1,6 +1,8 @@
 // @ts-nocheck
 import * as THREE from 'three'
 import URDFLoader from 'urdf-loader'
+import { ROBOT_REST_POSE } from '../domain/robotConfig.js'
+import { ROBOT_URDF_TEXT } from './robotSkeleton.js'
 
 /**
  * RobotStage — loads and displays a fixed-pose robot-arm skeleton in the main
@@ -35,33 +37,29 @@ export class RobotStage {
     this._group.position.set(x, y, z)
     scene.add(this._group)
 
+    // Parse the SAME bundled URDF string the tcp seed is derived from
+    // (ROBOT_URDF_TEXT, ADR-088 §1.1) — one source drives both the drawn flange
+    // and the seed, and no runtime fetch is needed. `parse` is synchronous.
     const loader = new URDFLoader()
-    const urdfUrl = `${import.meta.env.BASE_URL}robot/skeleton_arm.urdf`
-    loader.load(urdfUrl, (robot) => {
-      // ROS (+Z up) and THREE.js world (+Z up here, per SceneView.camera.up)
-      // already agree — URDFLoader instantiates links in URDF-native axes
-      // with no reframing needed (see URDFLoader.js header comment).
-      robot.rotation.x = 0
-      this.robot = robot
-      this._group.add(robot)
-      this._applyRestPose()
-    })
+    const robot = loader.parse(ROBOT_URDF_TEXT)
+    // ROS (+Z up) and THREE.js world (+Z up here, per SceneView.camera.up)
+    // already agree — URDFLoader instantiates links in URDF-native axes
+    // with no reframing needed (see URDFLoader.js header comment).
+    robot.rotation.x = 0
+    this.robot = robot
+    this._group.add(robot)
+    this._applyRestPose()
   }
 
   /**
-   * A legible bent-elbow UR rest pose (not a straight totem pole). These angles
-   * are a COUPLED PAIR with ROBOT_FRAME_DEFAULTS[tcp]: that constant is the
-   * forward-kinematics flange (tool0) position of THIS pose, so the tcp marker
-   * seeds at the skeleton's hand. Change one → recompute the other.
+   * Applies the shared rest pose (ADR-088). The angles live in ONE place —
+   * `ROBOT_REST_POSE` (domain/robotConfig) — and the tcp seed is DERIVED from
+   * this same pose via forward kinematics, so the two can no longer drift: the
+   * former "coupled pair, recompute the other" hand-discipline is now structural.
    */
   _applyRestPose() {
     if (!this.robot) return
-    this.setJointValues({
-      shoulder_lift_joint: -1.0,
-      elbow_joint: 1.2,
-      wrist_1_joint: -1.8,
-      wrist_2_joint: -1.5708,
-    })
+    this.setJointValues(ROBOT_REST_POSE)
   }
 
   /**

--- a/src/view/SceneView.js
+++ b/src/view/SceneView.js
@@ -7,6 +7,7 @@ import * as THREE from 'three'
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
 import { SceneStage } from './SceneStage.js'
 import { RobotStage } from './RobotStage.js'
+import { TCP_LOCAL_SEED } from './robotSkeleton.js'
 import { focusPose as computeFocusPose } from './CameraMath.js'
 
 export class SceneView {
@@ -50,6 +51,10 @@ export class SceneView {
     // grasp-search verification aid: a fixed-pose robot skeleton rendered
     // clear of the voxel workspace (ADR: see RobotStage.js doc comment).
     this.robotStage = new RobotStage(this.scene)
+    // The tcp default seed, DERIVED from the same bundled URDF the skeleton is
+    // drawn from (ADR-088). Handed to SceneService via AppController so the tool
+    // point seeds at the rendered flange — one source, no drift.
+    this.robotTcpSeed = TCP_LOCAL_SEED
 
     window.addEventListener('resize', () => this._onResize())
   }

--- a/src/view/robotSkeleton.js
+++ b/src/view/robotSkeleton.js
@@ -1,0 +1,31 @@
+/**
+ * robotSkeleton — the single bundled source of the robot skeleton (ADR-088).
+ *
+ * BROWSER-ONLY MODULE. It is the *only* place the URDF text is imported (via
+ * Vite `?raw`), so `import.meta`/`?raw` never leaks into a module the
+ * `node --test` lane executes (SceneService is imported by node tests; this
+ * module must stay out of that graph — it is imported only by main.js/view).
+ *
+ * WHY (ADR-088 §1.1): the URDF is the single authority for the arm's
+ * kinematics. Bundling it once and having BOTH the render path (`RobotStage`
+ * parses `ROBOT_URDF_TEXT`) and the seed path (`TCP_LOCAL_SEED` = its forward
+ * kinematics at the shared rest pose) read that one string means the drawn
+ * flange and the tcp seed can never disagree. No runtime fetch; the file rides
+ * the bundle.
+ */
+
+import urdfText from '../../public/robot/skeleton_arm.urdf?raw'
+import { ROBOT_REST_POSE } from '../domain/robotConfig.js'
+import { deriveFlangeSeed } from '../robotics/UrdfChain.js'
+
+/** The skeleton URDF as a bundled string (no runtime fetch). */
+export const ROBOT_URDF_TEXT = urdfText
+
+/**
+ * The tcp frame's default LOCAL translation: the URDF flange (tool0) position at
+ * the shared rest pose, DERIVED — replacing ADR-084's hand-copied
+ * `(-0.717,-0.133,0.346)` constant. Fed to `SceneService` (ensureRobotFrames) so
+ * the tool point seeds at the skeleton's hand from the same source that draws it.
+ * @type {{ x:number, y:number, z:number }}
+ */
+export const TCP_LOCAL_SEED = deriveFlangeSeed(ROBOT_URDF_TEXT, ROBOT_REST_POSE)


### PR DESCRIPTION
## What & Why（Goal ← Strategy）

**Goal**: 「tcp フレームの既定位置は、可視化されているアームの手先（フランジ）と常に一致する」を、人手の同期に依存せず**構造的に**保証する。

**Strategy**: フランジ位置の第二の源（手写し定数 `(-0.717,-0.133,0.346)`）を消し、真実の源を **URDF + 共有レストポーズ**に一本化。RobotStage が描画するのと同じバンドル URDF 文字列から純 FK で seed を**導出**する（ADR-088 Option B）。

以前は一つの事実（フランジ位置）が二箇所（URDF+レストポーズ ＝ 本来の源／手写し定数 ＝ 第二の源）に在り、URDF かレストポーズを変えると定数が黙ってズレた（§1.1 違反・silent drift、PHILOSOPHY #11 の構造的失敗形）。

## ADR / 設計判断

- 参照/新規 ADR: **ADR-088**（Proposed → **Accepted 実装済**）— `docs/adr/ADR-088-tcp-seed-derived-from-urdf-fk.md`
- `docs/adr/README.md` インデックス更新: [x] 済（Proposed → Accepted 実装済）

## Layer & Blast radius（波及範囲）

- 触ったレイヤ: **フロント `src/` のみ**
- 波及するモジュール:
  - `src/robotics/UrdfChain.js`（新）— 純 URDF→chain パーサ + `deriveFlangeSeed`（THREE / DOM 非依存 = `node --test` 可）
  - `src/domain/robotConfig.js`（新）— `ROBOT_REST_POSE` を RobotStage から共有データへ持ち上げ
  - `src/view/robotSkeleton.js`（新）— 唯一の `?raw` バンドル地点 + 導出 seed `TCP_LOCAL_SEED`
  - `src/domain/robotFrames.js` — tcp の手写し定数を**削除**
  - `src/view/RobotStage.js` — `loader.parse(bundledText)` へ（実行時 fetch 廃止）+ 共有レストポーズ読取
  - `src/service/SceneService.js` — ensureRobotFrames が導出 seed を注入で受ける
  - `src/controller/AppController.js` / `src/view/SceneView.js` — seed を view → service へ配線
- 契約（response/request スキーマ・`contractVersion`）への影響: **なし**（tcp の**向き**だけがワイヤに載る。既定**位置**の導出方法変更は契約に非波及）。越境（`src/`→`core/` の解法混入）なし — 可視化のための純 FK はフロント in-scope（ADR-053 の非対称、ADR-088 Context に明記）。

## Evidence（証拠 — 鎖を閉じる）

- [x] `pnpm test`（JS スイート）green — **708 pass / 0 fail**（BootWiring 型解決 gate 含む）
- [x] `pnpm typecheck` クリーン
- [x] `pnpm build` クリーン（URDF は `?raw` でバンドルへインライン、実行時 fetch なし）
- [x] 追加/更新したテスト: `src/robotics/UrdfChain.test.js`（7 tests）
  - `parseUrdfChain(skeleton_arm.urdf)` → 期待 6-joint chain（base→flange 順）
  - `forwardKinematics(chain, ROBOT_REST_POSE)` のフランジ位置が旧定数 `(-0.717,-0.133,0.346)` に 3dp 一致（**回帰の基準**）
  - レストポーズ改変 fixture で seed が追従（base yaw 90° → x/y 回転・z 不変）、手写し定数が残っていないことを固定
  - 空/不正 URDF・分岐ツリーを拒否（silent 0,0,0 を作らない — #11）

## Docs / Rules drift（#19）

- [x] `docs/adr/*` 更新（ADR-088 status + evidence 充足、README index）
- [ ] `docs/code_contracts/*.md`: **不要**（旧「coupled pair」規律はコメントのみ、両所を更新済。architecture.md の urdf-loader 言及は mesh-collision の別関心で非該当）
- [ ] `docs/PHILOSOPHY.md`: **不要**（§1.1 の 1 コンテキスト適用。2+ の無関係文脈での再発ではないため昇格せず — 核 Q2）

## Notes for reviewers

- 最初に見るべき: `src/robotics/UrdfChain.js`（純パーサの設計 + スコープ = 自前 URDF サブセット限定、一般 URDF は非目標）と `src/robotics/UrdfChain.test.js`（回帰基準）。
- **URDF loader 投資の所在**: `urdf-loader` は既に依存として RobotStage の描画に使用中。本 PR はそれを**バンドル文字列の同期 parse** に切替（fetch 廃止）しつつ、テストレーン用の**純パーサ twin** を新設した。urdf-loader は DOM 必須 + THREE オブジェクト生成のため seed 導出には不適 — 描画は loader、seed は純パーサ、という役割分担が将来の機種差し替え（URDF ファイル 1 つ + レストポーズ調整）を最も安く保つ。
- 意図的スコープ外: 一般の外部 URDF 対応（`<mimic>`・分岐ツリー・mesh 資産）は非目標。

---
_Generated by [Claude Code](https://claude.ai/code/session_018hBwsSoJBkEbJToX2qjP8p)_